### PR TITLE
Add simple `Framer` interface

### DIFF
--- a/backend/framer.go
+++ b/backend/framer.go
@@ -1,0 +1,22 @@
+package backend
+
+import "github.com/grafana/grafana-plugin-sdk-go/data"
+
+// FrameResponse creates a backend.DataResponse that contains the Framer's data.Frames
+func FrameResponse(f data.Framer) *DataResponse {
+	return &DataResponse{
+		Frames: f.Frames(),
+	}
+}
+
+// FrameResponseWithError creates a DataResponse with the error's contents (if not nil), and the Framer's data.Frames
+// This function is particularly useful if you have a function that returns `(StructX, error)`, where StructX implements Framer, which is a very common pattern
+func FrameResponseWithError(f data.Framer, err error) *DataResponse {
+	if err != nil {
+		return &DataResponse{
+			Error: err,
+		}
+	}
+
+	return FrameResponse(f)
+}

--- a/backend/framer.go
+++ b/backend/framer.go
@@ -4,8 +4,10 @@ import "github.com/grafana/grafana-plugin-sdk-go/data"
 
 // FrameResponse creates a DataResponse that contains the Framer's data.Frames
 func FrameResponse(f data.Framer) *DataResponse {
+	frames, err := f.Frames()
 	return &DataResponse{
-		Frames: f.Frames(),
+		Frames: frames,
+		Error:  err,
 	}
 }
 

--- a/backend/framer.go
+++ b/backend/framer.go
@@ -2,7 +2,7 @@ package backend
 
 import "github.com/grafana/grafana-plugin-sdk-go/data"
 
-// FrameResponse creates a DataResponse that contains the Framer's data.Frames
+// FrameResponse creates a DataResponse that contains the Framer's data.Frames.
 func FrameResponse(f data.Framer) *DataResponse {
 	frames, err := f.Frames()
 	return &DataResponse{

--- a/backend/framer.go
+++ b/backend/framer.go
@@ -11,7 +11,7 @@ func FrameResponse(f data.Framer) *DataResponse {
 	}
 }
 
-// FrameResponseWithError creates a DataResponse with the error's contents (if not nil), and the Framer's data.Frames
+// FrameResponseWithError creates a DataResponse with the error's contents (if not nil), and the Framer's data.Frames.
 // This function is particularly useful if you have a function that returns `(StructX, error)`, where StructX implements Framer, which is a very common pattern
 func FrameResponseWithError(f data.Framer, err error) *DataResponse {
 	if err != nil {

--- a/backend/framer.go
+++ b/backend/framer.go
@@ -12,7 +12,7 @@ func FrameResponse(f data.Framer) *DataResponse {
 }
 
 // FrameResponseWithError creates a DataResponse with the error's contents (if not nil), and the Framer's data.Frames.
-// This function is particularly useful if you have a function that returns `(StructX, error)`, where StructX implements Framer, which is a very common pattern
+// This function is particularly useful if you have a function that returns `(StructX, error)`, where StructX implements Framer, which is a very common pattern.
 func FrameResponseWithError(f data.Framer, err error) *DataResponse {
 	if err != nil {
 		return &DataResponse{

--- a/backend/framer.go
+++ b/backend/framer.go
@@ -2,7 +2,7 @@ package backend
 
 import "github.com/grafana/grafana-plugin-sdk-go/data"
 
-// FrameResponse creates a backend.DataResponse that contains the Framer's data.Frames
+// FrameResponse creates a DataResponse that contains the Framer's data.Frames
 func FrameResponse(f data.Framer) *DataResponse {
 	return &DataResponse{
 		Frames: f.Frames(),

--- a/data/framer.go
+++ b/data/framer.go
@@ -1,0 +1,8 @@
+package data
+
+// Framer is simply an object that can be converted to Grafana data frames.
+// This interface allows us to interact with types that represent datasource objects
+// Without having to convert them to dataframes first
+type Framer interface {
+	Frames() Frames
+}

--- a/data/framer.go
+++ b/data/framer.go
@@ -2,7 +2,7 @@ package data
 
 // Framer is simply an object that can be converted to Grafana data frames.
 // This interface allows us to interact with types that represent data source objects
-// Without having to convert them to data frames first
+// without having to convert them to data frames first.
 type Framer interface {
 	Frames() (Frames, error)
 }

--- a/data/framer.go
+++ b/data/framer.go
@@ -4,5 +4,5 @@ package data
 // This interface allows us to interact with types that represent data source objects
 // Without having to convert them to data frames first
 type Framer interface {
-	Frames() Frames
+	Frames() (Frames, error)
 }

--- a/data/framer.go
+++ b/data/framer.go
@@ -1,8 +1,8 @@
 package data
 
 // Framer is simply an object that can be converted to Grafana data frames.
-// This interface allows us to interact with types that represent datasource objects
-// Without having to convert them to dataframes first
+// This interface allows us to interact with types that represent data source objects
+// Without having to convert them to data frames first
 type Framer interface {
 	Frames() Frames
 }

--- a/experimental/golden_response_checker.go
+++ b/experimental/golden_response_checker.go
@@ -15,7 +15,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
-// CheckGoldenFramer calls CheckGoldenDataResponse using a data.Framer instead of a backend.DataResponse
+// CheckGoldenFramer calls CheckGoldenDataResponse using a data.Framer instead of a backend.DataResponse.
 func CheckGoldenFramer(path string, f data.Framer, updateFile bool) error {
 	return CheckGoldenDataResponse(path, backend.FrameResponse(f), updateFile)
 }

--- a/experimental/golden_response_checker.go
+++ b/experimental/golden_response_checker.go
@@ -15,6 +15,13 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
+// CheckGoldenFramer calls CheckGoldenDataResponse using a data.Framer instead of a backend.DataResponse
+func CheckGoldenFramer(path string, f data.Framer, updateFile bool) error {
+	return CheckGoldenDataResponse(path, &backend.DataResponse{
+		Frames: f.Frames(),
+	}, updateFile)
+}
+
 // CheckGoldenDataResponse will verify that the stored file matches the given data.DataResponse
 // when the updateFile flag is set, this will both add errors to the response and update the saved file
 func CheckGoldenDataResponse(path string, dr *backend.DataResponse, updateFile bool) error {

--- a/experimental/golden_response_checker.go
+++ b/experimental/golden_response_checker.go
@@ -17,9 +17,7 @@ import (
 
 // CheckGoldenFramer calls CheckGoldenDataResponse using a data.Framer instead of a backend.DataResponse
 func CheckGoldenFramer(path string, f data.Framer, updateFile bool) error {
-	return CheckGoldenDataResponse(path, &backend.DataResponse{
-		Frames: f.Frames(),
-	}, updateFile)
+	return CheckGoldenDataResponse(path, backend.FrameResponse(f), updateFile)
 }
 
 // CheckGoldenDataResponse will verify that the stored file matches the given data.DataResponse


### PR DESCRIPTION
I use / define this `Framer` interface in a few backend datasource plugins and I think it would be nice to have this in one location.

I can see a lot of nice utility functions being built around this that could reduce the code in some of our backend plugins by quite a bit.