### PR TITLE
Chore: don't create a new logger

### DIFF
--- a/backend/setup.go
+++ b/backend/setup.go
@@ -5,15 +5,11 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
-
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 // SetupPluginEnvironment will read the environment variables and apply the
 // standard environment behavior.  As the SDK evolves, this will likely change!
-func SetupPluginEnvironment(pluginID string) log.Logger {
-	pluginLogger := log.New()
-
+func SetupPluginEnvironment(pluginID string) {
 	// Enable profiler
 	profilerEnabled := false
 	if value, ok := os.LookupEnv("GF_PLUGINS_PROFILER"); ok {
@@ -22,14 +18,14 @@ func SetupPluginEnvironment(pluginID string) log.Logger {
 			profilerEnabled = true
 		}
 	}
-	pluginLogger.Info("Profiler", "enabled", profilerEnabled)
+	Logger.Info("Profiler", "enabled", profilerEnabled)
 	if profilerEnabled {
 		profilerPort := "6060"
 		if value, ok := os.LookupEnv("GF_PLUGINS_PROFILER_PORT"); ok {
 			profilerPort = value
 		}
 
-		pluginLogger.Info("Profiler", "port", profilerPort)
+		Logger.Info("Profiler", "port", profilerPort)
 		portConfig := fmt.Sprintf(":%s", profilerPort)
 
 		r := http.NewServeMux()
@@ -41,9 +37,8 @@ func SetupPluginEnvironment(pluginID string) log.Logger {
 
 		go func() {
 			if err := http.ListenAndServe(portConfig, r); err != nil {
-				pluginLogger.Error("Error Running profiler: %s", err.Error())
+				Logger.Error("Error Running profiler: %s", err.Error())
 			}
 		}()
 	}
-	return pluginLogger
 }


### PR DESCRIPTION
rather than encouraging plugins to make a new logger, they can just use `backend.Logger` and it should be setup properly