### PR TITLE
data: wide time series frame field sorting

### DIFF
--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -397,12 +397,12 @@ func ExampleFrame_tableLikeLongTimeSeries() {
 	// Name: Wide
 	// Dimensions: 5 Fields by 2 Rows
 	// +-------------------------------+------------------------+------------------------+------------------------+------------------------+
-	// | Name: time                    | Name: aMetric          | Name: bMetric          | Name: aMetric          | Name: bMetric          |
-	// | Labels:                       | Labels: SomeFactor=foo | Labels: SomeFactor=foo | Labels: SomeFactor=bar | Labels: SomeFactor=bar |
+	// | Name: time                    | Name: aMetric          | Name: aMetric          | Name: bMetric          | Name: bMetric          |
+	// | Labels:                       | Labels: SomeFactor=bar | Labels: SomeFactor=foo | Labels: SomeFactor=bar | Labels: SomeFactor=foo |
 	// | Type: []time.Time             | Type: []float64        | Type: []float64        | Type: []float64        | Type: []float64        |
 	// +-------------------------------+------------------------+------------------------+------------------------+------------------------+
-	// | 2020-01-02 03:04:00 +0000 UTC | 2                      | 10                     | 5                      | 15                     |
-	// | 2020-01-02 03:05:00 +0000 UTC | 3                      | 11                     | 6                      | 16                     |
+	// | 2020-01-02 03:04:00 +0000 UTC | 5                      | 2                      | 15                     | 10                     |
+	// | 2020-01-02 03:05:00 +0000 UTC | 6                      | 3                      | 16                     | 11                     |
 	// +-------------------------------+------------------------+------------------------+------------------------+------------------------+
 }
 

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -528,33 +528,31 @@ func SortWideFrameFields(frame *Frame) error {
 	if tsSchema.Type != TimeSeriesTypeWide {
 		return fmt.Errorf("field sorting for a wide time series frame called on a series that is not a wide frame")
 	}
-	sortWideFrameFields(&frame.Fields, tsSchema)
-	return nil
-}
 
