### PR TITLE
Chore: encourage using the sdk logger, not hclog

### DIFF
--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -12,10 +12,11 @@ type Logger interface {
 	Error(msg string, args ...interface{})
 }
 
-// New creates a new logger.
-func New() Logger {
+// NewLoggerWithName creates a named logger
+func NewLoggerWithName(name string) Logger {
 	return &hclogWrapper{
 		logger: hclog.New(&hclog.LoggerOptions{
+			Name: name,
 			// Use debug as level since anything less severe is supressed.
 			Level: hclog.Debug,
 			// Use JSON format to make the output in Grafana format and work
@@ -23,6 +24,11 @@ func New() Logger {
 			JSONFormat: true,
 		}),
 	}
+}
+
+// New creates a logger without a name
+func New() Logger {
+	return NewLoggerWithName("")
 }
 
 type hclogWrapper struct {

--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -12,11 +12,10 @@ type Logger interface {
 	Error(msg string, args ...interface{})
 }
 
-// NewLoggerWithName creates a named logger
-func NewLoggerWithName(name string) Logger {
+// New creates a new logger.
+func New() Logger {
 	return &hclogWrapper{
 		logger: hclog.New(&hclog.LoggerOptions{
-			Name: name,
 			// Use debug as level since anything less severe is supressed.
 			Level: hclog.Debug,
 			// Use JSON format to make the output in Grafana format and work
@@ -24,11 +23,6 @@ func NewLoggerWithName(name string) Logger {
 			JSONFormat: true,
 		}),
 	}
-}
-
-// New creates a logger without a name
-func New() Logger {
-	return NewLoggerWithName("")
 }
 
 type hclogWrapper struct {

--- a/backend/setup.go
+++ b/backend/setup.go
@@ -6,19 +6,13 @@ import (
 	"net/http/pprof"
 	"os"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 // SetupPluginEnvironment will read the environment variables and apply the
 // standard environment behavior.  As the SDK evolves, this will likely change!
-func SetupPluginEnvironment(pluginID string) hclog.Logger {
-	pluginLogger := hclog.New(&hclog.LoggerOptions{
-		Name: pluginID,
-		// TODO: How to make level configurable?
-		Level:      hclog.LevelFromString("DEBUG"),
-		JSONFormat: true,
-		// Color:      hclog.ColorOff, (when we use 0.12)
-	})
+func SetupPluginEnvironment(pluginID string) log.Logger {
+	pluginLogger := log.NewLoggerWithName(pluginID)
 
 	// Enable profiler
 	profilerEnabled := false

--- a/backend/setup.go
+++ b/backend/setup.go
@@ -12,7 +12,7 @@ import (
 // SetupPluginEnvironment will read the environment variables and apply the
 // standard environment behavior.  As the SDK evolves, this will likely change!
 func SetupPluginEnvironment(pluginID string) log.Logger {
-	pluginLogger := log.NewLoggerWithName(pluginID)
+	pluginLogger := log.New()
 
 	// Enable profiler
 	profilerEnabled := false


### PR DESCRIPTION
The setup function should return a logger that is properly configured... See also:
https://github.com/grafana/google-sheets-datasource/pull/45


Does it make sense to have a global logger set?  Looking at the various implementations there are lots of linds of code devoted to passing around the logger created in main()