### PR TITLE
feat: allow json.unmarshal and json.marshal for dataframes

### DIFF
--- a/data/frame.go
+++ b/data/frame.go
@@ -10,6 +10,7 @@
 package data
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"reflect"
@@ -39,6 +40,40 @@ type Frame struct {
 
 	// Meta is metadata about the Frame, and includes space for custom metadata.
 	Meta *FrameMeta
+}
+
+type frameJSONFormat struct {
+	Frame []byte `json:"frame"`
+}
+
+// UnmarshalJSON uses the `UnmasrhalArrow` function to unmarshal this type to JSON
+func (f *Frame) UnmarshalJSON(b []byte) error {
+	format := &frameJSONFormat{}
+
+	if err := json.Unmarshal(b, format); err != nil {
+		return err
+	}
+
+	frame, err := UnmarshalArrowFrame(format.Frame)
+	if err != nil {
+		return err
+	}
+
+	*f = *frame
+
+	return nil
+}
+
+// UnmarshalJSON uses the `MarshalArrow` function to marshal this type from JSON
+func (f *Frame) MarshalJSON() ([]byte, error) {
+	arrow, err := f.MarshalArrow()
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(&frameJSONFormat{
+		Frame: arrow,
+	})
 }
 
 // Frames is a slice of Frame pointers.

--- a/data/frame.go
+++ b/data/frame.go
@@ -64,7 +64,7 @@ func (f *Frame) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// UnmarshalJSON uses the `MarshalArrow` function to marshal this type from JSON
+// MarshalJSON uses the `MarshalArrow` function to marshal this type from JSON
 func (f *Frame) MarshalJSON() ([]byte, error) {
 	arrow, err := f.MarshalArrow()
 	if err != nil {

--- a/data/frame.go
+++ b/data/frame.go
@@ -42,19 +42,15 @@ type Frame struct {
 	Meta *FrameMeta
 }
 
-type frameJSONFormat struct {
-	Frame []byte `json:"frame"`
-}
-
 // UnmarshalJSON uses the `UnmasrhalArrow` function to unmarshal this type to JSON
 func (f *Frame) UnmarshalJSON(b []byte) error {
-	format := &frameJSONFormat{}
+	arrow := []byte{}
 
-	if err := json.Unmarshal(b, format); err != nil {
+	if err := json.Unmarshal(b, &arrow); err != nil {
 		return err
 	}
 
-	frame, err := UnmarshalArrowFrame(format.Frame)
+	frame, err := UnmarshalArrowFrame(arrow)
 	if err != nil {
 		return err
 	}
@@ -71,9 +67,7 @@ func (f *Frame) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	return json.Marshal(&frameJSONFormat{
-		Frame: arrow,
-	})
+	return json.Marshal(arrow)
 }
 
 // Frames is a slice of Frame pointers.


### PR DESCRIPTION
This allows us to use `json.NewDecoder(...)` and `json.Marshal` with `data.Frames`.

I did this for some upcoming cache layer stuff where these dataframes (and possibly other types) are going to have to be encoded/decoded before being shipped off to redis/memcached/whatever.