-func sortWideFrameFields(fields *[]*Field, tsSchema TimeSeriesSchema) {
 	// capture and remove the time index
-	timeIndexField := (*fields)[tsSchema.TimeIndex]
-	(*fields)[len(*fields)-1], (*fields)[tsSchema.TimeIndex] = (*fields)[tsSchema.TimeIndex], (*fields)[len(*fields)-1]
-	*fields = (*fields)[:len(*fields)-1]
+	timeIndexField := frame.Fields[tsSchema.TimeIndex]
+	frame.Fields[len(frame.Fields)-1], frame.Fields[tsSchema.TimeIndex] = frame.Fields[tsSchema.TimeIndex], (frame.Fields)[len(frame.Fields)-1]
+	frame.Fields = frame.Fields[:len(frame.Fields)-1]
 
-	// sort
-	sort.SliceStable(*fields, func(i, j int) bool {
-		if (*fields)[i].Name < (*fields)[j].Name {
+	sort.SliceStable(frame.Fields, func(i, j int) bool {
+		iField := frame.Fields[i]
+		jField := frame.Fields[j]
+		if iField.Name < jField.Name {
 			return true
 		}
-		if (*fields)[i].Name > (*fields)[j].Name {
+		if iField.Name > jField.Name {
 			return false
 		}
-		if (*fields)[i].Labels == nil && (*fields)[j].Labels != nil {
+		if iField.Labels == nil && jField.Labels != nil {
 			return true
 		}
-		if (*fields)[i].Labels != nil && (*fields)[j].Labels == nil {
+		if iField.Labels != nil && jField.Labels == nil {
 			return false
 		}
-		return (*fields)[i].Labels.String() < (*fields)[j].Labels.String()
+		return iField.Labels.String() < jField.Labels.String()
 	})
 
-	// restore the time index as first element
-	*fields = append([]*Field{timeIndexField}, *fields...)
+	frame.Fields = append(Fields{timeIndexField}, frame.Fields...)
+
+	return nil
 }

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -552,6 +552,7 @@ func SortWideFrameFields(frame *Frame) error {
 		return iField.Labels.String() < jField.Labels.String()
 	})
 
+	// restore the time index back as the first field
 	frame.Fields = append(Fields{timeIndexField}, frame.Fields...)
 
 	return nil

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -321,7 +321,10 @@ func LongToWide(longFrame *Frame, fillMissing *FillMissing) (*Frame, error) {
 			wideFrame.Set(wideFieldIdx, wideFrameRowCounter, longFrame.CopyAt(longFieldIdx, longRowIdx))
 		}
 	}
-
+	err = SortWideFrameFields(wideFrame)
+	if err != nil {
+		return nil, err
+	}
 	return wideFrame, nil
 }
 
@@ -445,7 +448,6 @@ func WideToLong(wideFrame *Frame) (*Frame, error) {
 			longFrameCounter++
 		}
 	}
-
 	return longFrame, nil
 }
 

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -515,3 +515,12 @@ func labelsTupleKey(l Labels) (string, error) {
 	t := labelsToTupleLabels(l)
 	return t.MapKey()
 }
+
+// sortWideFrameFields (WIP)
+// Sort the order of a Frame Fields when that is of a wide time series schema.
+// Keep the Datetime Column First
+// Then sort Fields by string representation of their Name + Labels
+// Needs to be stable sort
+func sortWideFrameFields(frame *Frame) error {
+	return nil
+}

--- a/data/time_series_field_sort_test.go
+++ b/data/time_series_field_sort_test.go
@@ -92,5 +92,4 @@ func TestSortWideFrameFields(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/data/time_series_field_sort_test.go
+++ b/data/time_series_field_sort_test.go
@@ -16,6 +16,19 @@ func TestSortWideFrameFields(t *testing.T) {
 		afterSort   *Frame
 	}{
 		{
+			name: "wide frame with names pass through",
+			frameToSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", nil, []float64{1}),
+				NewField("bValue", nil, []float64{5}),
+			),
+			afterSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", nil, []float64{1}),
+				NewField("bValue", nil, []float64{5}),
+			),
+		},
+		{
 			name: "wide frame with names only",
 			frameToSort: NewFrame("",
 				NewField("time", nil, []time.Time{aTime}),
@@ -28,10 +41,51 @@ func TestSortWideFrameFields(t *testing.T) {
 				NewField("bValue", nil, []float64{5}),
 			),
 		},
+		{
+			name: "wide frame with names only and time not first",
+			frameToSort: NewFrame("",
+				NewField("bValue", nil, []float64{5}),
+				NewField("aValue", nil, []float64{1}),
+				NewField("time", nil, []time.Time{aTime}),
+			),
+			afterSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", nil, []float64{1}),
+				NewField("bValue", nil, []float64{5}),
+			),
+		},
+		{
+			name: "wide frame with names only, valued time column and time not first",
+			frameToSort: NewFrame("",
+				NewField("aValue", nil, []float64{1}),
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("valueTime", nil, []time.Time{aTime.Add(time.Hour)}),
+			),
+			afterSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", nil, []float64{1}),
+				NewField("valueTime", nil, []time.Time{aTime.Add(time.Hour)}),
+			),
+		},
+		{
+			name: "wide frame with labels and one metric name",
+			frameToSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", Labels{"host": "b", "int": "eth0"}, []float64{5}),
+				NewField("aValue", Labels{"host": "a", "int": "eth1"}, []float64{3}),
+				NewField("aValue", Labels{"host": "a", "int": "eth0"}, []float64{1}),
+			),
+			afterSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", Labels{"host": "a", "int": "eth0"}, []float64{1}),
+				NewField("aValue", Labels{"host": "a", "int": "eth1"}, []float64{3}),
+				NewField("aValue", Labels{"host": "b", "int": "eth0"}, []float64{5}),
+			),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := sortWideFrameFields(tt.frameToSort)
+			err := SortWideFrameFields(tt.frameToSort)
 			require.NoError(t, err)
 			if diff := cmp.Diff(tt.frameToSort, tt.afterSort, FrameTestCompareOptions()...); diff != "" {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)

