### PR TITLE
Chore: Add thelper linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 defaults: &defaults
   docker:
-    - image: grafana/grafana-plugin-ci:1.1.0-alpine
+    - image: grafana/grafana-plugin-ci:1.1.1-alpine
 
 jobs:
   build:

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -45,6 +45,7 @@ enable = [
   "asciicheck",
   "errorlint",
   "sqlclosecheck",
+  "thelper",
 ]
 # Don't require that errors are included through wrapping, since might not always want to wrap an error
 [[issues.exclude-rules]]

--- a/backend/convert_from_protobuf_test.go
+++ b/backend/convert_from_protobuf_test.go
@@ -45,6 +45,7 @@ type requireCounter struct {
 }
 
 func (rec *requireCounter) Equal(t *testing.T, expected, actual interface{}, msgAngArgs ...interface{}) {
+	t.Helper()
 	require.Equal(t, expected, actual, msgAngArgs...)
 	rec.Count++
 }

--- a/build/utils/copy_test.go
+++ b/build/utils/copy_test.go
@@ -79,6 +79,8 @@ func TestCopyRecursive_ExistentDest(t *testing.T) {
 }
 
 func compareDirs(t *testing.T, src, dst string) {
+	t.Helper()
+
 	sfi, err := os.Stat(src)
 	require.NoError(t, err)
 	dfi, err := os.Stat(dst)

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -28,6 +28,8 @@ func TestFrame(t *testing.T) {
 }
 
 func assertPanic(t *testing.T, f func()) {
+	t.Helper()
+
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf("The code did not panic")


### PR DESCRIPTION
**What this PR does / why we need it**:
Add thelper linter and upgrade build image. The thelper linter ensures that test helper functions start with a call to `t.Helper`.