### PR TITLE
fix: s/Micro/Milli/ in DataQuery protobuf adapter

### DIFF
--- a/backend/core.go
+++ b/backend/core.go
@@ -87,7 +87,7 @@ func (q *DataQuery) toProtobuf() *pluginv2.DataQuery {
 	return &pluginv2.DataQuery{
 		RefId:         q.RefID,
 		MaxDataPoints: q.MaxDataPoints,
-		IntervalMS:    q.Interval.Microseconds(),
+		IntervalMS:    q.Interval.Milliseconds(),
 		TimeRange:     q.TimeRange.toProtobuf(),
 		Json:          q.JSON,
 	}


### PR DESCRIPTION
this resulted in incorrect Interval translation for datasource requests routed through GEL.