### PR TITLE
backend/data: New Types to make things cleaner and misc cleanup

### DIFF
--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -91,9 +91,7 @@ func (f convertFromProtobuf) QueryDataRequest(protoReq *pluginv2.QueryDataReques
 }
 
 func (f convertFromProtobuf) QueryDataResponse(protoRes *pluginv2.QueryDataResponse) (*QueryDataResponse, error) {
-	qdr := QueryDataResponse{
-		Responses: make(map[string]*DataResponse, len(protoRes.Responses)),
-	}
+	qdr := NewQueryDataResponse(len(protoRes.Responses))
 	for rIdx, res := range protoRes.Responses {
 		frames, err := data.BytesSliceToFrames(res.Frames)
 		if err != nil {

--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -93,7 +93,7 @@ func (f convertFromProtobuf) QueryDataRequest(protoReq *pluginv2.QueryDataReques
 func (f convertFromProtobuf) QueryDataResponse(protoRes *pluginv2.QueryDataResponse) (*QueryDataResponse, error) {
 	qdr := NewQueryDataResponse(len(protoRes.Responses))
 	for rIdx, res := range protoRes.Responses {
-		frames, err := data.BytesSliceToFrames(res.Frames)
+		frames, err := data.UnmarshalArrowFrames(res.Frames)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -111,7 +111,7 @@ func (t convertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.
 		Responses: make(map[string]*pluginv2.DataResponse, len(res.Responses)),
 	}
 	for refID, dr := range res.Responses {
-		encodedFrames, err := dr.Frames.ToBytesSlice()
+		encodedFrames, err := dr.Frames.MarshalArrow()
 		if err != nil {
 			return nil, err
 		}

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 )
 
@@ -112,7 +111,7 @@ func (t convertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.
 		Responses: make(map[string]*pluginv2.DataResponse, len(res.Responses)),
 	}
 	for refID, dr := range res.Responses {
-		encodedFrames, err := data.FramesToBytesSlice(dr.Frames)
+		encodedFrames, err := dr.Frames.ToBytesSlice()
 		if err != nil {
 			return nil, err
 		}

--- a/backend/data.go
+++ b/backend/data.go
@@ -51,8 +51,19 @@ type DataQuery struct {
 // It is the return type of a QueryData call.
 type QueryDataResponse struct {
 	// Responses is a map of RefIDs (Unique Query ID) to *DataResponse.
-	Responses map[string]*DataResponse
+	Responses Responses
 }
+
+// NewQueryDataResponse returns a QueryDataResponse with the Responses property
+// initialized to size.
+func NewQueryDataResponse(size int) QueryDataResponse {
+	return QueryDataResponse{
+		Responses: make(Responses, size),
+	}
+}
+
+// Responses is a map of RefIDs (Unique Query ID) to *DataResponse.
+type Responses map[string]*DataResponse
 
 // DataResponse contains the results from a DataQuery.
 // A map of RefIDs (unique query identifers) to this type makes up the Responses property of a QueryDataResponse.

--- a/backend/data.go
+++ b/backend/data.go
@@ -13,7 +13,7 @@ type QueryDataHandler interface {
 	// QueryData handles multiple queries and returns multiple responses.
 	// req contains the queries []DataQuery (where each query contains RefID as a unique identifer).
 	// The QueryDataResponse contains a map of RefID to the response for each query, and each response
-	// contains frames ([]*Frame).
+	// contains Frames ([]*Frame).
 	QueryData(ctx context.Context, req *QueryDataRequest) (*QueryDataResponse, error)
 }
 
@@ -59,7 +59,7 @@ type QueryDataResponse struct {
 // The Error property is used to allow for partial success responses from the containing QueryDataResponse.
 type DataResponse struct {
 	// The data returned from the Query. Each Frame repeats the RefID.
-	Frames []*data.Frame
+	Frames data.Frames
 
 	// Meta contains a custom JSON object for custom response metadata about the query. WARNING: Currently ignored by front end of Grafana.
 	Meta json.RawMessage

--- a/data/arrow.go
+++ b/data/arrow.go
@@ -711,7 +711,7 @@ func UnmarshalArrowFrames(bFrames [][]byte) (Frames, error) {
 
 // MarshalArrow encodes Frames into a slice of []byte using *Frame's MarshalArrow method on each Frame.
 // If an error occurs [][]byte will be nil.
-// See BytesSliceToFrames for the inverse operation.
+// See UnmarshalArrowFrames for the inverse operation.
 func (frames Frames) MarshalArrow() ([][]byte, error) {
 	bs := make([][]byte, len(frames))
 	var err error

--- a/data/arrow.go
+++ b/data/arrow.go
@@ -17,7 +17,7 @@ import (
 
 // MarshalArrow converts the Frame to an arrow table and returns a byte
 // representation of that table.
-func MarshalArrow(f *Frame) ([]byte, error) {
+func (f *Frame) MarshalArrow() ([]byte, error) {
 	arrowFields, err := buildArrowFields(f)
 	if err != nil {
 		return nil, err
@@ -640,8 +640,8 @@ func populateFrameFields(fR *ipc.FileReader, nullable []bool, frame *Frame) erro
 	return nil
 }
 
-// UnmarshalArrow converts a byte representation of an arrow table to a Frame
-func UnmarshalArrow(b []byte) (*Frame, error) {
+// UnmarshalArrowFrame converts a byte representation of an arrow table to a Frame.
+func UnmarshalArrowFrame(b []byte) (*Frame, error) {
 	fB := filebuffer.New(b)
 	fR, err := ipc.NewFileReader(fB)
 	if err != nil {
@@ -693,15 +693,15 @@ func toJSONString(val interface{}) (string, error) {
 	return string(b), nil
 }
 
-// BytesSliceToFrames decodes a slice of Arrow encoded frames to Frames ([]*Frame) by calling
-// the UnMarshalArrow function on each encoded frame.
+// UnmarshalArrowFrames decodes a slice of Arrow encoded frames to Frames ([]*Frame) by calling
+// the UnmarshalArrow function on each encoded frame.
 // If an error occurs Frames will be nil.
-// See Frames.ToBytesSlice() for the inverse operation.
-func BytesSliceToFrames(bFrames [][]byte) (Frames, error) {
+// See Frames.UnMarshalArrow() for the inverse operation.
+func UnmarshalArrowFrames(bFrames [][]byte) (Frames, error) {
 	frames := make(Frames, len(bFrames))
 	var err error
 	for i, encodedFrame := range bFrames {
-		frames[i], err = UnmarshalArrow(encodedFrame)
+		frames[i], err = UnmarshalArrowFrame(encodedFrame)
 		if err != nil {
 			return nil, err
 		}
@@ -709,14 +709,14 @@ func BytesSliceToFrames(bFrames [][]byte) (Frames, error) {
 	return frames, nil
 }
 
-// ToBytesSlice encodes Frames into a slice of []byte using *Frame's MarshalArrow method on each Frame.
+// UnmarshalArrow encodes Frames into a slice of []byte using *Frame's MarshalArrow method on each Frame.
 // If an error occurs [][]byte will be nil.
 // See BytesSliceToFrames for the inverse operation.
-func (frames Frames) ToBytesSlice() ([][]byte, error) {
+func (frames Frames) UnmarshalArrow() ([][]byte, error) {
 	bs := make([][]byte, len(frames))
 	var err error
 	for i, frame := range frames {
-		bs[i], err = MarshalArrow(frame)
+		bs[i], err = frame.MarshalArrow()
 		if err != nil {
 			return nil, err
 		}

--- a/data/arrow.go
+++ b/data/arrow.go
@@ -693,7 +693,10 @@ func toJSONString(val interface{}) (string, error) {
 	return string(b), nil
 }
 
-// BytesSliceToFrames decodes a slice of encoded Arrow frames to a slice of *Frame using the UnMarshalArrow function.
+// BytesSliceToFrames decodes a slice of Arrow encoded frames to Frames ([]*Frame) by calling
+// the UnMarshalArrow function on each encoded frame.
+// If an error occurs Frames will be nil.
+// See Frames.ToBytesSlice() for the inverse operation.
 func BytesSliceToFrames(bFrames [][]byte) (Frames, error) {
 	frames := make(Frames, len(bFrames))
 	var err error
@@ -707,6 +710,7 @@ func BytesSliceToFrames(bFrames [][]byte) (Frames, error) {
 }
 
 // ToBytesSlice encodes Frames into a slice of []byte using *Frame's MarshalArrow method on each Frame.
+// If an error occurs [][]byte will be nil.
 // See BytesSliceToFrames for the inverse operation.
 func (frames Frames) ToBytesSlice() ([][]byte, error) {
 	bs := make([][]byte, len(frames))

--- a/data/arrow.go
+++ b/data/arrow.go
@@ -693,9 +693,9 @@ func toJSONString(val interface{}) (string, error) {
 	return string(b), nil
 }
 
-// BytesSliceToFrames decodes a slice of encoded Arrow frames to a slice of *Frame.
-func BytesSliceToFrames(bFrames [][]byte) ([]*Frame, error) {
-	frames := make([]*Frame, len(bFrames))
+// BytesSliceToFrames decodes a slice of encoded Arrow frames to a slice of *Frame using the UnMarshalArrow function.
+func BytesSliceToFrames(bFrames [][]byte) (Frames, error) {
+	frames := make(Frames, len(bFrames))
 	var err error
 	for i, encodedFrame := range bFrames {
 		frames[i], err = UnmarshalArrow(encodedFrame)
@@ -706,8 +706,9 @@ func BytesSliceToFrames(bFrames [][]byte) ([]*Frame, error) {
 	return frames, nil
 }
 
-// FramesToBytesSlice encodes a slice of Frames into a slice of []byte.
-func FramesToBytesSlice(frames []*Frame) ([][]byte, error) {
+// ToBytesSlice encodes Frames into a slice of []byte using *Frame's MarshalArrow method on each Frame.
+// See BytesSliceToFrames for the inverse operation.
+func (frames Frames) ToBytesSlice() ([][]byte, error) {
 	bs := make([][]byte, len(frames))
 	var err error
 	for i, frame := range frames {

--- a/data/arrow.go
+++ b/data/arrow.go
@@ -709,10 +709,10 @@ func UnmarshalArrowFrames(bFrames [][]byte) (Frames, error) {
 	return frames, nil
 }
 
-// UnmarshalArrow encodes Frames into a slice of []byte using *Frame's MarshalArrow method on each Frame.
+// MarshalArrow encodes Frames into a slice of []byte using *Frame's MarshalArrow method on each Frame.
 // If an error occurs [][]byte will be nil.
 // See BytesSliceToFrames for the inverse operation.
-func (frames Frames) UnmarshalArrow() ([][]byte, error) {
+func (frames Frames) MarshalArrow() ([][]byte, error) {
 	bs := make([][]byte, len(frames))
 	var err error
 	for i, frame := range frames {

--- a/data/arrow_test.go
+++ b/data/arrow_test.go
@@ -228,7 +228,7 @@ func goldenDF() *data.Frame {
 
 func TestEncode(t *testing.T) {
 	df := goldenDF()
-	b, err := data.MarshalArrow(df)
+	b, err := df.MarshalArrow()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,7 +262,7 @@ func TestDecode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newDf, err := data.UnmarshalArrow(b)
+	newDf, err := data.UnmarshalArrowFrame(b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/data/conversion_input.go
+++ b/data/conversion_input.go
@@ -46,16 +46,16 @@ func NewFrameInputConverter(fieldConvs []FieldConverter, rowLen int) (*FrameInpu
 // Converter is not nil, then the Converter function is called before setting the value (otherwise Frame.Set is called directly).
 // If an error is returned from the Converter function this function returns that error.
 // Like Frame.Set and Field.Set, it will panic if fieldIdx or rowIdx are out of range.
-func (fcb *FrameInputConverter) Set(fieldIdx, rowIdx int, val interface{}) error {
-	if fcb.fieldConverters[fieldIdx].Converter == nil {
-		fcb.Frame.Set(fieldIdx, rowIdx, val)
+func (fic *FrameInputConverter) Set(fieldIdx, rowIdx int, val interface{}) error {
+	if fic.fieldConverters[fieldIdx].Converter == nil {
+		fic.Frame.Set(fieldIdx, rowIdx, val)
 		return nil
 	}
-	convertedVal, err := fcb.fieldConverters[fieldIdx].Converter(val)
+	convertedVal, err := fic.fieldConverters[fieldIdx].Converter(val)
 	if err != nil {
 		return err
 	}
-	fcb.Frame.Set(fieldIdx, rowIdx, convertedVal)
+	fic.Frame.Set(fieldIdx, rowIdx, convertedVal)
 	return nil
 }
 

--- a/data/frame.go
+++ b/data/frame.go
@@ -43,7 +43,7 @@ type Frame struct {
 	Warnings []Warning // TODO: Remove, will be replaced with FrameMeta.Notices.
 }
 
-// Frames is a a collection of Frames as a slice of Frame pointers.
+// Frames is a slice of Frame pointers.
 // It is the main data container within a backend.DataResponse.
 type Frames []*Frame
 

--- a/data/frame.go
+++ b/data/frame.go
@@ -43,6 +43,10 @@ type Frame struct {
 	Warnings []Warning // TODO: Remove, will be replaced with FrameMeta.Notices.
 }
 
+// Frames is a a collection of Frames as a slice of Frame pointers.
+// It is the main data container within a backend.DataResponse.
+type Frames []*Frame
+
 // AppendRow adds a new row to the Frame by appending to each element of vals to
 // the corresponding Field in the data.
 // The Frame's Fields must be initalized or AppendRow will panic.

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -129,7 +129,7 @@ func ExampleFrame_tSDBTimeSeriesDifferentTimeIndices() {
 	// | 2020-01-02 03:04:00 +0000 UTC | 3               |
 	// | 2020-01-02 03:05:00 +0000 UTC | 6               |
 	// +-------------------------------+-----------------+
-
+	//
 	// Name: cpu
 	// Dimensions: 2 Fields by 2 Rows
 	// +-------------------------------+-----------------+

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -250,6 +250,7 @@ func ExampleFrame_tableLikeLongTimeSeries() {
 	}
 	fmt.Println(frame.String())
 	w, _ := data.LongToWide(frame)
+	w.Name = "Wide"
 	fmt.Println(w.String())
 	// Output:
 	// Name: Long
@@ -265,7 +266,7 @@ func ExampleFrame_tableLikeLongTimeSeries() {
 	// | 2020-01-02 03:05:00 +0000 UTC | 6               | 16              | bar              |
 	// +-------------------------------+-----------------+-----------------+------------------+
 	//
-	// Name: Long
+	// Name: Wide
 	// Dimensions: 5 Fields by 2 Rows
 	// +-------------------------------+------------------------+------------------------+------------------------+------------------------+
 	// | Name: time                    | Name: aMetric          | Name: bMetric          | Name: aMetric          | Name: bMetric          |

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -69,7 +69,7 @@ func ExampleFrame_tSDBTimeSeriesDifferentTimeIndices() {
 	// by a Name and a set of key value pairs (Labels (a.k.a Tags)).
 
 	// In the case where the responses does not share identical time values and length (a single time index),
-	// then the proper representation is a []*Frame. Where each Frame has a Time type field and one or more
+	// then the proper representation is Frames ([]*Frame). Where each Frame has a Time type field and one or more
 	// Number fields.
 
 	// Each Frame should have its value sorted by time in ascending order.


### PR DESCRIPTION
* Adds `Frames` type which is `[]*Frame`
* Adds `Responses` type which is `map[string]*DataResponse`
* Adds `NewQueryDataResponse(size int)` which returns a `QueryDataResponse` with the Responses property initialized to size
* "MarshalArrow" cleanup:
  * Frame:
    * MarshalArrow -> *Frame.MarshalArrow
    * UnmarshalArrow -> UnmarshalArrowFrame
  * Frames:
    * FramesToByteSlice -> Frames.MarshalArrow 
    * BytesSliceToFrames -> UnmarshalArrowFrames
* Misc comment cleanup
