### PR TITLE
data: check field length in MarshalArrow

### DIFF
--- a/data/arrow.go
+++ b/data/arrow.go
@@ -16,7 +16,12 @@ import (
 
 // MarshalArrow converts the Frame to an arrow table and returns a byte
 // representation of that table.
+// All fields of a Frame must be of the same length or an error is returned.
 func (f *Frame) MarshalArrow() ([]byte, error) {
+	if _, err := f.RowLen(); err != nil {
+		return nil, err
+	}
+
 	arrowFields, err := buildArrowFields(f)
 	if err != nil {
 		return nil, err

--- a/data/arrow_test.go
+++ b/data/arrow_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/require"
 )
 
 var update = flag.Bool("update", false, "update .golden.arrow files")
@@ -298,4 +299,13 @@ func TestEncodeAndDecodeDuplicateFieldNames(t *testing.T) {
 	if diff := cmp.Diff(frame, decoded, data.FrameTestCompareOptions()...); diff != "" {
 		t.Errorf("Result mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func TestMarshalArrowRowLenError(t *testing.T) {
+	f := data.NewFrame("unequal length fields",
+		data.NewField("1", nil, []string{}),
+		data.NewField("1", nil, []string{"a"}),
+	)
+	_, err := f.MarshalArrow()
+	require.Error(t, err)
 }

--- a/data/arrow_test.go
+++ b/data/arrow_test.go
@@ -301,11 +301,17 @@ func TestEncodeAndDecodeDuplicateFieldNames(t *testing.T) {
 	}
 }
 
-func TestMarshalArrowRowLenError(t *testing.T) {
+func TestFrameMarshalArrowRowLenError(t *testing.T) {
 	f := data.NewFrame("unequal length fields",
 		data.NewField("1", nil, []string{}),
 		data.NewField("1", nil, []string{"a"}),
 	)
 	_, err := f.MarshalArrow()
 	require.Error(t, err)
+}
+
+func TestFrameMarshalArrowNoFields(t *testing.T) {
+	f := data.NewFrame("no fields")
+	_, err := f.MarshalArrow()
+	require.NoError(t, err)
 }

--- a/data/frame.go
+++ b/data/frame.go
@@ -237,15 +237,13 @@ func (f *Frame) ConcreteAt(fieldIdx int, rowIdx int) (val interface{}, ok bool) 
 
 // RowLen returns the the length of the Frame Fields.
 // If the Length of all the Fields is not the same then error is returned.
-// If the Frame's Fields are nil an error is returned.
 func (f *Frame) RowLen() (int, error) {
-	if f.Fields == nil || len(f.Fields) == 0 {
-		return 0, fmt.Errorf("frame's fields are nil or of zero length")
+	if len(f.Fields) == 0 {
+		return 0, nil
 	}
-
 	var l int
 	for i := 0; i < len(f.Fields); i++ {
-		if f.Fields[i].vector == nil {
+		if f.Fields[i] == nil || f.Fields[i].vector == nil {
 			return 0, fmt.Errorf("frame's field at index %v is nil", i)
 		}
 		if i == 0 {


### PR DESCRIPTION
check the row length inside Frame's MarshalArrow method before building the arrow frame to error instead of panicing.

fixes #203