### PR TITLE
Add error message to dataframe metadata

### DIFF
--- a/dataframe/arrow.go
+++ b/dataframe/arrow.go
@@ -200,12 +200,12 @@ func buildArrowSchema(f *Frame, fs []arrow.Field) (*arrow.Schema, error) {
 		}
 		tableMetaMap["meta"] = str
 	}
-	if f.Error != nil {
-		str, err := toJSONString(f.Error)
+	if f.Warnings != nil {
+		str, err := toJSONString(f.Warnings)
 		if err != nil {
 			return nil, err
 		}
-		tableMetaMap["error"] = str
+		tableMetaMap["warnings"] = str
 	}
 	tableMeta := arrow.MetadataFrom(tableMetaMap)
 
@@ -640,9 +640,9 @@ func UnmarshalArrow(b []byte) (*Frame, error) {
 		}
 	}
 
-	if errorAsString, ok := getMDKey("error", metaData); ok {
+	if errorAsString, ok := getMDKey("warnings", metaData); ok {
 		var err error
-		frame.Error, err = DataQueryErrorFromJSON(errorAsString)
+		frame.Warnings, err = WarningsFromJSON(errorAsString)
 		if err != nil {
 			return nil, err
 		}

--- a/dataframe/arrow.go
+++ b/dataframe/arrow.go
@@ -200,6 +200,13 @@ func buildArrowSchema(f *Frame, fs []arrow.Field) (*arrow.Schema, error) {
 		}
 		tableMetaMap["meta"] = str
 	}
+	if f.Error != nil {
+		str, err := toJSONString(f.Error)
+		if err != nil {
+			return nil, err
+		}
+		tableMetaMap["error"] = str
+	}
 	tableMeta := arrow.MetadataFrom(tableMetaMap)
 
 	return arrow.NewSchema(fs, &tableMeta), nil
@@ -628,6 +635,14 @@ func UnmarshalArrow(b []byte) (*Frame, error) {
 	if metaAsString, ok := getMDKey("meta", metaData); ok {
 		var err error
 		frame.Meta, err = QueryResultMetaFromJSON(metaAsString)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if errorAsString, ok := getMDKey("error", metaData); ok {
+		var err error
+		frame.Error, err = DataQueryErrorFromJSON(errorAsString)
 		if err != nil {
 			return nil, err
 		}

--- a/dataframe/arrow.go
+++ b/dataframe/arrow.go
@@ -200,7 +200,7 @@ func buildArrowSchema(f *Frame, fs []arrow.Field) (*arrow.Schema, error) {
 		}
 		tableMetaMap["meta"] = str
 	}
-	if f.Warnings != nil {
+	if len(f.Warnings) > 0 {
 		str, err := toJSONString(f.Warnings)
 		if err != nil {
 			return nil, err

--- a/dataframe/arrow.go
+++ b/dataframe/arrow.go
@@ -640,9 +640,9 @@ func UnmarshalArrow(b []byte) (*Frame, error) {
 		}
 	}
 
-	if errorAsString, ok := getMDKey("warnings", metaData); ok {
+	if warningsAsString, ok := getMDKey("warnings", metaData); ok {
 		var err error
-		frame.Warnings, err = WarningsFromJSON(errorAsString)
+		frame.Warnings, err = WarningsFromJSON(warningsAsString)
 		if err != nil {
 			return nil, err
 		}

--- a/dataframe/data_query_error.go
+++ b/dataframe/data_query_error.go
@@ -1,0 +1,22 @@
+package dataframe
+
+import "encoding/json"
+
+// DataQueryError
+type DataQueryError struct {
+	// Short message (typically shown in the header)
+	Message string `json:"message,omitempty"`
+
+	// longer error message, shown in the body
+	Details string `json:"details,omitempty"`
+}
+
+// DataQueryErrorFromJSON creates aDataQueryError from a json string
+func DataQueryErrorFromJSON(jsonStr string) (*DataQueryError, error) {
+	var m DataQueryError
+	err := json.Unmarshal([]byte(jsonStr), &m)
+	if err != nil {
+		return nil, err
+	}
+	return &m, nil
+}

--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -14,7 +14,7 @@ type Frame struct {
 
 	RefID    string
 	Meta     *QueryResultMeta
-	Warnings []*Warning
+	Warnings []Warning
 }
 
 // Field represents a column of data with a specific type.
@@ -41,7 +41,7 @@ func (f *Frame) AppendRow(vals ...interface{}) {
 
 // AppendWarning adds warnings to the data frame.
 func (f *Frame) AppendWarning(message string, details string) {
-	f.Warnings = append(f.Warnings, &Warning{Message: message, Details: details})
+	f.Warnings = append(f.Warnings, Warning{Message: message, Details: details})
 }
 
 // AppendRowSafe adds a new row to the Frame by appending to each each element of vals to

--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -12,9 +12,9 @@ type Frame struct {
 	Name   string
 	Fields []*Field
 
-	RefID string
-	Meta  *QueryResultMeta
-	Error *DataQueryError
+	RefID    string
+	Meta     *QueryResultMeta
+	Warnings []*Warning
 }
 
 // Field represents a column of data with a specific type.
@@ -37,6 +37,11 @@ func (f *Frame) AppendRow(vals ...interface{}) {
 	for i, v := range vals {
 		f.Fields[i].Vector.Append(v)
 	}
+}
+
+// AppendWarning adds warnings to the data frame.
+func (f *Frame) AppendWarning(message string, details string) {
+	f.Warnings = append(f.Warnings, &Warning{Message: message, Details: details})
 }
 
 // AppendRowSafe adds a new row to the Frame by appending to each each element of vals to

--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -14,6 +14,7 @@ type Frame struct {
 
 	RefID string
 	Meta  *QueryResultMeta
+	Error *DataQueryError
 }
 
 // Field represents a column of data with a specific type.

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -28,8 +28,8 @@ func TestDataFrame(t *testing.T) {
 
 func TestDataFrameWarnings(t *testing.T) {
 	df := dataframe.New("warning_test")
-	df.AppendWarning(&dataframe.Warning{Details: "details1", Message: "message1"})
-	df.AppendWarning(&dataframe.Warning{Details: "details2", Message: "message2"})
+	df.AppendWarning("details1", "message1")
+	df.AppendWarning("details2", "message2")
 
 	if len(df.Warnings) != 2 {
 		t.Fatal("expected two warnings to be appended")

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -26,6 +26,16 @@ func TestDataFrame(t *testing.T) {
 	}
 }
 
+func TestDataFrameWarnings(t *testing.T) {
+	df := dataframe.New("warning_test")
+	df.AppendWarning(&dataframe.Warning{Details: "details1", Message: "message1"})
+	df.AppendWarning(&dataframe.Warning{Details: "details2", Message: "message2"})
+
+	if len(df.Warnings) != 2 {
+		t.Fatal("expected two warnings to be appended")
+	}
+}
+
 func TestField(t *testing.T) {
 	f := dataframe.NewField("value", nil, []float64{1.0, 2.0, 3.0})
 

--- a/dataframe/dataframe_warning.go
+++ b/dataframe/dataframe_warning.go
@@ -12,8 +12,8 @@ type Warning struct {
 }
 
 // WarningsFromJSON creates a *Warning from a json string.
-func WarningsFromJSON(jsonStr string) ([]*Warning, error) {
-	var m []*Warning
+func WarningsFromJSON(jsonStr string) ([]Warning, error) {
+	var m []Warning
 	err := json.Unmarshal([]byte(jsonStr), &m)
 	if err != nil {
 		return nil, err

--- a/dataframe/dataframe_warning.go
+++ b/dataframe/dataframe_warning.go
@@ -2,8 +2,11 @@ package dataframe
 
 import "encoding/json"
 
-// DataQueryError
-type DataQueryError struct {
+// Warnings is an slice of Warning.
+type Warnings []Warning
+
+// Warning contains information about problems in a dataframe.
+type Warning struct {
 	// Short message (typically shown in the header)
 	Message string `json:"message,omitempty"`
 
@@ -11,12 +14,12 @@ type DataQueryError struct {
 	Details string `json:"details,omitempty"`
 }
 
-// DataQueryErrorFromJSON creates aDataQueryError from a json string
-func DataQueryErrorFromJSON(jsonStr string) (*DataQueryError, error) {
-	var m DataQueryError
+// WarningsFromJSON creates a *Warning from a json string.
+func WarningsFromJSON(jsonStr string) ([]*Warning, error) {
+	var m []*Warning
 	err := json.Unmarshal([]byte(jsonStr), &m)
 	if err != nil {
 		return nil, err
 	}
-	return &m, nil
+	return m, nil
 }

--- a/dataframe/dataframe_warning.go
+++ b/dataframe/dataframe_warning.go
@@ -2,9 +2,6 @@ package dataframe
 
 import "encoding/json"
 
-// Warnings is an slice of Warning.
-type Warnings []Warning
-
 // Warning contains information about problems in a dataframe.
 type Warning struct {
 	// Short message (typically shown in the header)


### PR DESCRIPTION
It should be possible to return an error from a query along with data.  Since the existing [frontend structure](https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/types/datasource.ts#L400) is too strange to use directly, I propose a simpler structure that we can convert.

This should let the backend return data along with an error message -- for example "data truncated" or "could not reach all hosts" etc