### PR TITLE
Enhancement: Adding internal datalinks

### DIFF
--- a/data/field_config.go
+++ b/data/field_config.go
@@ -161,11 +161,18 @@ type ValueMapping struct {
 	To   string `json:"to,omitempty"`
 }
 
+// InternalDataLink describes the structure for internal datalinks
+type InternalDataLink struct {
+	Query         interface{} `json:"query,omitempty"`
+	DatasourceUID string      `json:"datasourceUid,omitempty"`
+}
+
 // DataLink define what
 type DataLink struct { //revive:disable-line
-	Title       string `json:"title,omitempty"`
-	TargetBlank bool   `json:"targetBlank,omitempty"`
-	URL         string `json:"url,omitempty"`
+	Title       string           `json:"title,omitempty"`
+	TargetBlank bool             `json:"targetBlank,omitempty"`
+	URL         string           `json:"url,omitempty"`
+	Internal    InternalDataLink `json:"internal,omitempty"`
 }
 
 // ThresholdsConfig setup thresholds


### PR DESCRIPTION
The frontend defines a datalink like this:
```
export interface DataLink<T extends DataQuery = any> {
    title: string;
    targetBlank?: boolean;
    url: string;
    onBuildUrl?: (event: DataLinkClickEvent) => string;
    onClick?: (event: DataLinkClickEvent) => void;
    internal?: {
        query: T;
        datasourceUid: string;
    };
}
```

This PR adds the internal field to the backend so that datalinks can be set in the backend.