### PR TITLE
Improve Makefile, to also build Go code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 SRC_DIR=./proto
 DST_DIR=./genproto
 
-build-proto:
-				protoc -I=${SRC_DIR} --go_out=plugins=grpc:${DST_DIR}/datasource/ ${SRC_DIR}/datasource.proto
+all: build
 
+${DST_DIR}/datasource/datasource.pb.go: ${SRC_DIR}/datasource.proto
+	protoc -I=${SRC_DIR} --go_out=plugins=grpc:${DST_DIR}/datasource/ ${SRC_DIR}/datasource.proto
 
-.PHONY: proto
+build-proto: ${DST_DIR}/datasource/datasource.pb.go
+
+build: build-proto
+	go build ./...
+
+.PHONY: all build build-proto


### PR DESCRIPTION
Improve the Makefile to build Go code (by default), dependent on the protobuf source.