### PR TITLE
backend: remove size argument from NewQueryDataResponse

### DIFF
--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -94,7 +94,7 @@ func (f convertFromProtobuf) QueryDataResponse(protoRes *pluginv2.QueryDataRespo
 	qdr := &QueryDataResponse{
 		Responses: make(Responses, len(protoRes.Responses)),
 	}
-	for rIdx, res := range protoRes.Responses {
+	for refID, res := range protoRes.Responses {
 		frames, err := data.UnmarshalArrowFrames(res.Frames)
 		if err != nil {
 			return nil, err
@@ -106,7 +106,7 @@ func (f convertFromProtobuf) QueryDataResponse(protoRes *pluginv2.QueryDataRespo
 		if res.Error != "" {
 			dr.Error = errors.New(res.Error)
 		}
-		qdr.Responses[rIdx] = &dr
+		qdr.Responses[refID] = dr
 	}
 	return qdr, nil
 }

--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -91,7 +91,9 @@ func (f convertFromProtobuf) QueryDataRequest(protoReq *pluginv2.QueryDataReques
 }
 
 func (f convertFromProtobuf) QueryDataResponse(protoRes *pluginv2.QueryDataResponse) (*QueryDataResponse, error) {
-	qdr := NewQueryDataResponse(len(protoRes.Responses))
+	qdr := &QueryDataResponse{
+		Responses: make(Responses, len(protoRes.Responses)),
+	}
 	for rIdx, res := range protoRes.Responses {
 		frames, err := data.UnmarshalArrowFrames(res.Frames)
 		if err != nil {

--- a/backend/data.go
+++ b/backend/data.go
@@ -61,7 +61,7 @@ func NewQueryDataResponse() *QueryDataResponse {
 	}
 }
 
-// Responses is a map of RefIDs (Unique Query ID) to *DataResponse.
+// Responses is a map of RefIDs (Unique Query ID) to DataResponses.
 type Responses map[string]DataResponse
 
 // DataResponse contains the results from a DataQuery.

--- a/backend/data.go
+++ b/backend/data.go
@@ -62,7 +62,7 @@ func NewQueryDataResponse() *QueryDataResponse {
 }
 
 // Responses is a map of RefIDs (Unique Query ID) to *DataResponse.
-type Responses map[string]*DataResponse
+type Responses map[string]DataResponse
 
 // DataResponse contains the results from a DataQuery.
 // A map of RefIDs (unique query identifers) to this type makes up the Responses property of a QueryDataResponse.

--- a/backend/data.go
+++ b/backend/data.go
@@ -54,11 +54,10 @@ type QueryDataResponse struct {
 	Responses Responses
 }
 
-// NewQueryDataResponse returns a QueryDataResponse with the Responses property
-// initialized to size.
-func NewQueryDataResponse(size int) *QueryDataResponse {
+// NewQueryDataResponse returns a QueryDataResponse with the Responses property initialized.
+func NewQueryDataResponse() *QueryDataResponse {
 	return &QueryDataResponse{
-		Responses: make(Responses, size),
+		Responses: make(Responses),
 	}
 }
 


### PR DESCRIPTION
**Remove size argument:**

I just keep doing:

`result := backend.NewQueryDataResponse(0)`

So I regret this.  I doubt sizing the map to query length really matters. If one really cares, they can still make the object and size it (as we done in the protobuf conversion of this PR).

**DataResponse not a pointer:**

I don't see a reason to have this as a pointer. I don't think we want to have meaning for a entry in Responses that has a nil value.

In terms of being able to return `nil` from functions, that isn't the pattern here. DataResponse has an Error property, so one returns a `DataResponse` regardless, even in the case of an error (for case some queries successful, others not). The members are just an error and 2 slices, so the object should not be expensive to pass around as a non-pointer. If we add properties, I would guess they would be slices, or optional (pointers).

So end up doing things like `dr = &backend.DataResponse{}` for no reason instead of just `dr = backend.DataResponse{}`

In this named return context it is silly:

```
func (gs *GoogleSheets) Query(ctx context.Context, refID st....) (dr *backend.DataResponse) {
	dr = &backend.DataResponse{}
```

(If we decide we like one and not the other, I can make different PR/Commits).