### PR TITLE
data: provide keys for wide frame series field sort

### DIFF
--- a/data/time_series.go
+++ b/data/time_series.go
@@ -226,6 +226,11 @@ func LongToWide(longFrame *Frame, fillMissing *FillMissing) (*Frame, error) {
 		valueFactorToWideFieldIdx[i] = make(map[string]int)
 	}
 
+	sortKeys := make([]string, len(tsSchema.FactorIndices))
+	for i, v := range tsSchema.FactorIndices { // set dimension key order for final sort
+		sortKeys[i] = longFrame.Fields[v].Name
+	}
+
 	timeAt := func(idx int) (time.Time, error) { // get time.Time regardless if pointer
 		val, ok := longFrame.ConcreteAt(tsSchema.TimeIndex, idx)
 		if !ok {
@@ -321,10 +326,12 @@ func LongToWide(longFrame *Frame, fillMissing *FillMissing) (*Frame, error) {
 			wideFrame.Set(wideFieldIdx, wideFrameRowCounter, longFrame.CopyAt(longFieldIdx, longRowIdx))
 		}
 	}
-	err = SortWideFrameFields(wideFrame)
+
+	err = SortWideFrameFields(wideFrame, sortKeys...)
 	if err != nil {
 		return nil, err
 	}
+
 	return wideFrame, nil
 }
 

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -537,7 +537,7 @@ func SortWideFrameFields(frame *Frame, keys ...string) error {
 		return fmt.Errorf("field sorting for a wide time series frame called on a series that is not a wide frame")
 	}
 