--- a/data/time_series_field_sort_test.go
+++ b/data/time_series_field_sort_test.go
@@ -1,0 +1,42 @@
+package data
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortWideFrameFields(t *testing.T) {
+	aTime := time.Date(2020, 1, 1, 12, 30, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		frameToSort *Frame
+		afterSort   *Frame
+	}{
+		{
+			name: "wide frame with names only",
+			frameToSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("bValue", nil, []float64{5}),
+				NewField("aValue", nil, []float64{1}),
+			),
+			afterSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", nil, []float64{1}),
+				NewField("bValue", nil, []float64{5}),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sortWideFrameFields(tt.frameToSort)
+			require.NoError(t, err)
+			if diff := cmp.Diff(tt.frameToSort, tt.afterSort, FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+}

--- a/data/time_series_test.go
+++ b/data/time_series_test.go
@@ -197,13 +197,13 @@ func TestLongToWide(t *testing.T) {
 					1.0,
 					3.0,
 				}),
-				data.NewField(`Values Int64`, data.Labels{"Animal Factor": "cat"}, []int64{
-					1,
-					3,
-				}),
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth"}, []float64{
 					2.0,
 					4.0,
+				}),
+				data.NewField(`Values Int64`, data.Labels{"Animal Factor": "cat"}, []int64{
+					1,
+					3,
 				}),
 				data.NewField(`Values Int64`, data.Labels{"Animal Factor": "sloth"}, []int64{
 					2,
@@ -254,13 +254,13 @@ func TestLongToWide(t *testing.T) {
 					1.0,
 					3.0,
 				}),
-				data.NewField(`Values Int64`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []int64{
-					1,
-					3,
-				}),
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []float64{
 					2.0,
 					4.0,
+				}),
+				data.NewField(`Values Int64`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []int64{
+					1,
+					3,
 				}),
 				data.NewField(`Values Int64`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []int64{
 					2,
@@ -355,18 +355,19 @@ func TestLongToWide(t *testing.T) {
 					0.0,
 					0.0,
 				}),
-				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []float64{
-					2.0,
-					4.0,
-					0.0,
-					6.0,
-				}),
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []float64{
 					0.0,
 					0.0,
 					55.0,
 					0.0,
+				}),
+				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []float64{
+					2.0,
+					4.0,
+					0.0,
+					6.0,
 				})),
+
 			Err: require.NoError,
 		},
 		{
@@ -419,17 +420,17 @@ func TestLongToWide(t *testing.T) {
 					nil,
 					nil,
 				}),
-				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*float64{
-					float64Ptr(2.0),
-					float64Ptr(4.0),
-					nil,
-					float64Ptr(6.0),
-				}),
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*float64{
 					nil,
 					nil,
 					float64Ptr(55.0),
 					nil,
+				}),
+				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*float64{
+					float64Ptr(2.0),
+					float64Ptr(4.0),
+					nil,
+					float64Ptr(6.0),
 				})),
 			Err: require.NoError,
 		},
@@ -494,11 +495,11 @@ func TestLongToWide(t *testing.T) {
 					-1.0,
 					-1.0,
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []int64{
-					1,
-					3,
-					-1,
-					-1,
+				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []float64{
+					-1.0,
+					-1.0,
+					55.0,
+					-1.0,
 				}),
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []float64{
 					2.0,
@@ -506,23 +507,23 @@ func TestLongToWide(t *testing.T) {
 					-1.0,
 					6.0,
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []int64{
-					2,
-					4,
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []int64{
+					1,
+					3,
 					-1,
-					6,
-				}),
-				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []float64{
-					-1.0,
-					-1.0,
-					55.0,
-					-1.0,
+					-1,
 				}),
 				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []int64{
 					-1,
 					-1,
 					55,
 					-1,
+				}),
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []int64{
+					2,
+					4,
+					-1,
+					6,
 				}),
 			),
 			Err: require.NoError,
@@ -588,11 +589,11 @@ func TestLongToWide(t *testing.T) {
 					float64Ptr(3.0),
 					float64Ptr(3.0),
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []*int64{
-					int64Ptr(1),
-					int64Ptr(3),
-					int64Ptr(3),
-					int64Ptr(3),
+				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*float64{
+					nil,
+					nil,
+					float64Ptr(55.0),
+					float64Ptr(55.0),
 				}),
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*float64{
 					float64Ptr(2.0),
@@ -600,23 +601,23 @@ func TestLongToWide(t *testing.T) {
 					float64Ptr(4.0),
 					float64Ptr(6.0),
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*int64{
-					int64Ptr(2),
-					int64Ptr(4),
-					int64Ptr(4),
-					int64Ptr(6),
-				}),
-				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*float64{
-					nil,
-					nil,
-					float64Ptr(55.0),
-					float64Ptr(55.0),
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []*int64{
+					int64Ptr(1),
+					int64Ptr(3),
+					int64Ptr(3),
+					int64Ptr(3),
 				}),
 				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*int64{
 					nil,
 					nil,
 					int64Ptr(55),
 					int64Ptr(55),
+				}),
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*int64{
+					int64Ptr(2),
+					int64Ptr(4),
+					int64Ptr(4),
+					int64Ptr(6),
 				}),
 			),
 			Err: require.NoError,
