### PR TITLE
Skip plugin id when serving plugin

### DIFF
--- a/datasource/example/datasource.go
+++ b/datasource/example/datasource.go
@@ -10,8 +10,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/datasource"
 )
 
-const pluginID = "myorg-custom-datasource"
-
 type MyDatasource struct {
 	logger *log.Logger
 }
@@ -46,7 +44,7 @@ func (d *MyDatasource) Query(ctx context.Context, tr datasource.TimeRange, ds da
 func main() {
 	logger := log.New(os.Stderr, "", 0)
 
-	if err := datasource.Serve(pluginID, &MyDatasource{logger: logger}); err != nil {
+	if err := datasource.Serve(&MyDatasource{logger: logger}); err != nil {
 		logger.Fatal(err)
 	}
 }

--- a/datasource/server.go
+++ b/datasource/server.go
@@ -5,13 +5,15 @@ import (
 	plugin "github.com/hashicorp/go-plugin"
 )
 
+// PluginName the name of the data source plugin that can be dispensed
+// from the plugin server.
+const PluginName = "datasource"
+
 // Serve starts serving the datasource plugin over gRPC.
-//
-// The plugin ID should be in the format <org>-<name>-datasource.
-func Serve(pluginID string, handler DataSourceHandler) error {
+func Serve(handler DataSourceHandler) error {
 	versionedPlugins := map[int]plugin.PluginSet{
 		common.ProtocolVersion: {
-			pluginID: &DatasourcePluginImpl{
+			PluginName: &DatasourcePluginImpl{
 				Impl: datasourcePluginWrapper{
 					handler: handler,
 				},

--- a/transform/server.go
+++ b/transform/server.go
@@ -5,13 +5,15 @@ import (
 	plugin "github.com/hashicorp/go-plugin"
 )
 
-// Serve starts serving the datasource plugin over gRPC.
-//
-// The plugin ID should be in the format <org>-<name>-datasource.
-func Serve(pluginID string, handler TransformHandler) error {
+// PluginName the name of the plugin that can be dispensed
+// from the plugin server.
+const PluginName = "transform"
+
+// Serve starts serving the transform plugin over gRPC.
+func Serve(handler TransformHandler) error {
 	versionedPlugins := map[int]plugin.PluginSet{
 		common.ProtocolVersion: {
-			pluginID: &TransformPluginImpl{
+			PluginName: &TransformPluginImpl{
 				Impl: transformPluginWrapper{
 					handler: handler,
 				},


### PR DESCRIPTION
Idea is that by not serving plugins using their plugin id and instead an identifier for each kind of service, e.g. datasource, transform, streaming, we can construct the SDK in a way that would allow a plugin developer to opt-in implementing certain services/interfaces.

**Possible future plugin SDK:**
```go
// Serve starts serving plugin over gRPC.
func Serve(opts *ServeOpts) error {
	pluginSet := plugin.PluginSet{}

	if opts.DatasourceHandlerFunc != nil {
		pluginSet["datasource"] = opts.DatasourceHandlerFunc()
	}

	if opts.StreamingHandlerFunc != nil {
		pluginSet["streaming"] = opts.StreamingHandlerFunc()
	}

	versionedPlugins := map[int]plugin.PluginSet{
		common.ProtocolVersion: pluginSet,
	}

	plugin.Serve(&plugin.ServeConfig{
		HandshakeConfig:  common.Handshake,
		VersionedPlugins: versionedPlugins,
		GRPCServer:       plugin.DefaultGRPCServer,
	})

	return nil
}
```

On the Grafana side of things in the following [file](https://github.com/grafana/grafana/blob/master/pkg/plugins/backendplugin/client.go) we could replace the NewDatasourceClient, NewRendererClient, NewTransformClient with this instead:
```go
// NewClient returns a datasource plugin client.
func NewClient(pluginID, executablePath string, logger log.Logger) *plugin.Client {
	versionedPlugins := map[int]plugin.PluginSet{
		1: {
			pluginID: &datasourceV1.DatasourcePluginImpl{},
		},
		2: {
			pluginID:     &datasourceV2.DatasourcePluginImpl{},
			"streaming": &streamingV2.StreamingPluginImpl{},
			"service2": &streamingV2.Service2PluginImpl{},
                        // etc etc
		},
	}

	return plugin.NewClient(NewClientConfig(executablePath, logger, versionedPlugins))
}
```

When getting the service from the client, for example [here](https://github.com/grafana/grafana/blob/master/pkg/plugins/datasource_plugin.go#L97), we would instead use the kind of plugin instead of plugin-id:
```go
raw, err := rpcClient.Dispense("datasource")
```

If we don't find a service registered with that id we can fallback to using plugin id in `Dispense` if we want to support older versions (legacy):

In summary: With this in place we can add new rpc services in protobuf running side-by-side with existing rpc services, like datasource and transform currently. 