### PR TITLE
Build: support pre-build callback

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -20,11 +20,14 @@ import (
 )
 
 // Callbacks give you a way to run custom behavior when things happen
-var Callbacks = GlobalCallbacks{
-	// If your environment requires additional environment variables, this is a reasonable place to put them.
-	BeforeBuild: func(cfg Config) (Config, error) {
-		return cfg, nil
-	},
+var beforeBuild = func(cfg Config) (Config, error) {
+	return cfg, nil
+}
+
+// SetBeforeBuildCallback configures a custom callback
+func SetBeforeBuildCallback(cb BeforeBuildCallback) error {
+	beforeBuild = cb
+	return nil
 }
 
 var exname string
@@ -94,7 +97,7 @@ func killAllPIDs(pids []int) error {
 }
 
 func buildBackend(cfg Config) error {
-	cfg, err := BeforeBuildCallback(cfg)
+	cfg, err := beforeBuild(cfg)
 	if err != nil {
 		return err
 	}

--- a/build/common.go
+++ b/build/common.go
@@ -105,26 +105,26 @@ func buildBackend(cfg BuildConfig) error {
 	args := []string{
 		"build", "-o", path.Join("dist", exeName), "-tags", "netgo",
 	}
-	if cfg.enableDebug {
+	if cfg.EnableDebug {
 		args = append(args, "-gcflags=all=-N -l")
 	} else {
 		args = append(args, "-ldflags", "-w")
 	}
 	args = append(args, "./pkg")
 
-	cfg.env["GOARCH"] = cfg.ARCH
-	cfg.env["GOOS"] = cfg.OS
+	cfg.Env["GOARCH"] = cfg.ARCH
+	cfg.Env["GOOS"] = cfg.OS
 
 	// TODO: Change to sh.RunWithV once available.
-	return sh.RunWith(cfg.env, "go", args...)
+	return sh.RunWith(cfg.Env, "go", args...)
 }
 
 func newBuildConfig(os string, arch string) BuildConfig {
 	return BuildConfig{
 		OS:          os,
 		ARCH:        arch,
-		enableDebug: false,
-		env:         map[string]string{},
+		EnableDebug: false,
+		Env:         map[string]string{},
 	}
 }
 
@@ -149,7 +149,7 @@ func (Build) Darwin() error {
 // Debug builds the debug version for the current platform
 func (Build) Debug() error {
 	cfg := newBuildConfig(runtime.GOOS, runtime.GOARCH)
-	cfg.enableDebug = true
+	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
 

--- a/build/common.go
+++ b/build/common.go
@@ -21,7 +21,7 @@ import (
 
 // BeforeBuildCallback is called before each build.  If your environment requires additional environment variables,
 // this is a reasonable place to put them.
-var BeforeBuildCallback = func(cfg BuildConfig) (BuildConfig, error) {
+var BeforeBuildCallback = func(cfg Config) (Config, error) {
 	return cfg, nil
 }
 
@@ -91,7 +91,7 @@ func killAllPIDs(pids []int) error {
 	return nil
 }
 
-func buildBackend(cfg BuildConfig) error {
+func buildBackend(cfg Config) error {
 	cfg, err := BeforeBuildCallback(cfg)
 	if err != nil {
 		return err
@@ -119,8 +119,8 @@ func buildBackend(cfg BuildConfig) error {
 	return sh.RunWith(cfg.Env, "go", args...)
 }
 
-func newBuildConfig(os string, arch string) BuildConfig {
-	return BuildConfig{
+func newBuildConfig(os string, arch string) Config {
+	return Config{
 		OS:          os,
 		Arch:        arch,
 		EnableDebug: false,

--- a/build/common.go
+++ b/build/common.go
@@ -97,7 +97,7 @@ func buildBackend(cfg BuildConfig) error {
 		return err
 	}
 
-	exeName, err := getExecutableName(cfg.OS, cfg.ARCH)
+	exeName, err := getExecutableName(cfg.OS, cfg.Arch)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func buildBackend(cfg BuildConfig) error {
 	}
 	args = append(args, "./pkg")
 
-	cfg.Env["GOARCH"] = cfg.ARCH
+	cfg.Env["GOARCH"] = cfg.Arch
 	cfg.Env["GOOS"] = cfg.OS
 
 	// TODO: Change to sh.RunWithV once available.
@@ -122,7 +122,7 @@ func buildBackend(cfg BuildConfig) error {
 func newBuildConfig(os string, arch string) BuildConfig {
 	return BuildConfig{
 		OS:          os,
-		ARCH:        arch,
+		Arch:        arch,
 		EnableDebug: false,
 		Env:         map[string]string{},
 	}

--- a/build/common.go
+++ b/build/common.go
@@ -19,8 +19,8 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-// BeforeBuildCallback is called before each build.  If your environemt requires aditional environemt variables,
-// this is a reasonable place to put them
+// BeforeBuildCallback is called before each build.  If your environment requires additional environment variables,
+// this is a reasonable place to put them.
 var BeforeBuildCallback = func(cfg BuildConfig) (BuildConfig, error) {
 	return cfg, nil
 }

--- a/build/common.go
+++ b/build/common.go
@@ -19,10 +19,12 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-// BeforeBuildCallback is called before each build.  If your environment requires additional environment variables,
-// this is a reasonable place to put them.
-var BeforeBuildCallback = func(cfg Config) (Config, error) {
-	return cfg, nil
+// Callbacks give you a way to run custom behavior when things happen
+var Callbacks = GlobalCallbacks{
+	// If your environment requires additional environment variables, this is a reasonable place to put them.
+	BeforeBuild: func(cfg Config) (Config, error) {
+		return cfg, nil
+	},
 }
 
 var exname string

--- a/build/types.go
+++ b/build/types.go
@@ -1,5 +1,6 @@
 package build
 
+// BuildConfig holds the setup variables required for a build
 type BuildConfig struct {
 	OS          string // GOOS
 	ARCH        string // GOOS

--- a/build/types.go
+++ b/build/types.go
@@ -1,7 +1,7 @@
 package build
 
 // BuildConfig holds the setup variables required for a build
-type BuildConfig struct { //revive:disable-line
+type Config struct {
 	OS          string // GOOS
 	Arch        string // GOOS
 	EnableDebug bool

--- a/build/types.go
+++ b/build/types.go
@@ -1,7 +1,7 @@
 package build
 
 // BuildConfig holds the setup variables required for a build
-type BuildConfig struct {
+type BuildConfig struct { //revive:disable-line
 	OS          string // GOOS
 	Arch        string // GOOS
 	EnableDebug bool

--- a/build/types.go
+++ b/build/types.go
@@ -1,6 +1,6 @@
 package build
 
-// BuildConfig holds the setup variables required for a build
+// Config holds the setup variables required for a build
 type Config struct {
 	OS          string // GOOS
 	Arch        string // GOOS

--- a/build/types.go
+++ b/build/types.go
@@ -4,6 +4,6 @@ package build
 type BuildConfig struct {
 	OS          string // GOOS
 	ARCH        string // GOOS
-	enableDebug bool
-	env         map[string]string
+	EnableDebug bool
+	Env         map[string]string
 }

--- a/build/types.go
+++ b/build/types.go
@@ -3,7 +3,7 @@ package build
 // BuildConfig holds the setup variables required for a build
 type BuildConfig struct {
 	OS          string // GOOS
-	ARCH        string // GOOS
+	Arch        string // GOOS
 	EnableDebug bool
 	Env         map[string]string
 }

--- a/build/types.go
+++ b/build/types.go
@@ -1,0 +1,8 @@
+package build
+
+type BuildConfig struct {
+	OS          string // GOOS
+	ARCH        string // GOOS
+	enableDebug bool
+	env         map[string]string
+}

--- a/build/types.go
+++ b/build/types.go
@@ -7,3 +7,8 @@ type Config struct {
 	EnableDebug bool
 	Env         map[string]string
 }
+
+// GlobalCallbacks hooks into the build process
+type GlobalCallbacks struct {
+	BeforeBuild func(cfg Config) (Config, error)
+}

--- a/build/types.go
+++ b/build/types.go
@@ -8,7 +8,5 @@ type Config struct {
 	Env         map[string]string
 }
 
-// GlobalCallbacks hooks into the build process
-type GlobalCallbacks struct {
-	BeforeBuild func(cfg Config) (Config, error)
-}
+// BeforeBuildCallback hooks into the build process
+type BeforeBuildCallback func(cfg Config) (Config, error)


### PR DESCRIPTION
For some projects (oracle) we need to install dependencies and set special environment variables for the build.

This PR suggests a way to support that.  Totally open to any other suggestions!

See:
https://github.com/grafana/oracle-datasource/pull/109/files#diff-f60b2cbec853aa02423c3658f48e4155