@@ -682,10 +683,10 @@ func TestLongToWide(t *testing.T) {
 					nil,
 					nil,
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []*int64{
-					int64Ptr(1),
-					int64Ptr(3),
+				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*float64{
 					nil,
+					nil,
+					float64Ptr(55.0),
 					nil,
 				}),
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*float64{
@@ -694,16 +695,10 @@ func TestLongToWide(t *testing.T) {
 					nil,
 					float64Ptr(6.0),
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*int64{
-					int64Ptr(2),
-					int64Ptr(4),
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []*int64{
+					int64Ptr(1),
+					int64Ptr(3),
 					nil,
-					int64Ptr(6),
-				}),
-				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*float64{
-					nil,
-					nil,
-					float64Ptr(55.0),
 					nil,
 				}),
 				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*int64{
@@ -711,6 +706,12 @@ func TestLongToWide(t *testing.T) {
 					nil,
 					int64Ptr(55),
 					nil,
+				}),
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*int64{
+					int64Ptr(2),
+					int64Ptr(4),
+					nil,
+					int64Ptr(6),
 				}),
 			),
 			Err: require.NoError,
@@ -776,11 +777,11 @@ func TestLongToWide(t *testing.T) {
 					float64Ptr(-1.0),
 					float64Ptr(-1.0),
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []*int64{
-					int64Ptr(1),
-					int64Ptr(3),
-					int64Ptr(-1),
-					int64Ptr(-1),
+				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*float64{
+					float64Ptr(-1.0),
+					float64Ptr(-1.0),
+					float64Ptr(55.0),
+					float64Ptr(-1.0),
 				}),
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*float64{
 					float64Ptr(2.0),
@@ -788,23 +789,23 @@ func TestLongToWide(t *testing.T) {
 					float64Ptr(-1.0),
 					float64Ptr(6.0),
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*int64{
-					int64Ptr(2),
-					int64Ptr(4),
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []*int64{
+					int64Ptr(1),
+					int64Ptr(3),
 					int64Ptr(-1),
-					int64Ptr(6),
-				}),
-				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*float64{
-					float64Ptr(-1.0),
-					float64Ptr(-1.0),
-					float64Ptr(55.0),
-					float64Ptr(-1.0),
+					int64Ptr(-1),
 				}),
 				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*int64{
 					int64Ptr(-1),
 					int64Ptr(-1),
 					int64Ptr(55),
 					int64Ptr(-1),
+				}),
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*int64{
+					int64Ptr(2),
+					int64Ptr(4),
+					int64Ptr(-1),
+					int64Ptr(6),
 				}),
 			),
 			Err: require.NoError,
@@ -869,11 +870,11 @@ func TestLongToWide(t *testing.T) {
 					float64Ptr(3.0),
 					float64Ptr(3.0),
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []*int64{
-					int64Ptr(1),
-					int64Ptr(3),
-					int64Ptr(3),
-					int64Ptr(3),
+				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*float64{
+					nil,
+					nil,
+					float64Ptr(55.0),
+					float64Ptr(55.0),
 				}),
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*float64{
 					float64Ptr(2.0),
@@ -881,23 +882,23 @@ func TestLongToWide(t *testing.T) {
 					float64Ptr(4.0),
 					float64Ptr(6.0),
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*int64{
-					int64Ptr(2),
-					int64Ptr(4),
-					int64Ptr(4),
-					int64Ptr(6),
-				}),
-				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*float64{
-					nil,
-					nil,
-					float64Ptr(55.0),
-					float64Ptr(55.0),
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []*int64{
+					int64Ptr(1),
+					int64Ptr(3),
+					int64Ptr(3),
+					int64Ptr(3),
 				}),
 				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*int64{
 					nil,
 					nil,
 					int64Ptr(55),
 					int64Ptr(55),
+				}),
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*int64{
+					int64Ptr(2),
+					int64Ptr(4),
+					int64Ptr(4),
+					int64Ptr(6),
 				}),
 			),
 			Err: require.NoError,
