### PR TITLE
dataframe sorter

### DIFF
--- a/experimental/frame_sorter.go
+++ b/experimental/frame_sorter.go
@@ -23,15 +23,16 @@ func (fs FrameSorter) Swap(i, j int) {
 	}
 }
 func (fs FrameSorter) Less(i, j int) bool {
-	if fs.sortField.Type() == data.FieldTypeString {
+	switch kind := fs.sortField.Type(); kind {
+	case data.FieldTypeString:
 		valA := fs.sortField.At(i).(string)
 		valB := fs.sortField.At(j).(string)
 		return valA < valB
-	} else if fs.sortField.Type() == data.FieldTypeNullableString {
+	case data.FieldTypeNullableString:
 		valA := fs.sortField.At(i).(*string)
 		valB := fs.sortField.At(j).(*string)
 		return *valA < *valB
-	} else {
+	default:
 		valA, err := fs.sortField.FloatAt(i)
 		if err != nil {
 			return false

--- a/experimental/frame_sorter.go
+++ b/experimental/frame_sorter.go
@@ -2,18 +2,19 @@ package experimental
 
 import "github.com/grafana/grafana-plugin-sdk-go/data"
 
-// NewFrameSorter - returns a new frameSorter
+// NewFrameSorter returns a new frameSorter.
 func NewFrameSorter(frame *data.Frame, sortField *data.Field) FrameSorter {
 	return FrameSorter{frame, sortField}
 }
 
-// FrameSorter - sort a DataFrame by field
+// FrameSorter sorts a DataFrame by field.
 type FrameSorter struct {
 	frame     *data.Frame
 	sortField *data.Field
 }
 
 func (fs FrameSorter) Len() int { return fs.frame.Rows() }
+
 func (fs FrameSorter) Swap(i, j int) {
 	for _, field := range fs.frame.Fields {
 		valA := field.At(i)
@@ -22,6 +23,7 @@ func (fs FrameSorter) Swap(i, j int) {
 		field.Set(i, valB)
 	}
 }
+
 func (fs FrameSorter) Less(i, j int) bool {
 	switch kind := fs.sortField.Type(); kind {
 	case data.FieldTypeString:

--- a/experimental/frame_sorter.go
+++ b/experimental/frame_sorter.go
@@ -1,0 +1,45 @@
+package experimental
+
+import "github.com/grafana/grafana-plugin-sdk-go/data"
+
+// NewFrameSorter - returns a new frameSorter
+func NewFrameSorter(frame *data.Frame, sortField *data.Field) FrameSorter {
+	return FrameSorter{frame, sortField}
+}
+
+// FrameSorter - sort a DataFrame by field
+type FrameSorter struct {
+	frame     *data.Frame
+	sortField *data.Field
+}
+
+func (fs FrameSorter) Len() int { return fs.frame.Rows() }
+func (fs FrameSorter) Swap(i, j int) {
+	for _, field := range fs.frame.Fields {
+		valA := field.At(i)
+		valB := field.At(j)
+		field.Set(j, valA)
+		field.Set(i, valB)
+	}
+}
+func (fs FrameSorter) Less(i, j int) bool {
+	if fs.sortField.Type() == data.FieldTypeString {
+		valA := fs.sortField.At(i).(string)
+		valB := fs.sortField.At(j).(string)
+		return valA < valB
+	} else if fs.sortField.Type() == data.FieldTypeNullableString {
+		valA := fs.sortField.At(i).(*string)
+		valB := fs.sortField.At(j).(*string)
+		return *valA < *valB
+	} else {
+		valA, err := fs.sortField.FloatAt(i)
+		if err != nil {
+			return false
+		}
+		valB, err := fs.sortField.FloatAt(j)
+		if err != nil {
+			return true
+		}
+		return valA < valB
+	}
+}

--- a/experimental/frame_sorter.go
+++ b/experimental/frame_sorter.go
@@ -31,6 +31,12 @@ func (fs FrameSorter) Less(i, j int) bool {
 	case data.FieldTypeNullableString:
 		valA := fs.sortField.At(i).(*string)
 		valB := fs.sortField.At(j).(*string)
+		if valA == nil {
+			return false
+		}
+		if valB == nil {
+			return true
+		}
 		return *valA < *valB
 	default:
 		valA, err := fs.sortField.FloatAt(i)

--- a/experimental/frame_sorter_test.go
+++ b/experimental/frame_sorter_test.go
@@ -1,0 +1,33 @@
+package experimental
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+func TestFrameSorter(t *testing.T) {
+
+	field := data.NewField("Single float64", nil, []float64{
+		8.6, 8.7, 14.82, 10.07, 8.52,
+	}).SetConfig(&data.FieldConfig{Unit: "Percent"})
+
+	frame := data.NewFrame("Frame One",
+		field,
+	)
+
+	sorter := NewFrameSorter(frame, field)
+
+	sort.Sort(sorter)
+
+	val, err := frame.Fields[0].FloatAt(0)
+
+	if err != nil {
+		t.Error(err)
+	}
+	want := float64(8.52)
+	if val != want {
+		t.Errorf("Want %f Got %f", want, val)
+	}
+}

--- a/experimental/frame_sorter_test.go
+++ b/experimental/frame_sorter_test.go
@@ -24,8 +24,8 @@ func TestFrameSorter(t *testing.T) {
 
 	val, err := frame.Fields[0].FloatAt(0)
 	require.NoError(t, err)
-	want := float64(8.52)
 
+	want := float64(8.52)
 	assert.Equal(t, want, val)
 }
 
@@ -50,7 +50,7 @@ func TestFrameSorterLastNil(t *testing.T) {
 }
 
 func TestFrameSorterFirstNil(t *testing.T) {
-	value := "foo"
+	value := "test"
 	field := data.NewField("Foo", nil, []*string{
 		nil, &value,
 	})

--- a/experimental/frame_sorter_test.go
+++ b/experimental/frame_sorter_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFrameSorter(t *testing.T) {
@@ -44,10 +45,7 @@ func TestFrameSorterLastNil(t *testing.T) {
 
 	val, ok := frame.Fields[0].ConcreteAt(0)
 
-	if !ok {
-		t.Error("nil")
-	}
-
+	assert.True(t, ok)
 	assert.Equal(t, foo, val)
 }
 
@@ -67,9 +65,6 @@ func TestFrameSorterFirstNil(t *testing.T) {
 
 	val, ok := frame.Fields[0].ConcreteAt(0)
 
-	if !ok {
-		t.Error("nil")
-	}
-
+	assert.True(t, ok)
 	assert.Equal(t, value, val)
 }

--- a/experimental/frame_sorter_test.go
+++ b/experimental/frame_sorter_test.go
@@ -22,10 +22,7 @@ func TestFrameSorter(t *testing.T) {
 	sort.Sort(sorter)
 
 	val, err := frame.Fields[0].FloatAt(0)
-
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	want := float64(8.52)
 
 	assert.Equal(t, want, val)

--- a/experimental/frame_sorter_test.go
+++ b/experimental/frame_sorter_test.go
@@ -31,7 +31,7 @@ func TestFrameSorter(t *testing.T) {
 	assert.Equal(t, want, val)
 }
 
-func TestFrameSorterNil(t *testing.T) {
+func TestFrameSorterLastNil(t *testing.T) {
 	foo := "foo"
 	field := data.NewField("Foo", nil, []*string{
 		&foo, nil,
@@ -51,13 +51,13 @@ func TestFrameSorterNil(t *testing.T) {
 		t.Error("nil")
 	}
 
-	assert.Equal(t, "foo", val)
+	assert.Equal(t, foo, val)
 }
 
 func TestFrameSorterFirstNil(t *testing.T) {
-	foo := "foo"
+	value := "foo"
 	field := data.NewField("Foo", nil, []*string{
-		nil, &foo,
+		nil, &value,
 	})
 
 	frame := data.NewFrame("Frame One",
@@ -74,5 +74,5 @@ func TestFrameSorterFirstNil(t *testing.T) {
 		t.Error("nil")
 	}
 
-	assert.Equal(t, "foo", val)
+	assert.Equal(t, value, val)
 }

--- a/experimental/frame_sorter_test.go
+++ b/experimental/frame_sorter_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
 )
 
-// TestFrameSorter ...
 func TestFrameSorter(t *testing.T) {
 	field := data.NewField("Single float64", nil, []float64{
 		8.6, 8.7, 14.82, 10.07, 8.52,
@@ -27,7 +27,52 @@ func TestFrameSorter(t *testing.T) {
 		t.Error(err)
 	}
 	want := float64(8.52)
-	if val != want {
-		t.Errorf("Want %f Got %f", want, val)
+
+	assert.Equal(t, want, val)
+}
+
+func TestFrameSorterNil(t *testing.T) {
+	foo := "foo"
+	field := data.NewField("Foo", nil, []*string{
+		&foo, nil,
+	})
+
+	frame := data.NewFrame("Frame One",
+		field,
+	)
+
+	sorter := NewFrameSorter(frame, field)
+
+	sort.Sort(sorter)
+
+	val, ok := frame.Fields[0].ConcreteAt(0)
+
+	if !ok {
+		t.Error("nil")
 	}
+
+	assert.Equal(t, "foo", val)
+}
+
+func TestFrameSorterFirstNil(t *testing.T) {
+	foo := "foo"
+	field := data.NewField("Foo", nil, []*string{
+		nil, &foo,
+	})
+
+	frame := data.NewFrame("Frame One",
+		field,
+	)
+
+	sorter := NewFrameSorter(frame, field)
+
+	sort.Sort(sorter)
+
+	val, ok := frame.Fields[0].ConcreteAt(0)
+
+	if !ok {
+		t.Error("nil")
+	}
+
+	assert.Equal(t, "foo", val)
 }

--- a/experimental/frame_sorter_test.go
+++ b/experimental/frame_sorter_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
+// TestFrameSorter ...
 func TestFrameSorter(t *testing.T) {
-
 	field := data.NewField("Single float64", nil, []float64{
 		8.6, 8.7, 14.82, 10.07, 8.52,
 	}).SetConfig(&data.FieldConfig{Unit: "Percent"})


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow sorting Dataframes by field

**Which issue(s) this PR fixes**:
Mongo db plugin needs to sort by field ( atlas free tier doesn't allow sorting when aggregating )
