### PR TITLE
Add support for filling missing timestamps

### DIFF
--- a/data/frame.go
+++ b/data/frame.go
@@ -43,6 +43,13 @@ func (f *Frame) AppendRow(vals ...interface{}) {
 	}
 }
 
+// InsertAt adds values in the field vector (identyfied by fieldIdx) at the index specified by vectorIdx
+func (f *Frame) InsertRowAt(vectorIdx int, vals []interface{}) {
+	for i, v := range vals {
+		f.Fields[i].vector.InsertAt(vectorIdx, v)
+	}
+}
+
 // RowCopy returns an interface slice that contains the values of each Field for the given rowIdx.
 func (f *Frame) RowCopy(rowIdx int) []interface{} {
 	vals := make([]interface{}, len(f.Fields))

--- a/data/frame.go
+++ b/data/frame.go
@@ -44,9 +44,9 @@ func (f *Frame) AppendRow(vals ...interface{}) {
 }
 
 // InsertAt adds values in the field vector (identyfied by fieldIdx) at the index specified by vectorIdx
-func (f *Frame) InsertRowAt(vectorIdx int, vals []interface{}) {
+func (f *Frame) InsertRowAt(fieldIdx int, vals []interface{}) {
 	for i, v := range vals {
-		f.Fields[i].vector.InsertAt(vectorIdx, v)
+		f.Fields[i].vector.InsertAt(fieldIdx, v)
 	}
 }
 

--- a/data/generic_nullable_vector.go
+++ b/data/generic_nullable_vector.go
@@ -76,10 +76,7 @@ func (v *nullablegenVector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }

--- a/data/generic_nullable_vector.go
+++ b/data/generic_nullable_vector.go
@@ -10,7 +10,17 @@ func newNullablegenVector(n int) *nullablegenVector {
 }
 
 func (v *nullablegenVector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*gen)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case gen:
+		val := i.(gen)
+		(*v)[idx] = &val
+	case *gen:
+		(*v)[idx] = i.(*gen)
+	}
 }
 
 func (v *nullablegenVector) Append(i interface{}) {
@@ -59,4 +69,17 @@ func (v *nullablegenVector) Type() FieldType {
 
 func (v *nullablegenVector) Extend(i int) {
 	(*v) = append((*v), make([]*gen, i)...)
+}
+
+func (v *nullablegenVector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
 }

--- a/data/generic_vector.go
+++ b/data/generic_vector.go
@@ -58,10 +58,7 @@ func (v *genVector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }

--- a/data/generic_vector.go
+++ b/data/generic_vector.go
@@ -52,3 +52,16 @@ func (v *genVector) Type() FieldType {
 func (v *genVector) Extend(i int) {
 	(*v) = append((*v), make([]gen, i)...)
 }
+
+func (v *genVector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}

--- a/data/nullable_vector.gen.go
+++ b/data/nullable_vector.gen.go
@@ -16,7 +16,17 @@ func newNullableUint8Vector(n int) *nullableUint8Vector {
 }
 
 func (v *nullableUint8Vector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*uint8)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case uint8:
+		val := i.(uint8)
+		(*v)[idx] = &val
+	case *uint8:
+		(*v)[idx] = i.(*uint8)
+	}
 }
 
 func (v *nullableUint8Vector) Append(i interface{}) {
@@ -67,6 +77,19 @@ func (v *nullableUint8Vector) Extend(i int) {
 	(*v) = append((*v), make([]*uint8, i)...)
 }
 
+func (v *nullableUint8Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Uint16erate uint16ny -in=$GOFILE -out=nullable_vector.Uint16.go uint16 "Uint16=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableUint16Vector []*uint16
@@ -77,7 +100,17 @@ func newNullableUint16Vector(n int) *nullableUint16Vector {
 }
 
 func (v *nullableUint16Vector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*uint16)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case uint16:
+		val := i.(uint16)
+		(*v)[idx] = &val
+	case *uint16:
+		(*v)[idx] = i.(*uint16)
+	}
 }
 
 func (v *nullableUint16Vector) Append(i interface{}) {
@@ -128,6 +161,19 @@ func (v *nullableUint16Vector) Extend(i int) {
 	(*v) = append((*v), make([]*uint16, i)...)
 }
 
+func (v *nullableUint16Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Uint32erate uint32ny -in=$GOFILE -out=nullable_vector.Uint32.go uint32 "Uint32=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableUint32Vector []*uint32
@@ -138,7 +184,17 @@ func newNullableUint32Vector(n int) *nullableUint32Vector {
 }
 
 func (v *nullableUint32Vector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*uint32)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case uint32:
+		val := i.(uint32)
+		(*v)[idx] = &val
+	case *uint32:
+		(*v)[idx] = i.(*uint32)
+	}
 }
 
 func (v *nullableUint32Vector) Append(i interface{}) {
@@ -189,6 +245,19 @@ func (v *nullableUint32Vector) Extend(i int) {
 	(*v) = append((*v), make([]*uint32, i)...)
 }
 
+func (v *nullableUint32Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Uint64erate uint64ny -in=$GOFILE -out=nullable_vector.Uint64.go uint64 "Uint64=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableUint64Vector []*uint64
@@ -199,7 +268,17 @@ func newNullableUint64Vector(n int) *nullableUint64Vector {
 }
 
 func (v *nullableUint64Vector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*uint64)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case uint64:
+		val := i.(uint64)
+		(*v)[idx] = &val
+	case *uint64:
+		(*v)[idx] = i.(*uint64)
+	}
 }
 
 func (v *nullableUint64Vector) Append(i interface{}) {
@@ -250,6 +329,19 @@ func (v *nullableUint64Vector) Extend(i int) {
 	(*v) = append((*v), make([]*uint64, i)...)
 }
 
+func (v *nullableUint64Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Int8erate int8ny -in=$GOFILE -out=nullable_vector.Int8.go int8 "Int8=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableInt8Vector []*int8
@@ -260,7 +352,17 @@ func newNullableInt8Vector(n int) *nullableInt8Vector {
 }
 
 func (v *nullableInt8Vector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*int8)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case int8:
+		val := i.(int8)
+		(*v)[idx] = &val
+	case *int8:
+		(*v)[idx] = i.(*int8)
+	}
 }
 
 func (v *nullableInt8Vector) Append(i interface{}) {
@@ -311,6 +413,19 @@ func (v *nullableInt8Vector) Extend(i int) {
 	(*v) = append((*v), make([]*int8, i)...)
 }
 
+func (v *nullableInt8Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Int16erate int16ny -in=$GOFILE -out=nullable_vector.Int16.go int16 "Int16=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableInt16Vector []*int16
@@ -321,7 +436,17 @@ func newNullableInt16Vector(n int) *nullableInt16Vector {
 }
 
 func (v *nullableInt16Vector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*int16)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case int16:
+		val := i.(int16)
+		(*v)[idx] = &val
+	case *int16:
+		(*v)[idx] = i.(*int16)
+	}
 }
 
 func (v *nullableInt16Vector) Append(i interface{}) {
@@ -372,6 +497,19 @@ func (v *nullableInt16Vector) Extend(i int) {
 	(*v) = append((*v), make([]*int16, i)...)
 }
 
+func (v *nullableInt16Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Int32erate int32ny -in=$GOFILE -out=nullable_vector.Int32.go int32 "Int32=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableInt32Vector []*int32
@@ -382,7 +520,17 @@ func newNullableInt32Vector(n int) *nullableInt32Vector {
 }
 
 func (v *nullableInt32Vector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*int32)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case int32:
+		val := i.(int32)
+		(*v)[idx] = &val
+	case *int32:
+		(*v)[idx] = i.(*int32)
+	}
 }
 
 func (v *nullableInt32Vector) Append(i interface{}) {
@@ -433,6 +581,19 @@ func (v *nullableInt32Vector) Extend(i int) {
 	(*v) = append((*v), make([]*int32, i)...)
 }
 
+func (v *nullableInt32Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Int64erate int64ny -in=$GOFILE -out=nullable_vector.Int64.go int64 "Int64=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableInt64Vector []*int64
@@ -443,7 +604,17 @@ func newNullableInt64Vector(n int) *nullableInt64Vector {
 }
 
 func (v *nullableInt64Vector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*int64)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case int64:
+		val := i.(int64)
+		(*v)[idx] = &val
+	case *int64:
+		(*v)[idx] = i.(*int64)
+	}
 }
 
 func (v *nullableInt64Vector) Append(i interface{}) {
@@ -494,6 +665,19 @@ func (v *nullableInt64Vector) Extend(i int) {
 	(*v) = append((*v), make([]*int64, i)...)
 }
 
+func (v *nullableInt64Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Float32erate float32ny -in=$GOFILE -out=nullable_vector.Float32.go float32 "Float32=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableFloat32Vector []*float32
@@ -504,7 +688,17 @@ func newNullableFloat32Vector(n int) *nullableFloat32Vector {
 }
 
 func (v *nullableFloat32Vector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*float32)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case float32:
+		val := i.(float32)
+		(*v)[idx] = &val
+	case *float32:
+		(*v)[idx] = i.(*float32)
+	}
 }
 
 func (v *nullableFloat32Vector) Append(i interface{}) {
@@ -555,6 +749,19 @@ func (v *nullableFloat32Vector) Extend(i int) {
 	(*v) = append((*v), make([]*float32, i)...)
 }
 
+func (v *nullableFloat32Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Float64erate float64ny -in=$GOFILE -out=nullable_vector.Float64.go float64 "Float64=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableFloat64Vector []*float64
@@ -565,7 +772,17 @@ func newNullableFloat64Vector(n int) *nullableFloat64Vector {
 }
 
 func (v *nullableFloat64Vector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*float64)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case float64:
+		val := i.(float64)
+		(*v)[idx] = &val
+	case *float64:
+		(*v)[idx] = i.(*float64)
+	}
 }
 
 func (v *nullableFloat64Vector) Append(i interface{}) {
@@ -616,6 +833,19 @@ func (v *nullableFloat64Vector) Extend(i int) {
 	(*v) = append((*v), make([]*float64, i)...)
 }
 
+func (v *nullableFloat64Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Stringerate stringny -in=$GOFILE -out=nullable_vector.String.go string "String=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableStringVector []*string
@@ -626,7 +856,17 @@ func newNullableStringVector(n int) *nullableStringVector {
 }
 
 func (v *nullableStringVector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*string)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case string:
+		val := i.(string)
+		(*v)[idx] = &val
+	case *string:
+		(*v)[idx] = i.(*string)
+	}
 }
 
 func (v *nullableStringVector) Append(i interface{}) {
@@ -677,6 +917,19 @@ func (v *nullableStringVector) Extend(i int) {
 	(*v) = append((*v), make([]*string, i)...)
 }
 
+func (v *nullableStringVector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Boolerate boolny -in=$GOFILE -out=nullable_vector.Bool.go bool "Bool=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableBoolVector []*bool
@@ -687,7 +940,17 @@ func newNullableBoolVector(n int) *nullableBoolVector {
 }
 
 func (v *nullableBoolVector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*bool)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case bool:
+		val := i.(bool)
+		(*v)[idx] = &val
+	case *bool:
+		(*v)[idx] = i.(*bool)
+	}
 }
 
 func (v *nullableBoolVector) Append(i interface{}) {
@@ -738,6 +1001,19 @@ func (v *nullableBoolVector) Extend(i int) {
 	(*v) = append((*v), make([]*bool, i)...)
 }
 
+func (v *nullableBoolVector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:TimeTimeerate timeTimeny -in=$GOFILE -out=nullable_vector.TimeTime.go time.Time "TimeTime=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type nullableTimeTimeVector []*time.Time
@@ -748,7 +1024,17 @@ func newNullableTimeTimeVector(n int) *nullableTimeTimeVector {
 }
 
 func (v *nullableTimeTimeVector) Set(idx int, i interface{}) {
-	(*v)[idx] = i.(*time.Time)
+	if i == nil {
+		(*v)[idx] = nil
+		return
+	}
+	switch i.(type) {
+	case time.Time:
+		val := i.(time.Time)
+		(*v)[idx] = &val
+	case *time.Time:
+		(*v)[idx] = i.(*time.Time)
+	}
 }
 
 func (v *nullableTimeTimeVector) Append(i interface{}) {
@@ -797,4 +1083,17 @@ func (v *nullableTimeTimeVector) Type() FieldType {
 
 func (v *nullableTimeTimeVector) Extend(i int) {
 	(*v) = append((*v), make([]*time.Time, i)...)
+}
+
+func (v *nullableTimeTimeVector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
 }

--- a/data/nullable_vector.gen.go
+++ b/data/nullable_vector.gen.go
@@ -82,10 +82,7 @@ func (v *nullableUint8Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -166,10 +163,7 @@ func (v *nullableUint16Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -250,10 +244,7 @@ func (v *nullableUint32Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -334,10 +325,7 @@ func (v *nullableUint64Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -418,10 +406,7 @@ func (v *nullableInt8Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -502,10 +487,7 @@ func (v *nullableInt16Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -586,10 +568,7 @@ func (v *nullableInt32Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -670,10 +649,7 @@ func (v *nullableInt64Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -754,10 +730,7 @@ func (v *nullableFloat32Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -838,10 +811,7 @@ func (v *nullableFloat64Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -922,10 +892,7 @@ func (v *nullableStringVector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -1006,10 +973,7 @@ func (v *nullableBoolVector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -1090,10 +1054,7 @@ func (v *nullableTimeTimeVector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }

--- a/data/time_series_test.go
+++ b/data/time_series_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana/pkg/components/null"
 	"github.com/stretchr/testify/require"
 )
 
@@ -827,7 +826,7 @@ func TestFillMissing(t *testing.T) {
 			name: "Long frame; fill previous",
 			fillMissing: data.FillMissing{
 				Enabled:  true,
-				Mode:     data.FILL_MODE_PREVIOUS,
+				Mode:     data.FillModePrevious,
 				Interval: 5 * time.Second,
 			},
 			frame: data.NewFrame("long_test",
@@ -894,8 +893,8 @@ func TestFillMissing(t *testing.T) {
 			name: "Long frame; fill value",
 			fillMissing: data.FillMissing{
 				Enabled:  true,
-				Mode:     data.FILL_MODE_VALUE,
-				Value:    null.NewFloat(-1, true),
+				Mode:     data.FillModeValue,
+				Value:    -1,
 				Interval: 5 * time.Second,
 			},
 			frame: data.NewFrame("long_test",
@@ -961,7 +960,7 @@ func TestFillMissing(t *testing.T) {
 			name: "Wide frame; fill previous",
 			fillMissing: data.FillMissing{
 				Enabled:  true,
-				Mode:     data.FILL_MODE_PREVIOUS,
+				Mode:     data.FillModePrevious,
 				Interval: 5 * time.Second,
 			},
 			frame: data.NewFrame("wide_test",
@@ -1041,8 +1040,8 @@ func TestFillMissing(t *testing.T) {
 			name: "Wide frame; fill value",
 			fillMissing: data.FillMissing{
 				Enabled:  true,
-				Mode:     data.FILL_MODE_VALUE,
-				Value:    null.NewFloat(-1, true),
+				Mode:     data.FillModeValue,
+				Value:    -1,
 				Interval: 5 * time.Second,
 			},
 			frame: data.NewFrame("wide_test",
@@ -1131,6 +1130,7 @@ func TestFillMissing(t *testing.T) {
 		})
 	}
 }
+
 func TestFillMissingNullable(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -1143,7 +1143,7 @@ func TestFillMissingNullable(t *testing.T) {
 			name: "Long frame; fill null",
 			fillMissing: data.FillMissing{
 				Enabled:  true,
-				Mode:     data.FILL_MODE_NULL,
+				Mode:     data.FillModeNull,
 				Interval: 5 * time.Second,
 			},
 			frame: data.NewFrame("long_test",
@@ -1210,7 +1210,7 @@ func TestFillMissingNullable(t *testing.T) {
 			name: "Long frame; fill previous",
 			fillMissing: data.FillMissing{
 				Enabled:  true,
-				Mode:     data.FILL_MODE_PREVIOUS,
+				Mode:     data.FillModePrevious,
 				Interval: 5 * time.Second,
 			},
 			frame: data.NewFrame("long_test",
@@ -1276,8 +1276,8 @@ func TestFillMissingNullable(t *testing.T) {
 			name: "Long frame; fill value",
 			fillMissing: data.FillMissing{
 				Enabled:  true,
-				Mode:     data.FILL_MODE_VALUE,
-				Value:    null.NewFloat(-1, true),
+				Mode:     data.FillModeValue,
+				Value:    -1,
 				Interval: 5 * time.Second,
 			},
 			frame: data.NewFrame("long_test",
@@ -1343,7 +1343,7 @@ func TestFillMissingNullable(t *testing.T) {
 			name: "Wide frame; fill null",
 			fillMissing: data.FillMissing{
 				Enabled:  true,
-				Mode:     data.FILL_MODE_NULL,
+				Mode:     data.FillModeNull,
 				Interval: 5 * time.Second,
 			},
 			frame: data.NewFrame("wide_test",
@@ -1423,7 +1423,7 @@ func TestFillMissingNullable(t *testing.T) {
 			name: "Wide frame; fill previous",
 			fillMissing: data.FillMissing{
 				Enabled:  true,
-				Mode:     data.FILL_MODE_PREVIOUS,
+				Mode:     data.FillModePrevious,
 				Interval: 5 * time.Second,
 			},
 			frame: data.NewFrame("wide_test",
@@ -1503,8 +1503,8 @@ func TestFillMissingNullable(t *testing.T) {
 			name: "Wide frame; fill value",
 			fillMissing: data.FillMissing{
 				Enabled:  true,
-				Mode:     data.FILL_MODE_VALUE,
-				Value:    null.NewFloat(-1, true),
+				Mode:     data.FillModeValue,
+				Value:    -1,
 				Interval: 5 * time.Second,
 			},
 			frame: data.NewFrame("wide_test",

--- a/data/vector.gen.go
+++ b/data/vector.gen.go
@@ -53,6 +53,19 @@ func (v *uint8Vector) Extend(i int) {
 	(*v) = append((*v), make([]uint8, i)...)
 }
 
+func (v *uint8Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Uint16erate uint16ny -in=$GOFILE -out=vector.Uint16.go uint16 "Uint16=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type uint16Vector []uint16
@@ -98,6 +111,19 @@ func (v *uint16Vector) Type() FieldType {
 
 func (v *uint16Vector) Extend(i int) {
 	(*v) = append((*v), make([]uint16, i)...)
+}
+
+func (v *uint16Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
 }
 
 //go:Uint32erate uint32ny -in=$GOFILE -out=vector.Uint32.go uint32 "Uint32=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
@@ -147,6 +173,19 @@ func (v *uint32Vector) Extend(i int) {
 	(*v) = append((*v), make([]uint32, i)...)
 }
 
+func (v *uint32Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Uint64erate uint64ny -in=$GOFILE -out=vector.Uint64.go uint64 "Uint64=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type uint64Vector []uint64
@@ -192,6 +231,19 @@ func (v *uint64Vector) Type() FieldType {
 
 func (v *uint64Vector) Extend(i int) {
 	(*v) = append((*v), make([]uint64, i)...)
+}
+
+func (v *uint64Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
 }
 
 //go:Int8erate int8ny -in=$GOFILE -out=vector.Int8.go int8 "Int8=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
@@ -241,6 +293,19 @@ func (v *int8Vector) Extend(i int) {
 	(*v) = append((*v), make([]int8, i)...)
 }
 
+func (v *int8Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Int16erate int16ny -in=$GOFILE -out=vector.Int16.go int16 "Int16=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type int16Vector []int16
@@ -286,6 +351,19 @@ func (v *int16Vector) Type() FieldType {
 
 func (v *int16Vector) Extend(i int) {
 	(*v) = append((*v), make([]int16, i)...)
+}
+
+func (v *int16Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
 }
 
 //go:Int32erate int32ny -in=$GOFILE -out=vector.Int32.go int32 "Int32=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
@@ -335,6 +413,19 @@ func (v *int32Vector) Extend(i int) {
 	(*v) = append((*v), make([]int32, i)...)
 }
 
+func (v *int32Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Int64erate int64ny -in=$GOFILE -out=vector.Int64.go int64 "Int64=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type int64Vector []int64
@@ -380,6 +471,19 @@ func (v *int64Vector) Type() FieldType {
 
 func (v *int64Vector) Extend(i int) {
 	(*v) = append((*v), make([]int64, i)...)
+}
+
+func (v *int64Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
 }
 
 //go:Float32erate float32ny -in=$GOFILE -out=vector.Float32.go float32 "Float32=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
@@ -429,6 +533,19 @@ func (v *float32Vector) Extend(i int) {
 	(*v) = append((*v), make([]float32, i)...)
 }
 
+func (v *float32Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Float64erate float64ny -in=$GOFILE -out=vector.Float64.go float64 "Float64=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type float64Vector []float64
@@ -474,6 +591,19 @@ func (v *float64Vector) Type() FieldType {
 
 func (v *float64Vector) Extend(i int) {
 	(*v) = append((*v), make([]float64, i)...)
+}
+
+func (v *float64Vector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
 }
 
 //go:Stringerate stringny -in=$GOFILE -out=vector.String.go string "String=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
@@ -523,6 +653,19 @@ func (v *stringVector) Extend(i int) {
 	(*v) = append((*v), make([]string, i)...)
 }
 
+func (v *stringVector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:Boolerate boolny -in=$GOFILE -out=vector.Bool.go bool "Bool=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type boolVector []bool
@@ -570,6 +713,19 @@ func (v *boolVector) Extend(i int) {
 	(*v) = append((*v), make([]bool, i)...)
 }
 
+func (v *boolVector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
+}
+
 //go:TimeTimeerate timeTimeny -in=$GOFILE -out=vector.TimeTime.go time.Time "TimeTime=uint8,uint16,uint32,uint64,int8,int16,int32,int64,float32,float64,string,bool,time.Time"
 
 type timeTimeVector []time.Time
@@ -615,4 +771,17 @@ func (v *timeTimeVector) Type() FieldType {
 
 func (v *timeTimeVector) Extend(i int) {
 	(*v) = append((*v), make([]time.Time, i)...)
+}
+
+func (v *timeTimeVector) InsertAt(i int, val interface{}) {
+	if v.Len() < i {
+		v.Append(val)
+	} else {
+		v.Extend(1)
+		for j := v.Len() - 1; j > i; j-- {
+			previousVal, _ := v.ConcreteAt(j - 1)
+			v.Set(j, previousVal)
+		}
+		v.Set(i, val)
+	}
 }

--- a/data/vector.gen.go
+++ b/data/vector.gen.go
@@ -58,10 +58,7 @@ func (v *uint8Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -118,10 +115,7 @@ func (v *uint16Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -178,10 +172,7 @@ func (v *uint32Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -238,10 +229,7 @@ func (v *uint64Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -298,10 +286,7 @@ func (v *int8Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -358,10 +343,7 @@ func (v *int16Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -418,10 +400,7 @@ func (v *int32Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -478,10 +457,7 @@ func (v *int64Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -538,10 +514,7 @@ func (v *float32Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -598,10 +571,7 @@ func (v *float64Vector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -658,10 +628,7 @@ func (v *stringVector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -718,10 +685,7 @@ func (v *boolVector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }
@@ -778,10 +742,7 @@ func (v *timeTimeVector) InsertAt(i int, val interface{}) {
 		v.Append(val)
 	} else {
 		v.Extend(1)
-		for j := v.Len() - 1; j > i; j-- {
-			previousVal, _ := v.ConcreteAt(j - 1)
-			v.Set(j, previousVal)
-		}
+		copy((*v)[i+1:], (*v)[i:])
 		v.Set(i, val)
 	}
 }

--- a/data/vector.go
+++ b/data/vector.go
@@ -16,6 +16,7 @@ type vector interface {
 	PointerAt(i int) interface{}
 	CopyAt(i int) interface{}
 	ConcreteAt(i int) (val interface{}, ok bool)
+	InsertAt(i int, v interface{})
 }
 
 func newVector(t interface{}, n int) (v vector) {


### PR DESCRIPTION
Fixes #102 

I have introduced a new `(* Frame).FillMissing` method instead of changing the `LongToWide` and `WideToLong`.