### PR TITLE
backend: fix panic in convertToProtobuf QueryDataResponse

### DIFF
--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -120,7 +120,7 @@ func (t convertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.
 			JsonMeta: dr.Meta,
 		}
 		if dr.Error != nil {
-			pDR.Error = err.Error()
+			pDR.Error = dr.Error.Error()
 		}
 		pQDR.Responses[refID] = &pDR
 	}


### PR DESCRIPTION
Typo resulted in panic when dataresponse had an error.