### PR TITLE
Chore: Replace scopelint with exportloopref

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 defaults: &defaults
   docker:
-    - image: srclosson/grafana-plugin-ci-alpine:latest
+    - image: grafana/grafana-plugin-ci:latest-alpine
 
 jobs:
   build:

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -30,7 +30,7 @@ enable = [
   "misspell",
   "nakedret",
   "rowserrcheck",
-  "scopelint",
+  "exportloopref",
   "staticcheck",
   "structcheck",
   "stylecheck",


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace the deprecated scopelint Go linter with its suggested replacement [exportloopref](https://github.com/kyoh86/exportloopref).

Need also to upgrade golangci-lint in CI image to get support for this linter.