### PR TITLE
data: (breaking) FrameMeta change custom property to interface

### DIFF
--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -11,7 +11,7 @@ import (
 // this interface only exposes the values we want to be exposed
 type FrameMeta struct {
 	// Datasource specific values
-	Custom map[string]interface{} `json:"custom,omitempty"`
+	Custom interface{} `json:"custom,omitempty"`
 
 	// Stats is TODO
 	Stats interface{} `json:"stats,omitempty"`


### PR DESCRIPTION
As per @ryantxu in https://github.com/grafana/grafana-plugin-sdk-go/pull/182#discussion_r432726130

> I'm fine either way. We have two options:
> 
> 1. `interface{}`
>    pro: easy to work with, it is run though json serialization directly
>    con: _can_ put in invalid data if the value is not an interface
> 2. `map[string]interface{}`
>    pro: forces an object
>    con: can not use a well typed object in go to specify known properties
> 
> Given the trade offs, I think option 1 is better (but can happily go either way)

While doing this, if we do it, want to make sure FieldConfig Custom should not be the same way? But maybe that has to be an object?

As for an example in the wild, in Grafana cloudwatch there is:

```
	expectedFrame.Meta = &data.FrameMeta{
		Custom: map[string]interface{}{
			"Status": "Complete",
			"Statistics": cloudwatchlogs.QueryStatistics{
				BytesScanned:   aws.Float64(512),
				RecordsMatched: aws.Float64(256),
				RecordsScanned: aws.Float64(1024),
			},
		},
	}
```

So it would be nicer if Custom's property's value could be a type defined alongside the above code, instead of a `map[string]interface{}`

