### PR TITLE
sketch... expose common functions for parsing query and config

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -25,6 +25,7 @@ type DataSourceConfig struct {
 	JSONData                json.RawMessage
 	DecryptedSecureJSONData map[string]string
 	Updated                 time.Time
+	Model                   interface{}
 }
 
 // PluginConfig configuration for a plugin.
@@ -35,4 +36,5 @@ type PluginConfig struct {
 	DecryptedSecureJSONData map[string]string
 	Updated                 time.Time
 	DataSourceConfig        *DataSourceConfig
+	Model                   interface{}
 }

--- a/backend/data.go
+++ b/backend/data.go
@@ -22,6 +22,7 @@ type DataQuery struct {
 	Interval      time.Duration
 	TimeRange     TimeRange
 	JSON          json.RawMessage
+	Model         interface{} // The parsed model (same data as in JSON)
 }
 
 // QueryDataResponse holds the results for a given query.
@@ -38,5 +39,7 @@ type TimeRange struct {
 
 // QueryDataHandler handles data queries.
 type QueryDataHandler interface {
+	ParseDataSourceConfigModel(jsonBytes json.RawMessage, secureJSONData map[string]string) (interface{}, error)
+	ParseQueryModel(jsonBytes json.RawMessage) (interface{}, error)
 	QueryData(ctx context.Context, req *QueryDataRequest) (*QueryDataResponse, error)
 }

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -9,6 +9,7 @@ import (
 // dataSDKAdapter adapter between low level plugin protocol and SDK interfaces.
 type dataSDKAdapter struct {
 	queryDataHandler QueryDataHandler
+	configCache      map[int64]*PluginConfig // thread safety?!
 }
 
 func newDataSDKAdapter(handler QueryDataHandler) *dataSDKAdapter {
@@ -17,8 +18,39 @@ func newDataSDKAdapter(handler QueryDataHandler) *dataSDKAdapter {
 	}
 }
 
-func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataRequest) (*pluginv2.QueryDataResponse, error) {
-	resp, err := a.queryDataHandler.QueryData(ctx, fromProto().QueryDataRequest(req))
+func (a *dataSDKAdapter) QueryData(ctx context.Context, preq *pluginv2.QueryDataRequest) (*pluginv2.QueryDataResponse, error) {
+	req := fromProto().QueryDataRequest(preq)
+
+	// Parse the query objects
+	for i, q := range req.Queries {
+		m, err := a.queryDataHandler.ParseQueryModel(q.JSON)
+		if err != nil {
+			return nil, err
+		}
+		req.Queries[i].Model = m
+	}
+
+	// Check for cached version here
+	dscfg := req.PluginConfig.DataSourceConfig
+	cfg := a.configCache[dscfg.ID]
+	if cfg != nil {
+		if cfg.Updated != req.PluginConfig.Updated || cfg.DataSourceConfig.Updated != dscfg.Updated {
+			// CONFIG CHANGED! maybe make a callback?
+			cfg = nil
+		}
+	}
+	if cfg == nil { // first time or if it changed
+		m, err := a.queryDataHandler.ParseDataSourceConfigModel(dscfg.JSONData, dscfg.DecryptedSecureJSONData)
+		if err != nil {
+			return nil, err
+		}
+		cfg = &req.PluginConfig
+		cfg.DataSourceConfig.Model = m
+		a.configCache[dscfg.ID] = cfg
+	}
+	req.PluginConfig = *cfg
+
+	resp, err := a.queryDataHandler.QueryData(ctx, req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Just throwing stuff out there... 

can we expose a function that will:
* parse a well typed query object
* parse the datasource (and plugin?) config

Send the well typed -- but not generic :( objects as part of the API?

If we force these callbacks in the SDK, we could remove the JSON parts from the object also.  BUT that would break the current to/from protobuf that I am not sure is totally necessary