### PR TITLE
Build: Disable cgo

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -107,18 +107,24 @@ func buildBackend(cfg Config) error {
 		return err
 	}
 
+	// Link statically
+	ldFlags := `-extldflags "-static"`
+	if !cfg.EnableDebug {
+		// Add linker flags to drop debug information
+		ldFlags = "-w -s " + ldFlags
+	}
+
 	args := []string{
-		"build", "-o", path.Join("dist", exeName), "-tags", "netgo",
+		"build", "-o", path.Join("dist", exeName), "-ldflags", ldFlags,
 	}
 	if cfg.EnableDebug {
 		args = append(args, "-gcflags=all=-N -l")
-	} else {
-		args = append(args, "-ldflags", "-w")
 	}
 	args = append(args, "./pkg")
 
 	cfg.Env["GOARCH"] = cfg.Arch
 	cfg.Env["GOOS"] = cfg.OS
+	cfg.Env["CGO_ENABLED"] = "0"
 
 	// TODO: Change to sh.RunWithV once available.
 	return sh.RunWith(cfg.Env, "go", args...)


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable cgo when building the back-end components of plugins, so static linking will be employed and plugins are portable to musl based Linux distros (f.ex. Alpine).

For reference, [Tanka](https://github.com/grafana/tanka/blob/master/Makefile#L19) already does this.

**Which issue(s) this PR fixes**:

Fixes #188.
