### PR TITLE
data/docs: example for Replace

### DIFF
--- a/data/frame.go
+++ b/data/frame.go
@@ -369,6 +369,8 @@ func (f *Frame) StringTable(maxFields, maxRows int) (string, error) {
 
 	sb := &strings.Builder{}
 	sb.WriteString(fmt.Sprintf("Name: %v\n", f.Name))
+	sb.WriteString(fmt.Sprintf("Dimensions: %v Fields by %v Rows\n", len(f.Fields), rowLen))
+
 	table := tablewriter.NewWriter(sb)
 
 	// table formatting options
@@ -376,9 +378,6 @@ func (f *Frame) StringTable(maxFields, maxRows int) (string, error) {
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAutoWrapText(false)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
-
-	// (caption is below the table)
-	table.SetCaption(true, fmt.Sprintf("Field Count: %v\nRow Count: %v", len(f.Fields), rowLen))
 
 	// set table headers
 	headers := make([]string, width)

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -37,6 +37,7 @@ func ExampleNewFrame() {
 	fmt.Println(frame.String())
 	// Output:
 	// Name: Frame Name
+	// Dimensions: 3 Fields by 2 Rows
 	// +-------------------------------+-----------------------+-----------------------+
 	// | Name: Time                    | Name: Temp            | Name: Count           |
 	// | Labels:                       | Labels: place=Ecuador | Labels: place=Ecuador |
@@ -45,7 +46,6 @@ func ExampleNewFrame() {
 	// | 2020-01-02 03:04:05 +0000 UTC | 1                     | 12                    |
 	// | 2020-01-02 03:05:05 +0000 UTC | NaN                   | null                  |
 	// +-------------------------------+-----------------------+-----------------------+
-	// Field Count: 3 Row Count: 2
 }
 
 func TestStringTable(t *testing.T) {
@@ -65,6 +65,7 @@ func TestStringTable(t *testing.T) {
 			maxWidth:  3,
 			maxLength: 3,
 			output: `Name: sTest
+Dimensions: 3 Fields by 3 Rows
 +--------------+--------------+--------------+
 | Name:        | Name:        | Name:        |
 | Labels:      | Labels:      | Labels:      |
@@ -74,7 +75,6 @@ func TestStringTable(t *testing.T) {
 | false        | false        | false        |
 | false        | false        | false        |
 +--------------+--------------+--------------+
-Field Count: 3 Row Count: 3
 `,
 		},
 		{
@@ -82,6 +82,7 @@ Field Count: 3 Row Count: 3
 			maxWidth:  2,
 			maxLength: 2,
 			output: `Name: sTest
+Dimensions: 3 Fields by 3 Rows
 +--------------+----------------+
 | Name:        | ...+2 field... |
 | Labels:      |                |
@@ -90,7 +91,6 @@ Field Count: 3 Row Count: 3
 | false        | ...            |
 | ...          | ...            |
 +--------------+----------------+
-Field Count: 3 Row Count: 3
 `,
 		},
 		{
@@ -98,13 +98,13 @@ Field Count: 3 Row Count: 3
 			maxWidth:  10,
 			maxLength: 0,
 			output: `Name: sTest
+Dimensions: 3 Fields by 3 Rows
 +--------------+--------------+--------------+
 | Name:        | Name:        | Name:        |
 | Labels:      | Labels:      | Labels:      |
 | Type: []bool | Type: []bool | Type: []bool |
 +--------------+--------------+--------------+
 +--------------+--------------+--------------+
-Field Count: 3 Row Count: 3
 `,
 		},
 	}

--- a/data/sql_test.go
+++ b/data/sql_test.go
@@ -38,8 +38,10 @@ func ExampleReplace() {
 		return &s
 	}
 
-	frame := data.NewFrame("String Field Replacer Example",
-		data.NewField("string", nil, []*string{getString(), getString(), getString()}))
+	frame := data.NewFrame("Before",
+		data.NewField("string", nil, []*string{getString(), getString()}))
+
+	fmt.Println(frame.String()) // Before
 
 	intReplacer := &data.StringFieldReplacer{
 		VectorType: []*int64{},
@@ -60,9 +62,22 @@ func ExampleReplace() {
 		// return err
 	}
 
-	fmt.Println(frame.String())
+	frame.Name = "After"
+	fmt.Println(frame.String()) // After
 	// Output:
-	// Name: String Field Replacer Example
+	// Name: Before
+	// +-----------------+
+	// | Name: string    |
+	// | Labels:         |
+	// | Type: []*string |
+	// +-----------------+
+	// | 1               |
+	// | 2               |
+	// +-----------------+
+	// Field Count: 1 Row
+	// Count: 2
+	//
+	// Name: After
 	// +----------------+
 	// | Name: string   |
 	// | Labels:        |
@@ -70,10 +85,9 @@ func ExampleReplace() {
 	// +----------------+
 	// | 1              |
 	// | 2              |
-	// | 3              |
 	// +----------------+
 	// Field Count: 1 Row
-	// Count: 3
+	// Count: 2
 }
 
 func ExampleNewFromSQLRows() {

--- a/data/sql_test.go
+++ b/data/sql_test.go
@@ -66,6 +66,7 @@ func ExampleReplace() {
 	fmt.Println(frame.String()) // After
 	// Output:
 	// Name: Before
+	// Dimensions: 1 Fields by 2 Rows
 	// +-----------------+
 	// | Name: string    |
 	// | Labels:         |
@@ -74,10 +75,9 @@ func ExampleReplace() {
 	// | 1               |
 	// | 2               |
 	// +-----------------+
-	// Field Count: 1 Row
-	// Count: 2
 	//
 	// Name: After
+	// Dimensions: 1 Fields by 2 Rows
 	// +----------------+
 	// | Name: string   |
 	// | Labels:        |
@@ -86,8 +86,6 @@ func ExampleReplace() {
 	// | 1              |
 	// | 2              |
 	// +----------------+
-	// Field Count: 1 Row
-	// Count: 2
 }
 
 func ExampleNewFromSQLRows() {

--- a/data/sql_test.go
+++ b/data/sql_test.go
@@ -2,6 +2,7 @@ package data_test
 
 import (
 	"database/sql"
+	"fmt"
 	"reflect"
 	"strconv"
 
@@ -29,8 +30,18 @@ func ExampleSQLStringConverter() {
 	}
 }
 
-func ExampleStringFieldReplacer() {
-	_ = &data.StringFieldReplacer{
+func ExampleReplace() {
+	i := 0
+	getString := func() *string {
+		i++
+		s := strconv.Itoa(i)
+		return &s
+	}
+
+	frame := data.NewFrame("String Field Replacer Example",
+		data.NewField("string", nil, []*string{getString(), getString(), getString()}))
+
+	intReplacer := &data.StringFieldReplacer{
 		VectorType: []*int64{},
 		ReplaceFunc: func(in *string) (interface{}, error) {
 			if in == nil {
@@ -43,6 +54,26 @@ func ExampleStringFieldReplacer() {
 			return &v, nil
 		},
 	}
+
+	err := data.Replace(frame, 0, intReplacer)
+	if err != nil {
+		// return err
+	}
+
+	fmt.Println(frame.String())
+	// Output:
+	// Name: String Field Replacer Example
+	// +----------------+
+	// | Name: string   |
+	// | Labels:        |
+	// | Type: []*int64 |
+	// +----------------+
+	// | 1              |
+	// | 2              |
+	// | 3              |
+	// +----------------+
+	// Field Count: 1 Row
+	// Count: 3
 }
 
 func ExampleNewFromSQLRows() {


### PR DESCRIPTION
Made example:

![image](https://user-images.githubusercontent.com/1692624/77463702-6dc3c280-6ddc-11ea-9d14-0a1ba0ba6a4e.png)


# Likely in future PR:

Might change:
 - StringFieldReplacer to take a FieldType instead of VectorType I think, more consistent with other recent changes.
 - Make Method on Frame instead, more consistent with rest of package.

Will change:
 - vector language to "Field"