### PR TITLE
Docs: Basic repository documentation/guides, security policy and issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Report a bug
+labels: 'bug'
+---
+
+<!--
+Please use this template while reporting a bug and provide as much info as possible.
+Questions should be posted to https://community.grafana.com
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- SDK version:
+- Grafana version:
+- Go version:

--- a/.github/ISSUE_TEMPLATE/2-enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/2-enhancement_request.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement request
+about: Suggest an enhancement or new feature
+labels: 'enhancement'
+---
+
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Help
+    url: https://community.grafana.com
+    about: Please ask and answer questions here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+
+Thank you for sending a pull request! Here are some tips:
+
+1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md
+
+2. Ensure you include and run the appropriate tests as part of your Pull Request.
+
+3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
+
+4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.
+
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+
+<!--
+
+* Automatically closes linked issue when the Pull Request is merged.
+
+Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
+
+-->
+
+Fixes #
+
+**Special notes for your reviewer**:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at contact@grafana.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Thank you for your interest in contributing to Grafana Plugin SDK for Go! We welcome all people who want to contribute in a healthy and constructive manner within our community. To help us create a safe and positive community experience for all, we require all participants to adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+This document is a guide to help you through the process of contributing to Grafana Plugin SDK for Go.
+
+## Become a contributor
+
+You can contribute to Grafana Plugin SDK for Go in several ways. Here are some examples:
+
+- Contribute to the Grafana SDK for Go codebase.
+- Report bugs and enhancements.
+
+For more ways to contribute, check out the [Open Source Guides](https://opensource.guide/how-to-contribute/).
+
+### Report bugs
+
+Report a bug by submitting a [bug report](https://github.com/grafana/grafana-plugin-sdk-go/issues/new?labels=bug&template=1-bug_report.md). Make sure that you provide as much information as possible on how to reproduce the bug.
+
+Before submitting a new issue, try to make sure someone hasn't already reported the problem. Look through the [existing issues](https://github.com/grafana/grafana-plugin-sdk-go/issues) for similar issues.
+
+#### Security issues
+
+If you believe you've found a security vulnerability, please read our [security policy](https://github.com/grafana/grafana-plugin-sdk-go/security/policy) for more details.
+
+### Suggest enhancements
+
+If you have an idea of how to improve Grafana Plugin SDK for Go, submit an [enhancement request](https://github.com/grafana/grafana-plugin-sdk-go/issues/new?labels=enhancement&template=2-enhancement_request.md).
+
+## Where do I go from here?
+
+- Set up your [development environment](contribute/developer-guide.md).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This SDK enables building [Grafana](https://github.com/grafana/grafana) backend 
 
 ## Current state
 
-**Warning:** This SDK is currently in alpha and will likely have major breaking changes during early development. Please do not consider this SDK stable until this warning has been removed.
+This SDK is still in development. The protocol between the Grafana server and the plugin SDK is considered stable but we might introduce breaking changes in the SDK. This means that plugins using the older SDK should work with Grafana but it might lose out on new features and capabilities that we introduce in the SDK.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,55 +1,23 @@
 # Grafana Plugin SDK for Go
 
-Develop Grafana backend plugins with this Go SDK.
+This SDK enables building [Grafana](https://github.com/grafana/grafana) backend plugins using Go.
 
-**Warning**: This SDK is currently in alpha and will likely have major breaking changes during early development. Please do not consider this SDK published until this warning has been removed.
+[![License](https://img.shields.io/github/license/grafana/grafana-plugin-sdk-go)](LICENSE)
+[![GoDoc](https://godoc.org/github.com/grafana/grafana-plugin-sdk-go?status.svg)](https://godoc.org/github.com/grafana/grafana-plugin-sdk-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/grafana/grafana-plugin-sdk-go)](https://goreportcard.com/report/github.com/grafana/grafana-plugin-sdk-go)
+[![Circle CI](https://img.shields.io/circleci/build/gh/grafana/grafana-plugin-sdk-go/master)](https://circleci.com/gh/grafana/grafana-plugin-sdk-go?branch=master)
 
-## Usage
+## Current state
 
-```go
-package main
+**Warning:** This SDK is currently in alpha and will likely have major breaking changes during early development. Please do not consider this SDK stable until this warning has been removed.
 
-import (
-	"context"
-	"log"
-	"os"
+## Contributing
 
-	gf "github.com/grafana/grafana-plugin-sdk-go"
-)
+If you're interested in contributing to this project:
 
-const pluginID = "myorg-custom-datasource"
+- Start by reading the [Contributing guide](/CONTRIBUTING.md).
+- Learn how to set up your local environment, in our [Developer guide](/contribute/developer-guide.md).
 
-type MyDataSource struct {
-	logger *log.Logger
-}
+## License
 
-func (d *MyDataSource) Query(ctx context.Context, tr gf.TimeRange, ds gf.DataSourceInfo, queries []gf.Query) ([]gf.QueryResult, error) {
-	return []gf.QueryResult{}, nil
-}
-
-func main() {
-	logger := log.New(os.Stderr, "", 0)
-
-	srv := gf.NewServer()
-
-	srv.HandleDataSource(pluginID, &MyDataSource{
-		logger: logger,
-	})
-
-	if err := srv.Serve(); err != nil {
-		logger.Fatal(err)
-	}
-}
-```
-
-## Developing
-
-### Generate Go code for Protobuf definitions
-
-```
-make protobuf
-```
-
-### Changing `generic_*.go` files in the `data` package
-
-Currently [genny](https://github.com/cheekybits/genny) is used for generating some go code. If you make changes to generic template files then `genny` needs to be installed, and then `mage dataGenerate`. Changed generated files should be committed with the change in the template files.
+[Apache 2.0 License](https://github.com/grafana/grafana-plugin-sdk-go/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This SDK enables building [Grafana](https://github.com/grafana/grafana) backend 
 
 ## Current state
 
-This SDK is still in development. The protocol between the Grafana server and the plugin SDK is considered stable but we might introduce breaking changes in the SDK. This means that plugins using the older SDK should work with Grafana but it might lose out on new features and capabilities that we introduce in the SDK.
+This SDK is still in development. The protocol between the Grafana server and the plugin SDK is considered stable, but we might introduce breaking changes in the SDK. This means that plugins using the older SDK should work with Grafana, but might lose out on new features and capabilities that we introduce in the SDK.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Reporting security issues
+
+If you think you have found a security vulnerability, please send a report to [security@grafana.com](mailto:security@grafana.com). This address can be used for all of Grafana Labs's open source and commercial products (including but not limited to Grafana, Grafana Cloud, Grafana Enterprise, and grafana.com). We can accept only vulnerability reports at this address. 
+
+Please encrypt your message to us; please use our PGP key. The key fingerprint is:
+
+F988 7BEA 027A 049F AE8E  5CAA D125 8932 BE24 C5CA
+
+The key is available from [pgp.mit.edu](https://pgp.mit.edu/pks/lookup?op=get&search=0xF9887BEA027A049FAE8E5CAAD1258932BE24C5CA) by searching for [grafana](https://pgp.mit.edu/pks/lookup?search=grafana&op=index).
+
+Grafana Labs will send you a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+**Important:** We ask you to not disclose the vulnerability before it have been fixed and announced, unless you received a response from the Grafana Labs security team that you can do so.
+
+## Security announcements
+
+We maintain a category on the community site called [Security Announcements](https://community.grafana.com/c/security-announcements),
+where we will post a summary, remediation, and mitigation details for any patch containing security fixes. 
+
+You can also subscribe to email updates to this category if you have a grafana.com account and sign on to the community site or track updates via an [RSS feed](https://community.grafana.com/c/security-announcements.rss).

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -1,0 +1,59 @@
+# Developer guide
+
+This guide helps you get started developing Grafana Plugin SDK for Go.
+
+## Tooling
+
+Make sure you have the following tools installed before setting up your developer environment:
+
+- [Git](https://git-scm.com/)
+- [Go](https://golang.org/dl/) (see [go.mod](../go.mod#L3) for minimum required version)
+- [Mage](https://magefile.org/)
+
+## Building
+
+We use [Mage](https://magefile.org/) as our primary tool for development related tasks like building and testing etc. It should be run from the root of this repository.
+
+List available Mage targets that are available:
+
+```bash
+mage -l
+```
+
+You can use the `build` target to verify all code compiles. It  doesn't output any binary though.
+
+```bash
+mage -v build
+```
+
+The `-v` flag can be used to show verbose output when running Mage targets.
+
+### Testing
+
+```bash
+mage test
+```
+
+### Linting
+
+```bash
+mage lint
+```
+
+### Generate Go code for Protobuf definitions
+
+A prerequisite is to have [protoc](http://google.github.io/proto-lens/installing-protoc.html) installed and available in your path.
+
+Next, you need to have [protoc-gen-go](https://github.com/golang/protobuf/tree/v1.3.4#installation) installed and available in your path. It's very important that you match the version specified of `github.com/golang/protobuf` in [go.mod](go.mod) file, as of this writing it's v1.3.4.
+
+```
+mage protobuf
+```
+
+### Changing `generic_*.go` files in the `data` package
+
+Currently [genny](https://github.com/cheekybits/genny) is used for generating some go code. If you make changes to generic template files then `genny` needs to be installed, and then `mage dataGenerate`. Changed generated files should be committed with the change in the template files.
+
+### Dependency management
+
+We use Go modules for managing Go dependencies. After you've updated/modified modules dependencies, please run `go mod tidy` to cleanup dependencies.


### PR DESCRIPTION
- Cleanup readme for now by removing outdated example and linking to contribution and development guides plus adding some nice badges
- Adds issues and PR templates (copy from grafana repo with modifications)
- Adds security policy (copy from grafana repo)
- Adds contributing guideline (copy from grafana repo with modifications)- 
- Adds development guideline

Should tick the boxes [here](https://github.com/grafana/grafana-plugin-sdk-go/community).