### PR TITLE
WIP: Chore: Disable golangci-lint default excludes

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -41,6 +41,9 @@ enable = [
   "whitespace",
 ]
 
+[issues]
+exclude-use-default = false
+
 # Disabled linters (might want them later)
 # "gocyclo",
 # "unparam"

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -47,3 +47,7 @@ exclude-use-default = false
 # Disabled linters (might want them later)
 # "gocyclo",
 # "unparam"
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
+text = "G304"

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -50,4 +50,8 @@ exclude-use-default = false
 
 [[issues.exclude-rules]]
 linters = ["gosec"]
+text = "G301"
+
+[[issues.exclude-rules]]
+linters = ["gosec"]
 text = "G304"

--- a/backend/datasource/serve_example_test.go
+++ b/backend/datasource/serve_example_test.go
@@ -65,7 +65,10 @@ func (ds *testDataSource) CheckHealth(ctx context.Context, req *backend.CheckHea
 	if err != nil {
 		return nil, err
 	}
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
@@ -77,7 +80,10 @@ func (ds *testDataSource) QueryData(ctx context.Context, req *backend.QueryDataR
 		if err != nil {
 			return err
 		}
-		resp.Body.Close()
+		if err := resp.Body.Close(); err != nil {
+			return err
+		}
+
 		return nil
 	})
 
