### PR TITLE
Diagnostics adapter: Introduce error type UnhealthyError

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 defaults: &defaults
   docker:
-    - image: srclosson/grafana-plugin-ci-alpine:latest
+    - image: grafana/grafana-plugin-ci:latest-alpine
 
 jobs:
   build:

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -30,7 +30,7 @@ enable = [
   "misspell",
   "nakedret",
   "rowserrcheck",
-  "scopelint",
+  "exportloopref",
   "staticcheck",
   "structcheck",
   "stylecheck",

--- a/backend/diagnostics_adapter.go
+++ b/backend/diagnostics_adapter.go
@@ -20,6 +20,7 @@ func (e UnhealthyError) Error() string {
 	return e.message
 }
 
+// Is this equivalent to a given error?
 func (e UnhealthyError) Is(err error) bool {
 	_, ok := err.(UnhealthyError)
 	return ok


### PR DESCRIPTION
**What this PR does / why we need it**:
Reading @ryantxu's drone-adapter source code, I realized that the CheckHealth implementation is very cookie cutter, in that it will convert every error to a CheckHealthResult with `Status: backend.HealthStatusError`. This is both overly verbose, pushes too much responsibility onto each plugin implementation, plus is non-idiomatic Go code in my opinion (errors should be returned as errors).

I suggest we instead introduce a specialized error type `UnhealthyError`, which should be used by SDK clients to indicate that they are unhealthy due to some sort of error condition. The SDK should take care of the conversion of this into a CheckHealthResult, as @ryantxu's code is currently doing. When it comes to general, i.e. unrecognized, errors, I'm not sure exactly how they are best handled, i.e. if they should be returned to gRPC or into CheckHealthResult.

I added a test for this case, and made all the cases run in a sub-test with a description, so you can easily identify the case that eventually broke and run individual cases from the command line.

It would break API right now, but maybe we want to change the plugin CheckHealth method to only return an error, and treat non-error as OK? It would be far more ergonomic, and the shaping of the healthcheck response would be left to the SDK as I think it should be (no need for clients to customize the health check response is there?).