@@ -962,10 +963,10 @@ func TestLongToWide(t *testing.T) {
 					nil,
 					nil,
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []*int64{
-					int64Ptr(1),
-					int64Ptr(3),
+				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*float64{
 					nil,
+					nil,
+					float64Ptr(55.0),
 					nil,
 				}),
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*float64{
@@ -974,16 +975,10 @@ func TestLongToWide(t *testing.T) {
 					nil,
 					float64Ptr(6.0),
 				}),
-				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*int64{
-					int64Ptr(2.0),
-					int64Ptr(4.0),
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "cat", "Location": "Florida"}, []*int64{
+					int64Ptr(1),
+					int64Ptr(3),
 					nil,
-					int64Ptr(6.0),
-				}),
-				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*float64{
-					nil,
-					nil,
-					float64Ptr(55.0),
 					nil,
 				}),
 				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "pangolin", "Location": ""}, []*int64{
@@ -991,6 +986,12 @@ func TestLongToWide(t *testing.T) {
 					nil,
 					int64Ptr(55),
 					nil,
+				}),
+				data.NewField(`Values Ints`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []*int64{
+					int64Ptr(2.0),
+					int64Ptr(4.0),
+					nil,
+					int64Ptr(6.0),
 				}),
 			),
 			Err: require.NoError,
@@ -1381,4 +1382,3 @@ func TestFloatAt(t *testing.T) {
 		t.Errorf("Result mismatch (-want +got):\n%s", diff)
 	}
 }
-

--- a/data/time_series_test.go
+++ b/data/time_series_test.go
@@ -1381,3 +1381,4 @@ func TestFloatAt(t *testing.T) {
 		t.Errorf("Result mismatch (-want +got):\n%s", diff)
 	}
 }
+

--- a/data/vector.go
+++ b/data/vector.go
@@ -524,7 +524,7 @@ func (p FieldType) Nullable() bool {
 	return false
 }
 
-// Numeric returns if Field type is a nullable type
+// Numeric returns if Field type is a nullable type.
 func (p FieldType) Numeric() bool {
 	switch p {
 	case FieldTypeInt8, FieldTypeInt16, FieldTypeInt32, FieldTypeInt64:
@@ -543,6 +543,11 @@ func (p FieldType) Numeric() bool {
 		return true
 	}
 	return false
+}
+
+// Time returns if Field type is a time type (FieldTypeTime or FieldTypeNullableTime).
+func (p FieldType) Time() bool {
+	return p == FieldTypeTime || p == FieldTypeNullableTime
 }
 
 // numericFieldTypes is an array of FieldTypes that are numeric.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.14
 require (
 	github.com/apache/arrow/go/arrow v0.0.0-20200629181129-68b1273cbbf7
 	github.com/cheekybits/genny v1.0.0
-	github.com/davecgh/go-spew v1.1.1
 	github.com/golang/protobuf v1.3.4
 	github.com/google/go-cmp v0.3.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/apache/arrow/go/arrow v0.0.0-20200629181129-68b1273cbbf7
 	github.com/cheekybits/genny v1.0.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/golang/protobuf v1.3.4
 	github.com/google/go-cmp v0.3.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0


### PR DESCRIPTION
If things are not sorted, than depending on the nature of the data, when it changes the default coloring in a Grafana series graph will change.

This is for issues like https://github.com/grafana/grafana/issues/22937 

This only applies to the single wide frame time series model.

A similar thing will need to be done for Frames to handle the other common time series case of multiple frames, with a Frame each having one time and one value column like https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/data?tab=doc#example-Frame-TSDBTimeSeriesDifferentTimeIndices 

This is called now when LongToWide to use. In the cited issue (insights metrics), it is actually building a wide frame, so this exported as in that case it will be called without LongToWide.

Also adds the following for https://github.com/grafana/grafana-plugin-sdk-go/issues/194:

```
// Time returns if Field type is a time type (FieldTypeTime or FieldTypeNullableTime).
func (p FieldType) Time() bool {
	return p == FieldTypeTime || p == FieldTypeNullableTime
}
```