### PR TITLE
Mage: add warning when executable is not defined

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -49,11 +49,12 @@ func getExecutableFromPluginJSON() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	executable, ok := result["executable"]
-	if !ok {
+	executable := result["executable"]
+	name, ok := executable.(string)
+	if !ok || name == "" {
 		return "", fmt.Errorf("plugin.json is missing an executable name")
 	}
-	return executable.(string), nil
+	return name, nil
 }
 
 func findRunningPIDs(exe string) []int {

--- a/build/common.go
+++ b/build/common.go
@@ -49,7 +49,11 @@ func getExecutableFromPluginJSON() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return result["executable"].(string), nil
+	executable, ok := result["executable"]
+	if !ok {
+		return "", fmt.Errorf("plugin.json is missing an executable name")
+	}
+	return executable.(string), nil
 }
 
 func findRunningPIDs(exe string) []int {


### PR DESCRIPTION
banged my head for a long time while working on a plugin that did not have the executable defined 🤦 