### PR TITLE
dataframe: Add Append method to Vector interface

### DIFF
--- a/dataframe/arrow.go
+++ b/dataframe/arrow.go
@@ -241,15 +241,13 @@ func UnMarshalArrow(b []byte) (*Frame, error) {
 				v := array.NewFloat64Data(col.Data())
 				for _, f := range v.Float64Values() {
 					vF := f
-					vec := append(*frame.Fields[i].Vector.(*floatVector), &vF)
-					frame.Fields[i].Vector = &vec
+					frame.Fields[i].Vector.Append(&vF)
 				}
 			case arrow.TIMESTAMP:
 				v := array.NewTimestampData(col.Data())
 				for _, ts := range v.TimestampValues() {
 					t := time.Unix(0, int64(ts)) // nanosecond assumption
-					vec := append(*frame.Fields[i].Vector.(*timeVector), &t)
-					frame.Fields[i].Vector = &vec
+					frame.Fields[i].Vector.Append(&t)
 				}
 			default:
 				return nil, fmt.Errorf("unsupported arrow type %s for conversion", col.DataType().ID())

--- a/dataframe/bool_vector.go
+++ b/dataframe/bool_vector.go
@@ -7,6 +7,18 @@ func newBoolVector(l int) *boolVector {
 	return &v
 }
 
-func (v *boolVector) Set(i int, val interface{}) { (*v)[i] = val.(*bool) }
-func (v *boolVector) At(i int) interface{}       { return (*v)[i] }
-func (v *boolVector) Len() int                   { return len(*v) }
+func (v *boolVector) Set(i int, val interface{}) {
+	(*v)[i] = val.(*bool)
+}
+
+func (v *boolVector) Append(val interface{}) {
+	*v = append(*v, val.(*bool))
+}
+
+func (v *boolVector) At(i int) interface{} {
+	return (*v)[i]
+}
+
+func (v *boolVector) Len() int {
+	return len(*v)
+}

--- a/dataframe/float_vector.go
+++ b/dataframe/float_vector.go
@@ -6,6 +6,15 @@ func newFloatVector(l int) *floatVector {
 	v := make(floatVector, l)
 	return &v
 }
-func (v *floatVector) Set(i int, val interface{}) { (*v)[i] = val.(*float64) }
-func (v *floatVector) At(i int) interface{}       { return (*v)[i] }
-func (v *floatVector) Len() int                   { return len(*v) }
+
+func (v *floatVector) Set(i int, val interface{}) {
+	(*v)[i] = val.(*float64)
+}
+
+func (v *floatVector) Append(val interface{}) {
+	*v = append(*v, val.(*float64))
+}
+
+func (v *floatVector) At(i int) interface{} { return (*v)[i] }
+
+func (v *floatVector) Len() int { return len(*v) }

--- a/dataframe/string_vector.go
+++ b/dataframe/string_vector.go
@@ -7,6 +7,18 @@ func newStringVector(l int) *stringVector {
 	return &v
 }
 
-func (v *stringVector) Set(i int, val interface{}) { (*v)[i] = val.(*string) }
-func (v *stringVector) At(i int) interface{}       { return (*v)[i] }
-func (v *stringVector) Len() int                   { return len(*v) }
+func (v *stringVector) Set(i int, val interface{}) {
+	(*v)[i] = val.(*string)
+}
+
+func (v *stringVector) Append(val interface{}) {
+	*v = append(*v, val.(*string))
+}
+
+func (v *stringVector) At(i int) interface{} {
+	return (*v)[i]
+}
+
+func (v *stringVector) Len() int {
+	return len(*v)
+}

--- a/dataframe/time_vector.go
+++ b/dataframe/time_vector.go
@@ -1,6 +1,8 @@
 package dataframe
 
-import "time"
+import (
+	"time"
+)
 
 type timeVector []*time.Time
 
@@ -9,6 +11,18 @@ func newTimeVector(l int) *timeVector {
 	return &v
 }
 
-func (v *timeVector) Set(i int, val interface{}) { (*v)[i] = val.(*time.Time) }
-func (v *timeVector) At(i int) interface{}       { return (*v)[i] }
-func (v *timeVector) Len() int                   { return len(*v) }
+func (v *timeVector) Set(i int, val interface{}) {
+	(*v)[i] = val.(*time.Time)
+}
+
+func (v *timeVector) Append(val interface{}) {
+	*v = append(*v, val.(*time.Time))
+}
+
+func (v *timeVector) At(i int) interface{} {
+	return (*v)[i]
+}
+
+func (v *timeVector) Len() int {
+	return len(*v)
+}

--- a/dataframe/vector.go
+++ b/dataframe/vector.go
@@ -3,6 +3,7 @@ package dataframe
 // Vector represents a collection of Elements.
 type Vector interface {
 	Set(idx int, i interface{})
+	Append(i interface{})
 	At(i int) interface{}
 	Len() int
 }


### PR DESCRIPTION
Add `Append` method to `Vector` interface, since it's required for work in gel-app. Also helps cleaning up some internal code.