### PR TITLE
DataResponse >> QueryResponse

### DIFF
--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -97,14 +97,14 @@ func (f convertFromProtobuf) QueryDataResponse(protoRes *pluginv2.QueryDataRespo
 		if err != nil {
 			return nil, err
 		}
-		dr := DataResponse{
+		qr := QueryResponse{
 			Frames: frames,
 			Meta:   res.JsonMeta,
 		}
 		if res.Error != "" {
-			dr.Error = errors.New(res.Error)
+			qr.Error = errors.New(res.Error)
 		}
-		qdr.Responses[rIdx] = &dr
+		qdr.Responses[rIdx] = &qr
 	}
 	return &qdr, nil
 }

--- a/backend/data.go
+++ b/backend/data.go
@@ -63,12 +63,12 @@ func NewQueryDataResponse(size int) QueryDataResponse {
 }
 
 // Responses is a map of RefIDs (Unique Query ID) to *DataResponse.
-type Responses map[string]*DataResponse
+type Responses map[string]*QueryResponse
 
-// DataResponse contains the results from a DataQuery.
+// QueryResponse contains the results from a single DataQuery.
 // A map of RefIDs (unique query identifers) to this type makes up the Responses property of a QueryDataResponse.
 // The Error property is used to allow for partial success responses from the containing QueryDataResponse.
-type DataResponse struct {
+type QueryResponse struct {
 	// The data returned from the Query. Each Frame repeats the RefID.
 	Frames data.Frames
 


### PR DESCRIPTION
Having a single query return a DataResponse is werid.   can it be a query response?

This just changes the SDK side, but this should likely also change in the protobuf