-	// Capture and remove the time index, will be preprended again after sort
+	// Capture and remove the time index, will be prepended again after sort
 	timeIndexField := frame.Fields[tsSchema.TimeIndex]
 	frame.Fields[len(frame.Fields)-1], frame.Fields[tsSchema.TimeIndex] = frame.Fields[tsSchema.TimeIndex], (frame.Fields)[len(frame.Fields)-1]
 	frame.Fields = frame.Fields[:len(frame.Fields)-1]

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -573,8 +573,8 @@ func SortWideFrameFields(frame *Frame, keys ...string) error {
 		// Sort on specified
 		for _, k := range keys {
 			// If the specified key is missing, we sort as if it is was there with the default value of "".
-			iV, _ := iField.Labels[k]
-			jV, _ := jField.Labels[k]
+			iV := iField.Labels[k]
+			jV := jField.Labels[k]
 
 			if iV < jV {
 				return true
@@ -585,7 +585,6 @@ func SortWideFrameFields(frame *Frame, keys ...string) error {
 		}
 
 		return false
-
 	})
 
 	// restore the time index back as the first field

--- a/data/time_series_field_sort_test.go
+++ b/data/time_series_field_sort_test.go
@@ -11,9 +11,10 @@ import (
 func TestSortWideFrameFields(t *testing.T) {
 	aTime := time.Date(2020, 1, 1, 12, 30, 0, 0, time.UTC)
 	tests := []struct {
-		name        string
-		frameToSort *Frame
-		afterSort   *Frame
+		name          string
+		sortLabelKeys []string
+		frameToSort   *Frame
+		afterSort     *Frame
 	}{
 		{
 			name: "wide frame with names pass through",
@@ -39,6 +40,19 @@ func TestSortWideFrameFields(t *testing.T) {
 				NewField("time", nil, []time.Time{aTime}),
 				NewField("aValue", nil, []float64{1}),
 				NewField("bValue", nil, []float64{5}),
+			),
+		},
+		{
+			name: "wide frame with empty names and labels",
+			frameToSort: NewFrame("",
+				NewField("", nil, []time.Time{aTime}),
+				NewField("", Labels{"host": "b"}, []float64{5}),
+				NewField("", Labels{"host": "a"}, []float64{1}),
+			),
+			afterSort: NewFrame("",
+				NewField("", nil, []time.Time{aTime}),
+				NewField("", Labels{"host": "a"}, []float64{1}),
+				NewField("", Labels{"host": "b"}, []float64{5}),
 			),
 		},
 		{
@@ -82,13 +96,121 @@ func TestSortWideFrameFields(t *testing.T) {
 				NewField("aValue", Labels{"host": "b", "int": "eth0"}, []float64{5}),
 			),
 		},
+		{
+			name:          "wide frame with labels and one metric name - specifying sort keys",
+			sortLabelKeys: []string{"node", "int"},
+			frameToSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", Labels{"node": "b", "int": "eth0"}, []float64{5}),
+				NewField("aValue", Labels{"node": "a", "int": "eth1"}, []float64{3}),
+				NewField("aValue", Labels{"node": "a", "int": "eth0"}, []float64{1}),
+			),
+			afterSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", Labels{"node": "a", "int": "eth0"}, []float64{1}),
+				NewField("aValue", Labels{"node": "a", "int": "eth1"}, []float64{3}),
+				NewField("aValue", Labels{"node": "b", "int": "eth0"}, []float64{5}),
+			),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := SortWideFrameFields(tt.frameToSort)
+			err := SortWideFrameFields(tt.frameToSort, tt.sortLabelKeys...)
 			require.NoError(t, err)
 			if diff := cmp.Diff(tt.frameToSort, tt.afterSort, FrameTestCompareOptions()...); diff != "" {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+				t.Logf(tt.frameToSort.StringTable(-1, -1))
+			}
+		})
+	}
+}
+
+func TestSortWideFrameFields_MixedLabels(t *testing.T) {
+	aTime := time.Date(2020, 1, 1, 12, 30, 0, 0, time.UTC)
+	tests := []struct {
+		name          string
+		sortLabelKeys []string
+		frameToSort   *Frame
+		afterSort     *Frame
+	}{
+		{
+			name:          "wide frame with and one metric name - specifying sort keys",
+			sortLabelKeys: []string{"node", "int"},
+			frameToSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", Labels{"node": "b", "int": "eth0"}, []float64{5}),
+				NewField("aValue", Labels{"node": "a", "int": "eth1"}, []float64{3}),
+				NewField("aValue", Labels{"node": "c"}, []float64{7}),
+				NewField("aValue", Labels{"node": "a"}, []float64{1}),
+			),
+			afterSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", Labels{"node": "a"}, []float64{1}),
+				NewField("aValue", Labels{"node": "a", "int": "eth1"}, []float64{3}),
+				NewField("aValue", Labels{"node": "b", "int": "eth0"}, []float64{5}),
+				NewField("aValue", Labels{"node": "c"}, []float64{7}),
+			),
+		},
+		{
+			name:          "specifying sort keys when some labels are nil",
+			sortLabelKeys: []string{"node", "int"},
+			frameToSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", Labels{"node": "b", "int": "eth0"}, []float64{5}),
+				NewField("aValue", Labels{"node": "a", "int": "eth1"}, []float64{3}),
+				NewField("aValue", Labels{"node": "c"}, []float64{7}),
+				NewField("aValue", nil, []float64{1}),
+			),
+			afterSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", nil, []float64{1}),
+				NewField("aValue", Labels{"node": "a", "int": "eth1"}, []float64{3}),
+				NewField("aValue", Labels{"node": "b", "int": "eth0"}, []float64{5}),
+				NewField("aValue", Labels{"node": "c"}, []float64{7}),
+			),
+		},
+		{
+			name:          "wide frame with mixed labels and one metric name - specifying some sort keys",
+			sortLabelKeys: []string{"node"},
+			frameToSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", Labels{"node": "b", "int": "eth0"}, []float64{5}),
+				NewField("aValue", Labels{"node": "a", "int": "eth1"}, []float64{3}),
+				NewField("aValue", Labels{"node": "a"}, []float64{1}),
+				NewField("aValue", Labels{"node": "c"}, []float64{7}),
+			),
+			afterSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", Labels{"node": "a", "int": "eth1"}, []float64{3}),
+				NewField("aValue", Labels{"node": "a"}, []float64{1}),
+				NewField("aValue", Labels{"node": "b", "int": "eth0"}, []float64{5}),
+				NewField("aValue", Labels{"node": "c"}, []float64{7}),
+			),
+		},
+		{
+			name:          "wide frame with mixed labels and one metric name - specifying some sort keys (other from above)",
+			sortLabelKeys: []string{"int"},
+			frameToSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", Labels{"int": "eth0", "node": "b"}, []float64{5}),
+				NewField("aValue", Labels{"int": "eth1", "node": "a"}, []float64{3}),
+				NewField("aValue", Labels{"node": "b"}, []float64{1}),
+			),
+			afterSort: NewFrame("",
+				NewField("time", nil, []time.Time{aTime}),
+				NewField("aValue", Labels{"node": "b"}, []float64{1}),
+				NewField("aValue", Labels{"int": "eth0", "node": "b"}, []float64{5}),
+				NewField("aValue", Labels{"int": "eth1", "node": "a"}, []float64{3}),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := SortWideFrameFields(tt.frameToSort, tt.sortLabelKeys...)
+			require.NoError(t, err)
+			if diff := cmp.Diff(tt.frameToSort, tt.afterSort, FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+				t.Logf(tt.frameToSort.StringTable(-1, -1))
 			}
 		})
 	}


### PR DESCRIPTION
For the reasons stated in https://github.com/grafana/grafana/pull/26207#issuecomment-656315046 , would like sort order to be able to be order based on the label keys.

This aims to do that, and using these changes with Grafana, the results are now sorting more how I think users would like.

**Special notes for your reviewer**:

Follow up on https://github.com/grafana/grafana-plugin-sdk-go/pull/198