### PR TITLE
Chore: Enable unparam linter

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -39,8 +39,8 @@ enable = [
   "unused",
   "varcheck",
   "whitespace",
+  "unparam",
 ]
 
 # Disabled linters (might want them later)
 # "gocyclo",
-# "unparam"


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable the unparam linter.
