### PR TITLE
data: remove Frame.String() method

### DIFF
--- a/data/conversion_input_test.go
+++ b/data/conversion_input_test.go
@@ -105,7 +105,9 @@ func ExampleNewFrameInputConverter() {
 	}
 	convBuilder.Frame.Name = "Converted"
 
-	fmt.Println(convBuilder.Frame.String())
+	st, _ := convBuilder.Frame.StringTable(-1, -1)
+	fmt.Println(st)
+
 	// Output:
 	// Name: Converted
 	// Dimensions: 3 Fields by 3 Rows

--- a/data/frame.go
+++ b/data/frame.go
@@ -347,20 +347,12 @@ func FrameTestCompareOptions() []cmp.Option {
 	return []cmp.Option{f32s, f32Ptrs, f64s, f64Ptrs, confFloats, unexportedField, cmpopts.EquateEmpty()}
 }
 
-func (f *Frame) String() string {
-	s, err := f.StringTable(10, 10)
-	if err != nil {
-		return err.Error()
-	}
-	return s
-}
-
 // StringTable prints a human readable table of the Frame.
-// The table's width is limited to maxFields and the length is limited to maxRows.
+// The table's width is limited to maxFields and the length is limited to maxRows (a value of -1 is unlimited).
 // If the width or length is excceded then last column or row displays "..." as the contents.
 func (f *Frame) StringTable(maxFields, maxRows int) (string, error) {
-	if maxFields < 2 {
-		return "", fmt.Errorf("maxWidth than 2")
+	if maxFields > 0 && maxFields < 2 {
+		return "", fmt.Errorf("maxFields must be less than 0 (unlimited) or greather than 2, got %v", maxFields)
 	}
 
 	rowLen, err := f.RowLen()
@@ -370,14 +362,14 @@ func (f *Frame) StringTable(maxFields, maxRows int) (string, error) {
 
 	// calculate output column width (fields)
 	width := len(f.Fields)
-	exceedsWidth := width > maxFields
+	exceedsWidth := maxFields > 0 && width > maxFields
 	if exceedsWidth {
 		width = maxFields
 	}
 
 	// calculate output length (rows)
 	length := rowLen
-	exceedsLength := rowLen > maxRows
+	exceedsLength := maxRows >= 0 && rowLen > maxRows
 	if exceedsLength {
 		length = maxRows + 1
 	}

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -34,7 +34,8 @@ func ExampleNewFrame() {
 		data.NewField("Temp", data.Labels{"place": "Ecuador"}, []float64{1, math.NaN()}),
 		data.NewField("Count", data.Labels{"place": "Ecuador"}, []*int64{&anInt64, nil}),
 	)
-	fmt.Println(frame.String())
+	st, _ := frame.StringTable(-1, -1)
+	fmt.Println(st)
 	// Output:
 	// Name: Frame Name
 	// Dimensions: 3 Fields by 2 Rows
@@ -116,7 +117,8 @@ func ExampleFrame_tSDBTimeSeriesDifferentTimeIndices() {
 	}
 
 	for _, frame := range frames {
-		fmt.Println(frame.String())
+		st, _ := frame.StringTable(-1, -1)
+		fmt.Println(st)
 	}
 	// Output:
 	// Name: cpu
@@ -194,7 +196,8 @@ func ExampleFrame_tSDBTimeSeriesSharedTimeIndex() {
 		}
 	}
 
-	fmt.Println(frame.String())
+	st, _ := frame.StringTable(-1, -1)
+	fmt.Println(st)
 	// Output:
 	// Name: Wide
 	// Dimensions: 3 Fields by 2 Rows
@@ -248,10 +251,12 @@ func ExampleFrame_tableLikeLongTimeSeries() {
 	for _, row := range myLongTable.Rows {
 		frame.AppendRow(row...)
 	}
-	fmt.Println(frame.String())
+	st, _ := frame.StringTable(-1, -1)
+	fmt.Println(st)
 	w, _ := data.LongToWide(frame, nil)
 	w.Name = "Wide"
-	fmt.Println(w.String())
+	st, _ = w.StringTable(-1, -1)
+	fmt.Println(st)
 	// Output:
 	// Name: Long
 	// Dimensions: 4 Fields by 4 Rows

--- a/data/sqlutil/sql_test.go
+++ b/data/sqlutil/sql_test.go
@@ -42,7 +42,8 @@ func ExampleReplace() {
 	frame := data.NewFrame("Before",
 		data.NewField("string", nil, []*string{getString(), getString()}))
 
-	fmt.Println(frame.String()) // Before
+	st, _ := frame.StringTable(-1, -1)
+	fmt.Println(st)
 
 	intReplacer := &sqlutil.StringFieldReplacer{
 		OutputFieldType: data.FieldTypeNullableInt64,
@@ -64,7 +65,8 @@ func ExampleReplace() {
 	}
 
 	frame.Name = "After"
-	fmt.Println(frame.String()) // After
+	st, _ = frame.StringTable(-1, -1)
+	fmt.Println(st) // After
 	// Output:
 	// Name: Before
 	// Dimensions: 1 Fields by 2 Rows


### PR DESCRIPTION
It messes up the diff output when testing.
Also it was just a shortcut for StringTable, so the functionality is still there.