### PR TITLE
Chore: Switch from GoDoc to Go.dev link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This SDK enables building [Grafana](https://github.com/grafana/grafana) backend plugins using Go.
 
 [![License](https://img.shields.io/github/license/grafana/grafana-plugin-sdk-go)](LICENSE)
-[![GoDoc](https://godoc.org/github.com/grafana/grafana-plugin-sdk-go?status.svg)](https://godoc.org/github.com/grafana/grafana-plugin-sdk-go)
+[![Go.dev](https://pkg.go.dev/badge/github.com/grafana/grafana-plugin-sdk-go)](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go?tab=doc)
 [![Go Report Card](https://goreportcard.com/badge/github.com/grafana/grafana-plugin-sdk-go)](https://goreportcard.com/report/github.com/grafana/grafana-plugin-sdk-go)
 [![Circle CI](https://img.shields.io/circleci/build/gh/grafana/grafana-plugin-sdk-go/master)](https://circleci.com/gh/grafana/grafana-plugin-sdk-go?branch=master)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch from GoDoc to the new Go.dev site in the README, since it's the replacement.