### PR TITLE
Updates FrameMeta definition

### DIFF
--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -24,12 +24,26 @@ type FrameMeta struct {
 	Transformations []string `json:"transformations,omitempty"`
 
 	// PreferredVisualisationType is currently used to show results in Explore only in preferred visualisation option.
-	PreferredVisualisationType string `json:"preferredVisualisationType,omitempty"`
+	PreferredVisualization VisualizationType `json:"preferredVisualisationType,omitempty"`
 
 	// ExecutedQueryString is the raw query sent to the underlying system. All macros and templating
 	// have been applied.  When metadata contains this value, it will be shown in the query inspector.
 	ExecutedQueryString string `json:"executedQueryString,omitempty"`
 }
+
+const (
+	// Graph indicates the response should be visualized using a graph
+	Graph VisualizationType = "graph"
+
+	// Table indicates the response should be visualized using a table
+	Table = "table"
+
+	// Logs indicates the response should be visualized using a logs visualization
+	Logs = "logs"
+)
+
+// VisualizationType is used to indicate how the data should be visualized in explore
+type VisualizationType string
 
 // FrameMetaFromJSON creates a QueryResultMeta from a json string
 func FrameMetaFromJSON(jsonStr string) (*FrameMeta, error) {
@@ -50,13 +64,14 @@ func (f *Frame) AppendNotices(notices ...Notice) {
 	f.Meta.Notices = append(f.Meta.Notices, notices...)
 }
 
-// QueryResultMetaStat matches https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/types/data.ts#L53
+// QueryResultMetaStat is used for storing arbitrary statistics metadata related to a query and its result
+// e.g. total request time, data processing time. Matches https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/types/data.ts#L53
 type QueryResultMetaStat struct {
 	FieldConfig
 
 	DisplayName string `json:"displayName"`
 
-	Value float32 `json:"value"`
+	Value float64 `json:"value"`
 }
 
 // Notice provides a structure for presenting notifications in Grafana's user interface.

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -13,16 +13,22 @@ type FrameMeta struct {
 	// Datasource specific values
 	Custom interface{} `json:"custom,omitempty"`
 
-	// Stats is TODO
-	Stats interface{} `json:"stats,omitempty"`
-
-	// This is the raw query sent to the underlying system.  All macros and templating
-	// as been applied.  When metadata contains this value, it will be shown in the query inspector
-	ExecutedQueryString string `json:"executedQueryString,omitempty"`
+	// Query Stats
+	Stats []QueryResultMetaStat `json:"stats,omitempty"`
 
 	// Notices provide additional information about the data in the Frame that
 	// Grafana can display to the user in the user interface.
 	Notices []Notice `json:"notices,omitempty"`
+
+	// Used to track transformation IDs that were part of the processing
+	Transformations []string `json:"transformations,omitempty"`
+
+	// Currently used to show results in Explore only in preferred visualisation option
+	PreferredVisualisationType string `json:"preferredVisualisationType,omitempty"`
+
+	// This is the raw query sent to the underlying system.  All macros and templating
+	// as been applied.  When metadata contains this value, it will be shown in the query inspector
+	ExecutedQueryString string `json:"executedQueryString,omitempty"`
 }
 
 // FrameMetaFromJSON creates a QueryResultMeta from a json string
@@ -42,6 +48,15 @@ func (f *Frame) AppendNotices(notices ...Notice) {
 		f.Meta = &FrameMeta{}
 	}
 	f.Meta.Notices = append(f.Meta.Notices, notices...)
+}
+
+// QueryResultMetaStat matches https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/types/data.ts#L53
+type QueryResultMetaStat struct {
+	FieldConfig
+
+	DisplayName string `json:"displayName"`
+
+	Value float32 `json:"value"`
 }
 
 // Notice provides a structure for presenting notifications in Grafana's user interface.

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -14,14 +14,14 @@ type FrameMeta struct {
 	Custom interface{} `json:"custom,omitempty"`
 
 	// Stats is an array of query result statistics.
-	Stats []QueryResultMetaStat `json:"stats,omitempty"`
+	Stats []QueryStat `json:"stats,omitempty"`
 
 	// Notices provide additional information about the data in the Frame that
 	// Grafana can display to the user in the user interface.
 	Notices []Notice `json:"notices,omitempty"`
 
 	// PreferredVisualisationType is currently used to show results in Explore only in preferred visualisation option.
-	PreferredVisualization VisualizationType `json:"preferredVisualisationType,omitempty"`
+	PreferredVisualization VisType `json:"preferredVisualisationType,omitempty"`
 
 	// ExecutedQueryString is the raw query sent to the underlying system. All macros and templating
 	// have been applied.  When metadata contains this value, it will be shown in the query inspector.
@@ -29,18 +29,18 @@ type FrameMeta struct {
 }
 
 const (
-	// Graph indicates the response should be visualized using a graph
-	Graph VisualizationType = "graph"
+	// VisTypeGraph indicates the response should be visualized using a graph.
+	VisTypeGraph VisType = "graph"
 
-	// Table indicates the response should be visualized using a table
-	Table = "table"
+	// VisTypeTable indicates the response should be visualized using a table.
+	VisTypeTable = "table"
 
-	// Logs indicates the response should be visualized using a logs visualization
-	Logs = "logs"
+	// VisTypeLogs indicates the response should be visualized using a logs visualization.
+	VisTypeLogs = "logs"
 )
 
-// VisualizationType is used to indicate how the data should be visualized in explore
-type VisualizationType string
+// VisType is used to indicate how the data should be visualized in explore.
+type VisType string
 
 // FrameMetaFromJSON creates a QueryResultMeta from a json string
 func FrameMetaFromJSON(jsonStr string) (*FrameMeta, error) {
@@ -61,12 +61,11 @@ func (f *Frame) AppendNotices(notices ...Notice) {
 	f.Meta.Notices = append(f.Meta.Notices, notices...)
 }
 
-// QueryResultMetaStat is used for storing arbitrary statistics metadata related to a query and its result
-// e.g. total request time, data processing time. Matches https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/types/data.ts#L53
-type QueryResultMetaStat struct {
+// QueryStat is used for storing arbitrary statistics metadata related to a query and its result, e.g. total request time, data processing time.
+// The embedded FieldConfig's display name must be set.
+// It corresponds to the QueryResultMetaStat on the frontend (https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/types/data.ts#L53).
+type QueryStat struct {
 	FieldConfig
-
-	DisplayName string `json:"displayName"`
 
 	Value float64 `json:"value"`
 }

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -20,9 +20,6 @@ type FrameMeta struct {
 	// Grafana can display to the user in the user interface.
 	Notices []Notice `json:"notices,omitempty"`
 
-	// Transformations is used to track transformation IDs that were part of the processing.
-	Transformations []string `json:"transformations,omitempty"`
-
 	// PreferredVisualisationType is currently used to show results in Explore only in preferred visualisation option.
 	PreferredVisualization VisualizationType `json:"preferredVisualisationType,omitempty"`
 

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -13,21 +13,21 @@ type FrameMeta struct {
 	// Datasource specific values
 	Custom interface{} `json:"custom,omitempty"`
 
-	// Query Stats
+	// Stats is an array of query result statistics.
 	Stats []QueryResultMetaStat `json:"stats,omitempty"`
 
 	// Notices provide additional information about the data in the Frame that
 	// Grafana can display to the user in the user interface.
 	Notices []Notice `json:"notices,omitempty"`
 
-	// Used to track transformation IDs that were part of the processing
+	// Transformations is used to track transformation IDs that were part of the processing.
 	Transformations []string `json:"transformations,omitempty"`
 
-	// Currently used to show results in Explore only in preferred visualisation option
+	// PreferredVisualisationType is currently used to show results in Explore only in preferred visualisation option.
 	PreferredVisualisationType string `json:"preferredVisualisationType,omitempty"`
 
-	// This is the raw query sent to the underlying system.  All macros and templating
-	// as been applied.  When metadata contains this value, it will be shown in the query inspector
+	// ExecutedQueryString is the raw query sent to the underlying system. All macros and templating
+	// have been applied.  When metadata contains this value, it will be shown in the query inspector.
 	ExecutedQueryString string `json:"executedQueryString,omitempty"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Syncs `FrameMeta` definition with typescript interface and defines `QueryResultMetaStat` type.