@@ -98,7 +104,10 @@ func (ds *testDataSource) handleTest(rw http.ResponseWriter, req *http.Request) 
 		rw.WriteHeader(500)
 		return
 	}
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		rw.WriteHeader(500)
+		return
+	}
 }
 
 func Example() {

--- a/backend/grpcplugin/grpc_transform.go
+++ b/backend/grpcplugin/grpc_transform.go
@@ -72,7 +72,9 @@ func (t *transformGRPCServer) TransformData(ctx context.Context, req *pluginv2.Q
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 	api := &transformDataCallBackGrpcClient{pluginv2.NewTransformDataCallBackClient(conn)}
 	return t.server.TransformData(ctx, req, api)
 }

--- a/backend/resource/httpadapter/handler_test.go
+++ b/backend/resource/httpadapter/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,7 +70,10 @@ func TestHttpResourceHandler(t *testing.T) {
 			require.Contains(t, httpHandler.req.Header, "X-Header-In-2")
 			require.Equal(t, []string{"F"}, httpHandler.req.Header["X-Header-In-2"])
 			require.NotNil(t, httpHandler.req.Body)
-			defer httpHandler.req.Body.Close()
+			t.Cleanup(func() {
+				err := httpHandler.req.Body.Close()
+				assert.NoError(t, err)
+			})
 			actualBodyBytes, err := ioutil.ReadAll(httpHandler.req.Body)
 			require.NoError(t, err)
 			var actualJSONMap map[string]interface{}

--- a/build/common.go
+++ b/build/common.go
@@ -1,3 +1,4 @@
+// Package build contains build logic.
 package build
 
 import (

--- a/build/utils/copy.go
+++ b/build/utils/copy.go
@@ -69,7 +69,9 @@ func copyFileContents(src, dst string) (err error) {
 	if err != nil {
 		return
 	}
-	defer in.Close()
+	defer func() {
+		_ = in.Close()
+	}()
 
 	out, err := os.Create(dst)
 	if err != nil {

--- a/build/utils/copy_test.go
+++ b/build/utils/copy_test.go
@@ -8,19 +8,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCopyFile(t *testing.T) {
 	src, err := ioutil.TempFile("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(src.Name())
+	t.Cleanup(func() {
+		err := os.RemoveAll(src.Name())
+		assert.NoError(t, err)
+	})
 	err = ioutil.WriteFile(src.Name(), []byte("Contents"), 0600)
 	require.NoError(t, err)
 
 	dst, err := ioutil.TempFile("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(dst.Name())
+	t.Cleanup(func() {
+		err := os.RemoveAll(dst.Name())
+		assert.NoError(t, err)
+	})
 
 	err = CopyFile(src.Name(), dst.Name())
 	require.NoError(t, err)
@@ -30,7 +37,10 @@ func TestCopyFile(t *testing.T) {
 func TestCopyFile_NonExistentDestDir(t *testing.T) {
 	src, err := ioutil.TempFile("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(src.Name())
+	t.Cleanup(func() {
+		err := os.RemoveAll(src.Name())
+		assert.NoError(t, err)
+	})
 
 	err = CopyFile(src.Name(), "non-existent/dest")
 	require.EqualError(t, err, "destination directory doesn't exist: \"non-existent\"")
@@ -39,7 +49,10 @@ func TestCopyFile_NonExistentDestDir(t *testing.T) {
 func TestCopyRecursive_NonExistentDest(t *testing.T) {
 	src, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(src)
+	t.Cleanup(func() {
+		err := os.RemoveAll(src)
+		assert.NoError(t, err)
+	})
 
 	err = os.MkdirAll(path.Join(src, "data"), 0755)
 	require.NoError(t, err)
@@ -48,7 +61,10 @@ func TestCopyRecursive_NonExistentDest(t *testing.T) {
 
 	dstParent, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(dstParent)
+	t.Cleanup(func() {
+		err := os.RemoveAll(dstParent)
+		assert.NoError(t, err)
+	})
 
 	dst := path.Join(dstParent, "dest")
 
@@ -61,7 +77,10 @@ func TestCopyRecursive_NonExistentDest(t *testing.T) {
 func TestCopyRecursive_ExistentDest(t *testing.T) {
 	src, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(src)
+	t.Cleanup(func() {
+		err := os.RemoveAll(src)
+		assert.NoError(t, err)
+	})
 
 	err = os.MkdirAll(path.Join(src, "data"), 0755)
 	require.NoError(t, err)
@@ -70,7 +89,10 @@ func TestCopyRecursive_ExistentDest(t *testing.T) {
 
 	dst, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
-	defer os.RemoveAll(dst)
+	t.Cleanup(func() {
+		err := os.RemoveAll(dst)
+		assert.NoError(t, err)
+	})
 
 	err = CopyRecursive(src, dst)
 	require.NoError(t, err)

--- a/build/utils/exists_test.go
+++ b/build/utils/exists_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +19,10 @@ func TestExists_NonExistent(t *testing.T) {
 func TestExists_Existent(t *testing.T) {
 	f, err := ioutil.TempFile("", "")
 	require.NoError(t, err)
-	defer os.Remove(f.Name())
+	t.Cleanup(func() {
+		err := os.Remove(f.Name())
+		assert.NoError(t, err)
+	})
 
 	exists, err := Exists(f.Name())
 	require.NoError(t, err)

--- a/build/utils/utils.go
+++ b/build/utils/utils.go
@@ -1,0 +1,2 @@
+// Package utils contains utilities.
+package utils

--- a/data/arrow.go
+++ b/data/arrow.go
@@ -621,7 +621,9 @@ func UnmarshalArrowFrame(b []byte) (*Frame, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer fR.Close()
+	defer func() {
+		_ = fR.Close()
+	}()
 
 	schema := fR.Schema()
 	metaData := schema.Metadata()

--- a/data/sqlutil/sql_test.go
+++ b/data/sqlutil/sql_test.go
@@ -95,23 +95,29 @@ func ExampleFrameFromRows() {
 	aQuery := "SELECT * FROM GoodData"
 	db, err := sql.Open("fancySql", "fancysql://user:pass@localhost:1433")
 	if err != nil {
-		// return err
+		return
 	}
 
-	defer db.Close()
+	defer func() {
+		_ = db.Close()
+	}()
 
+	// For some reason the rowserrcheck linter doesn't catch that rows.Err is checked
+	// nolint: rowserrcheck
 	rows, err := db.Query(aQuery)
 	if err != nil {
-		// return err
+		return
 	}
 	if rows.Err() != nil {
-		// return err
+		return
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	frame, mappings, err := sqlutil.FrameFromRows(rows, 1000)
 	if err != nil {
-		// return err
+		return
 	}
 	_, _ = frame, mappings
 }

--- a/experimental/experimental.go
+++ b/experimental/experimental.go
@@ -1,0 +1,2 @@
+// Package experimental contains experimental parts of the SDK.
+package experimental

--- a/experimental/golden_response_checker.go
+++ b/experimental/golden_response_checker.go
@@ -65,7 +65,9 @@ func readGoldenFile(path string) (*backend.DataResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	dr := &backend.DataResponse{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable golangci-lint default excludes since they disable e.g. catching of missing comments for exported symbols. Malformed documentation for some public members is still not caught, not sure why not.

I think we'll need to replicate some of the default excludes though, since a subset is actually useful.