### PR TITLE
backend: Set refId on Frame if refId == ""

### DIFF
--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -137,6 +137,11 @@ func (t ConvertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.
 		Responses: make(map[string]*pluginv2.DataResponse, len(res.Responses)),
 	}
 	for refID, dr := range res.Responses {
+		for _, f := range dr.Frames {
+			if f.RefID == "" {
+				f.RefID = refID
+			}
+		}
 		encodedFrames, err := dr.Frames.MarshalArrow()
 		if err != nil {
 			return nil, err

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -132,6 +132,8 @@ func (t ConvertToProtobuf) QueryDataRequest(req *QueryDataRequest) *pluginv2.Que
 }
 
 // QueryDataResponse converts the SDK version of a QueryDataResponse to the protobuf version.
+// It will set the RefID on the frames to the RefID key in Responses if a Frame's
+// RefId property is an empty string.
 func (t ConvertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.QueryDataResponse, error) {
 	pQDR := &pluginv2.QueryDataResponse{
 		Responses: make(map[string]*pluginv2.DataResponse, len(res.Responses)),

--- a/backend/data.go
+++ b/backend/data.go
@@ -14,6 +14,10 @@ type QueryDataHandler interface {
 	// req contains the queries []DataQuery (where each query contains RefID as a unique identifer).
 	// The QueryDataResponse contains a map of RefID to the response for each query, and each response
 	// contains Frames ([]*Frame).
+	//
+	// The Frames' RefID property, when it is an empty string, will be automatically set to
+	// the RefID in QueryDataResponse.Responses map. This is done before the QueryDataResponse is
+	// sent to Grafana. Therefore one does not need to be set that property on frames when using this method.
 	QueryData(ctx context.Context, req *QueryDataRequest) (*QueryDataResponse, error)
 }
 
@@ -59,6 +63,8 @@ func NewQueryDataResponse() *QueryDataResponse {
 }
 
 // Responses is a map of RefIDs (Unique Query ID) to DataResponses.
+// The QueryData method the QueryDataHandler method will set the RefId
+// property on the DataRespones' frames based on these RefIDs.
 type Responses map[string]DataResponse
 
 // DataResponse contains the results from a DataQuery.

--- a/data/frame.go
+++ b/data/frame.go
@@ -34,7 +34,7 @@ type Frame struct {
 	// All Fields must be of the same the length when marshalling the Frame for transmission.
 	Fields []*Field
 
-	// RefID is a property that can be set to match a Frame to its orginating query
+	// RefID is a property that can be set to match a Frame to its orginating query.
 	RefID string
 
 	// Meta is metadata about the Frame, and includes space for custom metadata.


### PR DESCRIPTION
Else people have to set in there plugin, and will forget, and kind of a silly line.

For example, our template:

```
// create data frame response
frame := data.NewFrame("response")
```

would need the addition of

```
frame.RefID = query.RefID
```