### PR TITLE
Explicit endpoints over nested PluginConfig fields

### DIFF
--- a/proto/backend.proto
+++ b/proto/backend.proto
@@ -9,7 +9,7 @@ option go_package = ".;pluginv2";
 
 message DataSourceConfig {
   int64 id = 1;
-  int64 orgId;
+  int64 orgId = 1;
   string name = 2;
   string url = 3;
   string user = 4;
@@ -84,7 +84,7 @@ message CallResourceResponse {
 
 service Data {
   rpc QueryData(QueryDataRequest) returns (QueryDataResponse);
-  rpc CheckDatasourceHealth(CheckDatasourceHealthRequest) returns (CheckHealthResponse);
+  rpc CheckHealth(CheckDatasourceHealthRequest) returns (CheckHealthResponse);
   rpc CallResource(CallDatasourceResourceRequest) returns (stream CallResourceResponse);
 }
 
@@ -104,6 +104,7 @@ message DataQuery {
 message CallDatasourceResourceRequest {
   DatasourceConfig config = 1;
   ResourceRequest resource = 2;
+  User user = 3;
 }
 
 message CheckDatasourceHealthRequest {
@@ -171,19 +172,21 @@ Message TestAlertNotifierResponse {}
 
 service AnnotationStorage {
   rpc SaveAnnotation(SaveAnnotationRequest) return (SaveAnnotationResponse);
-  rpc CheckAnnotationHealth(CheckAnnotationHealthRequest) return (CheckAnnotationHealthResponse);
+  rpc CheckHealth(CheckAnnotationHealthRequest) return (CheckAnnotationHealthResponse);
   rpc CallResource(CallAnnotationResourceRequest) returns (stream CallResourceResponse);
 }
 
 message CallAnnotationResourceRequest {
   AnnotationConfig config = 1;
   ResourceRequest resource = 2;
+  User user = 3;
 }
 
 message AnnotationConfig {}
 
 message SaveAnnotationRequest {
   AnnotationConfig config = 1;
+  User user = 2;
 }
 
 message SaveAnnotationResponse {}

--- a/proto/backend.proto
+++ b/proto/backend.proto
@@ -60,6 +60,10 @@ message StringList {
 
 message CallResourceRequest {
   AppConfig config = 1;
+  ResourceRequest resource = 2;
+}
+
+message ResourceRequest {
   User user = 2;
   string path = 3;
   string method = 4;
@@ -97,7 +101,10 @@ message DataQuery {
   bytes json = 5;
 }
 
-message CallDatasourceResourceRequest {}
+message CallDatasourceResourceRequest {
+  DatasourceConfig config = 1;
+  ResourceRequest resource = 2;
+}
 
 message CheckDatasourceHealthRequest {
   DataSourceConfig config = 1;
@@ -141,7 +148,10 @@ service AlertNotifier {
   rpc CallResource(CallAlertNotifierResourceRequest) returns (stream CallResourceResponse);
 }
 
-message CallAlertNotifierResourceRequest {}
+message CallAlertNotifierResourceRequest {
+  AlertNotifierConfig config = 1;
+  ResourceRequest resource = 2;
+}
 
 message AlertNotifierConfig {}
 
@@ -165,7 +175,10 @@ service AnnotationStorage {
   rpc CallResource(CallAnnotationResourceRequest) returns (stream CallResourceResponse);
 }
 
-message CallAnnotationResourceRequest {}
+message CallAnnotationResourceRequest {
+  AnnotationConfig config = 1;
+  ResourceRequest resource = 2;
+}
 
 message AnnotationConfig {}
 

--- a/proto/backend.proto
+++ b/proto/backend.proto
@@ -191,10 +191,10 @@ message SaveAnnotationResponse {}
 message CheckAnnotationHealthRequest {}
 
 //-----------------------------------------------
-// Diagnostics
+// CorePlugin
 //-----------------------------------------------
 
-service Diagnostics {
+service CorePlugin {
   rpc CheckHealth(CheckHealthRequest) returns (CheckHealthResponse);
   rpc CollectMetrics(CollectMetricsRequest) returns (CollectMetricsResponse);
 }

--- a/proto/backend.proto
+++ b/proto/backend.proto
@@ -9,6 +9,7 @@ option go_package = ".;pluginv2";
 
 message DataSourceConfig {
   int64 id = 1;
+  int64 orgId;
   string name = 2;
   string url = 3;
   string user = 4;
@@ -24,7 +25,7 @@ message DataSourceConfig {
   int64 lastUpdatedMS = 10;
 }
 
-message PluginConfig {
+message AppConfig {
   int64 orgId = 1;
   string pluginId = 2;
   
@@ -49,7 +50,7 @@ message User {
 // Resource service enables HTTP-style requests over gRPC.
 //---------------------------------------------------------
 
-service Resource {
+service App {
   rpc CallResource(CallResourceRequest) returns (stream CallResourceResponse);
 }
 
@@ -58,7 +59,7 @@ message StringList {
 }
 
 message CallResourceRequest {
-  PluginConfig config = 1;
+  AppConfig config = 1;
   User user = 2;
   string path = 3;
   string method = 4;
@@ -79,6 +80,8 @@ message CallResourceResponse {
 
 service Data {
   rpc QueryData(QueryDataRequest) returns (QueryDataResponse);
+  rpc CheckDatasourceHealth(CheckDatasourceHealthRequest) returns (CheckHealthResponse);
+  rpc CallResource(CallDatasourceResourceRequest) returns (stream CallResourceResponse);
 }
 
 message TimeRange {
@@ -94,10 +97,16 @@ message DataQuery {
   bytes json = 5;
 }
 
+message CallDatasourceResourceRequest {}
+
+message CheckDatasourceHealthRequest {
+  DataSourceConfig config = 1;
+}
+
 // QueryDataRequest
 message QueryDataRequest {
   // Plugin Configuration
-  PluginConfig config = 1;
+  DataSourceConfig config = 1;
 
   //Info about the user who calls the plugin.
   User user = 2;
@@ -122,6 +131,52 @@ message DataResponse {
   bytes jsonMeta = 3; // Warning: Current ignored by frontend. Would be for metadata about the query.
 }
 
+//----------------------------------------------- 
+// Alert notfier
+//----------------------------------------------- 
+
+service AlertNotifier {
+  rpc SendAlertNotification(SendAlertNotificationRequest) return (SendAlertNotificationResponse);
+  rpc TestAlertNotifier(TestAlertNotifierRequest) return (TestAlertNotifierResponse);
+  rpc CallResource(CallAlertNotifierResourceRequest) returns (stream CallResourceResponse);
+}
+
+message CallAlertNotifierResourceRequest {}
+
+message AlertNotifierConfig {}
+
+message SendAlertNotificationRequest {
+  AlertNotifierConfig config = 1;
+}
+
+message SendAlertNotificationResponse {
+}
+
+message TestAlertNotifierRequest {}
+Message TestAlertNotifierResponse {}
+
+//----------------------------------------------- 
+// Annotation storage
+//----------------------------------------------- 
+
+service AnnotationStorage {
+  rpc SaveAnnotation(SaveAnnotationRequest) return (SaveAnnotationResponse);
+  rpc CheckAnnotationHealth(CheckAnnotationHealthRequest) return (CheckAnnotationHealthResponse);
+  rpc CallResource(CallAnnotationResourceRequest) returns (stream CallResourceResponse);
+}
+
+message CallAnnotationResourceRequest {}
+
+message AnnotationConfig {}
+
+message SaveAnnotationRequest {
+  AnnotationConfig config = 1;
+}
+
+message SaveAnnotationResponse {}
+
+message CheckAnnotationHealthRequest {}
+
 //-----------------------------------------------
 // Diagnostics
 //-----------------------------------------------
@@ -142,9 +197,7 @@ message CollectMetricsResponse {
   Payload metrics = 1;
 }
 
-message CheckHealthRequest {
-  PluginConfig config = 1;
-}
+message CheckHealthRequest {}
 
 message CheckHealthResponse {
   enum HealthStatus {


### PR DESCRIPTION
I just had to share this... 

Alertnotifier and Annotation Storage are just examples of how it would look once we implement more types. I dont think this is the perfect solution but this solution favors being explicit over message reuse. Which I like.

To me, this makes it more clear what each endpoint is expected to do and what endpoint the grafana-server should call. We could definitely solve this in the SDK but that creates a difference for how plugins are called and what they end up acting on. Which I find confusing. I want plugins
to be an extension of Grafana, not an external integration or a redesign of how datasources are implemented.

So what do we do with all this? I'm not sure... Do we like it? Can we make some changes in this direction?