### PR TITLE
remove meta from DataResponse

### DIFF
--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -101,7 +101,6 @@ func (f convertFromProtobuf) QueryDataResponse(protoRes *pluginv2.QueryDataRespo
 		}
 		dr := DataResponse{
 			Frames: frames,
-			//	Meta:   res.JsonMeta,
 		}
 		if res.Error != "" {
 			dr.Error = errors.New(res.Error)

--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -101,7 +101,7 @@ func (f convertFromProtobuf) QueryDataResponse(protoRes *pluginv2.QueryDataRespo
 		}
 		dr := DataResponse{
 			Frames: frames,
-			Meta:   res.JsonMeta,
+			//	Meta:   res.JsonMeta,
 		}
 		if res.Error != "" {
 			dr.Error = errors.New(res.Error)

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -116,8 +116,8 @@ func (t convertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.
 			return nil, err
 		}
 		pDR := pluginv2.DataResponse{
-			Frames:   encodedFrames,
-			JsonMeta: dr.Meta,
+			Frames: encodedFrames,
+			//		JsonMeta: dr.Meta,
 		}
 		if dr.Error != nil {
 			pDR.Error = dr.Error.Error()

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -117,7 +117,6 @@ func (t convertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.
 		}
 		pDR := pluginv2.DataResponse{
 			Frames: encodedFrames,
-			//		JsonMeta: dr.Meta,
 		}
 		if dr.Error != nil {
 			pDR.Error = dr.Error.Error()

--- a/backend/data.go
+++ b/backend/data.go
@@ -71,8 +71,8 @@ type DataResponse struct {
 	// The data returned from the Query. Each Frame repeats the RefID.
 	Frames data.Frames
 
-	// Meta contains a custom JSON object for custom response metadata about the query. WARNING: Currently ignored by front end of Grafana.
-	Meta json.RawMessage
+	// // Meta contains a custom JSON object for custom response metadata about the query. WARNING: Currently ignored by front end of Grafana.
+	// Meta json.RawMessage
 
 	// Error is a property to be set if the the corresponding DataQuery has an error.
 	Error error

--- a/backend/data.go
+++ b/backend/data.go
@@ -71,9 +71,6 @@ type DataResponse struct {
 	// The data returned from the Query. Each Frame repeats the RefID.
 	Frames data.Frames
 
-	// // Meta contains a custom JSON object for custom response metadata about the query. WARNING: Currently ignored by front end of Grafana.
-	// Meta json.RawMessage
-
 	// Error is a property to be set if the the corresponding DataQuery has an error.
 	Error error
 }


### PR DESCRIPTION
we added a metadata object to DataResponse -- this makes sense, but it does not (yet) have anywhere to go on the frontend.

I am reluctant to add it now knowing that it does not do anything.  When we do want it (soon) it should likely be something other than `Meta json.RawMessage`