### PR TITLE
Document root and backend packages

### DIFF
--- a/backend/doc.go
+++ b/backend/doc.go
@@ -1,0 +1,2 @@
+// Package backend provides SDK handler interfaces and contracts for implementing and serving backend plugins.
+package backend

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,5 @@
+/*
+Package sdk is the root of the packages used to access Grafana Plugin SDK for Go.
+See https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go for a full list of sub-packages.
+*/
+package sdk // import "github.com/grafana/grafana-plugin-sdk-go"


### PR DESCRIPTION
Adds package documentation to the root should hopefully co-op better with the go-module is defined in the root.
Adds backend package documentation. Quite hard to describe that package.