### PR TITLE
Chore: Enable more linters

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -41,4 +41,12 @@ enable = [
   "whitespace",
   "gocyclo",
   "unparam",
+  "dogsled",
+  "asciicheck",
+  "errorlint",
+  "sqlclosecheck",
 ]
+# Don't require that errors are included through wrapping, since might not always want to wrap an error
+[[issues.exclude-rules]]
+linters = ["errorlint"]
+text = "non-wrapping format verb for fmt.Errorf"

--- a/data/arrow.go
+++ b/data/arrow.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -410,7 +411,7 @@ func initializeFrameField(field arrow.Field, idx int, nullable []bool, sdkField 
 func populateFrameFields(fR arrio.Reader, nullable []bool, frame *Frame) error {
 	for {
 		record, err := fR.Read()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable the following linters:

* dogsled
* asciicheck
* errorlint
* sqlclosecheck

errorlint is pretty cool, since it makes sure you compare against wrapped errors properly.