### PR TITLE
Converters: add common converters to SDK

### DIFF
--- a/data/conversion_input.go
+++ b/data/conversion_input.go
@@ -1,7 +1,5 @@
 package data
 
-import "fmt"
-
 // FrameInputConverter is a type to support building a Frame while also
 // doing conversion as data is added to the Frame.
 type FrameInputConverter struct {
@@ -57,15 +55,4 @@ func (fic *FrameInputConverter) Set(fieldIdx, rowIdx int, val interface{}) error
 	}
 	fic.Frame.Set(fieldIdx, rowIdx, convertedVal)
 	return nil
-}
-
-var asStringConverter Converter = func(v interface{}) (interface{}, error) {
-	return fmt.Sprintf("%v", v), nil
-}
-
-// AsStringFieldConverter will always return a string a regardless of the input.
-// This is done with fmt.Sprintf which uses reflection.
-var AsStringFieldConverter = FieldConverter{
-	OutputFieldType: FieldTypeString,
-	Converter:       asStringConverter,
 }

--- a/data/conversion_input_test.go
+++ b/data/conversion_input_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	conv "github.com/grafana/grafana-plugin-sdk-go/data/converters"
 )
 
 func ExampleNewFrameInputConverter() {
@@ -75,7 +76,7 @@ func ExampleNewFrameInputConverter() {
 	for i, cType := range inputData.ColumnTypes {
 		fc, ok := converterMap[cType]
 		if !ok {
-			fc = data.AsStringFieldConverter
+			fc = conv.AnyToString
 		}
 		converters[i] = fc
 	}

--- a/data/converters/converters.go
+++ b/data/converters/converters.go
@@ -1,0 +1,194 @@
+package converters
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+// Int64NOOP .....
+var Int64NOOP = data.FieldConverter{
+	OutputFieldType: data.FieldTypeInt64,
+}
+
+// BoolNOOP .....
+var BoolNOOP = data.FieldConverter{
+	OutputFieldType: data.FieldTypeBool,
+}
+
+// Float64NOOP .....
+var Float64NOOP = data.FieldConverter{
+	OutputFieldType: data.FieldTypeFloat64,
+}
+
+// StringNOOP value is already in the proper format
+var StringNOOP = data.FieldConverter{
+	OutputFieldType: data.FieldTypeString,
+}
+
+// AnyToOptionalString any value as a string
+var AnyToOptionalString = data.FieldConverter{
+	OutputFieldType: data.FieldTypeNullableString,
+	Converter: func(v interface{}) (interface{}, error) {
+		if v == nil {
+			return nil, nil
+		}
+		str := fmt.Sprintf("%+v", v) // the +v adds field names
+		return &str, nil
+	},
+}
+
+// AnyToString any value as a string
+var AnyToString = data.FieldConverter{
+	OutputFieldType: data.FieldTypeString,
+	Converter: func(v interface{}) (interface{}, error) {
+		if v == nil {
+			return nil, nil
+		}
+		return fmt.Sprintf("%+v", v), nil // the +v adds field names
+	},
+}
+
+// Float64ToOptionalFloat64 optional float value
+var Float64ToOptionalFloat64 = data.FieldConverter{
+	OutputFieldType: data.FieldTypeNullableFloat64,
+	Converter: func(v interface{}) (interface{}, error) {
+		if v == nil {
+			return nil, nil
+		}
+		val, ok := v.(float64)
+		if !ok { // or return some default value instead of erroring
+			return nil, fmt.Errorf("[float] expected float64 input but got type %T", v)
+		}
+		return &val, nil
+	},
+}
+
+// Int64ToOptionalInt64 optional int value
+var Int64ToOptionalInt64 = data.FieldConverter{
+	OutputFieldType: data.FieldTypeNullableInt64,
+	Converter: func(v interface{}) (interface{}, error) {
+		if v == nil {
+			return nil, nil
+		}
+		val, ok := v.(int64)
+		if !ok { // or return some default value instead of erroring
+			return nil, fmt.Errorf("[int] expected int64 input but got type %T", v)
+		}
+		return &val, nil
+	},
+}
+
+// UInt64ToOptionalUInt64 optional int value
+var UInt64ToOptionalUInt64 = data.FieldConverter{
+	OutputFieldType: data.FieldTypeNullableUint64,
+	Converter: func(v interface{}) (interface{}, error) {
+		if v == nil {
+			return nil, nil
+		}
+		val, ok := v.(uint64)
+		if !ok { // or return some default value instead of erroring
+			return nil, fmt.Errorf("[uint] expected uint64 input but got type %T", v)
+		}
+		return &val, nil
+	},
+}
+
+// BoolToOptionalBool optional int value
+var BoolToOptionalBool = data.FieldConverter{
+	OutputFieldType: data.FieldTypeNullableBool,
+	Converter: func(v interface{}) (interface{}, error) {
+		if v == nil {
+			return nil, nil
+		}
+		val, ok := v.(bool)
+		if !ok { // or return some default value instead of erroring
+			return nil, fmt.Errorf("[bool] expected bool input but got type %T", v)
+		}
+		return &val, nil
+	},
+}
+
+// TimeToOptionalTime optional int value
+var TimeToOptionalTime = data.FieldConverter{
+	OutputFieldType: data.FieldTypeNullableTime,
+	Converter: func(v interface{}) (interface{}, error) {
+		if v == nil {
+			return nil, nil
+		}
+		val, ok := v.(time.Time)
+		if !ok { // or return some default value instead of erroring
+			return nil, fmt.Errorf("[time] expected time input but got type %T", v)
+		}
+		return &val, nil
+	},
+}
+
+// RFC3339StringToNullableTime .....
+func RFC3339StringToNullableTime(s string) (*time.Time, error) {
+	if s == "" {
+		return nil, nil
+	}
+
+	rv, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil, err
+	}
+
+	u := rv.UTC()
+	return &u, nil
+}
+
+// StringToOptionalFloat64 string to float
+var StringToOptionalFloat64 = data.FieldConverter{
+	OutputFieldType: data.FieldTypeNullableFloat64,
+	Converter: func(v interface{}) (interface{}, error) {
+		if v == nil {
+			return nil, nil
+		}
+		val, ok := v.(string)
+		if !ok { // or return some default value instead of erroring
+			return nil, fmt.Errorf("[floatz] expected string input but got type %T", v)
+		}
+		fV, err := strconv.ParseFloat(val, 64)
+		return &fV, err
+	},
+}
+
+// Float64EpochSecondsToTime  numeric seconds to time
+var Float64EpochSecondsToTime = data.FieldConverter{
+	OutputFieldType: data.FieldTypeTime,
+	Converter: func(v interface{}) (interface{}, error) {
+		fV, ok := v.(float64)
+		if !ok { // or return some default value instead of erroring
+			return nil, fmt.Errorf("[seconds] expected float64 input but got type %T", v)
+		}
+		return time.Unix(int64(fV), 0).UTC(), nil
+	},
+}
+
+// Float64EpochMillisToTime convert to time
+var Float64EpochMillisToTime = data.FieldConverter{
+	OutputFieldType: data.FieldTypeTime,
+	Converter: func(v interface{}) (interface{}, error) {
+		fV, ok := v.(float64)
+		if !ok { // or return some default value instead of erroring
+			return nil, fmt.Errorf("[ms] expected float64 input but got type %T", v)
+		}
+		return time.Unix(0, int64(fV)*int64(time.Millisecond)).UTC(), nil
+	},
+}
+
+// Boolean ...
+var Boolean = data.FieldConverter{
+	OutputFieldType: data.FieldTypeBool,
+	Converter: func(v interface{}) (interface{}, error) {
+		fV, ok := v.(bool)
+		if !ok { // or return some default value instead of erroring
+			return nil, fmt.Errorf("[ms] expected bool input but got type %T", v)
+		}
+		return fV, nil
+	},
+}

--- a/data/converters/converters_test.go
+++ b/data/converters/converters_test.go
@@ -1,0 +1,24 @@
+package converters_test
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data/converters"
+	"github.com/stretchr/testify/require"
+)
+
+func CheckStringConversions(t *testing.T) {
+	val, err := converters.AnyToOptionalString.Converter(12.3)
+	require.Nil(t, err)
+	require.Equal(t, "12.3", val)
+
+	val, err = converters.AnyToOptionalString.Converter(nil)
+	require.Nil(t, err)
+	require.Nil(t, val)
+}
+
+func CheckNumericConversions(t *testing.T) {
+	val, err := converters.Float64ToOptionalFloat64.Converter(12.34)
+	require.Nil(t, err)
+	require.Equal(t, 12.34, val)
+}


### PR DESCRIPTION
This takes a growing set of converters that have been coppied to each plugin and adds them to the SDK.

If the structure looks OK, I'll add better tests

See also:
https://github.com/grafana/grafana/blob/master/pkg/tsdb/influxdb/flux/converters.go

Ideally this has its own package so that autocomplete works with `converters.XyzToAbc`