### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.13
+    working_directory: ~/build
+    steps:
+      - checkout
+      - run:
+          name: Build
+          command: |
+            go build ./...
+            go test ./...


### PR DESCRIPTION
Add initial CircleCI configuration. Fixes #6.

**NB:** I left out building protobuf source code for now, since we need a base image with `protoc` included.