### PR TITLE
Don't process nil frames

### DIFF
--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -141,6 +141,10 @@ func (t ConvertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.
 	}
 	for refID, dr := range res.Responses {
 		for _, f := range dr.Frames {
+			// Don't process nil frames
+			if f == nil {
+				continue
+			}
 			if f.RefID == "" {
 				f.RefID = refID
 			}

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
@@ -140,10 +141,10 @@ func (t ConvertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.
 		Responses: make(map[string]*pluginv2.DataResponse, len(res.Responses)),
 	}
 	for refID, dr := range res.Responses {
-		for _, f := range dr.Frames {
+		for i, f := range dr.Frames {
 			// Don't process nil frames
 			if f == nil {
-				continue
+				return nil, fmt.Errorf("Frame [%d] is nil", i)
 			}
 			if f.RefID == "" {
 				f.RefID = refID

--- a/data/frame.go
+++ b/data/frame.go
@@ -175,6 +175,7 @@ func NewFrame(name string, fields ...*Field) *Frame {
 	return &Frame{
 		Name:   name,
 		Fields: fields,
+		RefID:  "",
 	}
 }
 

--- a/data/frame.go
+++ b/data/frame.go
@@ -175,7 +175,6 @@ func NewFrame(name string, fields ...*Field) *Frame {
 	return &Frame{
 		Name:   name,
 		Fields: fields,
-		RefID:  "",
 	}
 }
 


### PR DESCRIPTION
The idea here is to be more explicit. Dev's should not be adding nil frames, but the sdk should also be checking for them. 

I believe this fixes this issue: https://app.zenhub.com/workspaces/enterprise-plugins-5f47fd7ab9cc54000f3c2f80/issues/grafana/splunk-datasource/205

Additionally, I think it's nice to be explicit. Because RefID is a string, it's probably going to be set to an empty string anyway, but it's better IMO to be explicit about what's being set. 