### PR TITLE
Change how InstanceManager manages instance caching

### DIFF
--- a/backend/instancemgmt/instance_manager.go
+++ b/backend/instancemgmt/instance_manager.go
@@ -98,9 +98,7 @@ func (im *instanceManager) Get(pluginContext backend.PluginContext) (Instance, e
 
 	defer im.locker.Unlock(cacheKey)
 
-	ci, ok = im.cache.Load(cacheKey)
-
-	if ok {
+	if ci, ok := im.cache.Load(cacheKey); ok {
 		needsUpdate := im.provider.NeedsUpdate(pluginContext, ci.(CachedInstance))
 
 		if !needsUpdate {

--- a/backend/instancemgmt/instance_manager.go
+++ b/backend/instancemgmt/instance_manager.go
@@ -95,7 +95,6 @@ func (im *instanceManager) Get(pluginContext backend.PluginContext) (Instance, e
 	}
 
 	im.locker.Lock(cacheKey)
-
 	defer im.locker.Unlock(cacheKey)
 
 	if ci, ok := im.cache.Load(cacheKey); ok {

--- a/backend/instancemgmt/instance_manager_test.go
+++ b/backend/instancemgmt/instance_manager_test.go
@@ -1,6 +1,8 @@
 package instancemgmt
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -59,17 +61,155 @@ func TestInstanceManager(t *testing.T) {
 	})
 }
 
+func TestInstanceManagerConcurrency(t *testing.T) {
+	t.Run("Check possible race condition issues when initially creating instance", func(t *testing.T) {
+		tip := &testInstanceProvider{}
+		im := New(tip)
+		ctx := backend.PluginContext{
+			OrgID: 1,
+			AppInstanceSettings: &backend.AppInstanceSettings{
+				Updated: time.Now(),
+			},
+		}
+		var wg sync.WaitGroup
+		wg.Add(10)
+
+		var createdInstances []*testInstance
+		mutex := new(sync.Mutex)
+		// Creating new instances because of updated context
+		for i := 0; i < 10; i++ {
+			go func() {
+				instance, _ := im.Get(ctx)
+				mutex.Lock()
+				defer mutex.Unlock()
+				// Collect all instances created
+				createdInstances = append(createdInstances, instance.(*testInstance))
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		t.Run("All created instances should be either disposed or exist in cache for later disposing", func(t *testing.T) {
+			cachedInstance, _ := im.Get(ctx)
+			for _, instance := range createdInstances {
+				if cachedInstance.(*testInstance) != instance && instance.disposedTimes < 1 {
+					require.FailNow(t, "Found lost reference to un-disposed instance")
+				}
+			}
+		})
+	})
+
+	t.Run("Check possible race condition issues when re-creating instance on settings update", func(t *testing.T) {
+		initialCtx := backend.PluginContext{
+			OrgID: 1,
+			AppInstanceSettings: &backend.AppInstanceSettings{
+				Updated: time.Now(),
+			},
+		}
+		tip := &testInstanceProvider{}
+		im := New(tip)
+		// Creating initial instance with old contexts
+		instanceToDispose, _ := im.Get(initialCtx)
+
+		updatedCtx := backend.PluginContext{
+			OrgID: 1,
+			AppInstanceSettings: &backend.AppInstanceSettings{
+				Updated: time.Now(),
+			},
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(10)
+
+		var createdInstances []*testInstance
+		mutex := new(sync.Mutex)
+		// Creating new instances because of updated context
+		for i := 0; i < 10; i++ {
+			go func() {
+				instance, _ := im.Get(updatedCtx)
+				mutex.Lock()
+				defer mutex.Unlock()
+				// Collect all instances created during concurrent update
+				createdInstances = append(createdInstances, instance.(*testInstance))
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		t.Run("Initial instance should be disposed only once", func(t *testing.T) {
+			require.Equal(t, int64(1), instanceToDispose.(*testInstance).disposedTimes, "Instance should be disposed only once")
+		})
+		t.Run("All created instances should be either disposed or exist in cache for later disposing", func(t *testing.T) {
+			cachedInstance, _ := im.Get(updatedCtx)
+			for _, instance := range createdInstances {
+				if cachedInstance.(*testInstance) != instance && instance.disposedTimes < 1 {
+					require.FailNow(t, "Found lost reference to un-disposed instance")
+				}
+			}
+		})
+	})
+
+	t.Run("Long recreation of instance should not affect datasources with different ID", func(t *testing.T) {
+		const delay = time.Millisecond * 50
+		ctx := backend.PluginContext{
+			OrgID: 1,
+			AppInstanceSettings: &backend.AppInstanceSettings{
+				Updated: time.Now(),
+			},
+		}
+		if testing.Short() {
+			t.Skip("Tests with Sleep")
+		}
+
+		tip := &testInstanceProvider{delay: delay}
+		im := New(tip)
+		// Creating instance with id#1 in cache
+		_, err := im.Get(ctx)
+		require.NoError(t, err)
+		var wg1, wg2 sync.WaitGroup
+		wg1.Add(1)
+		wg2.Add(1)
+		go func() {
+			// Creating instance with id#2 in cache
+			wg1.Done()
+			_, err := im.Get(backend.PluginContext{
+				OrgID: 2,
+				AppInstanceSettings: &backend.AppInstanceSettings{
+					Updated: time.Now(),
+				},
+			})
+			require.NoError(t, err)
+			wg2.Done()
+		}()
+		// Waiting before thread 2 starts to get the instance, so thread 2 could qcquire the lock before thread 1
+		wg1.Wait()
+		// Getting existing instance with id#1 from cache
+		start := time.Now()
+		_, err = im.Get(ctx)
+		elapsed := time.Since(start)
+		require.NoError(t, err)
+		// Waiting before thread 2 finished to get the instance
+		wg2.Wait()
+		if elapsed > delay {
+			require.Fail(t, "Instance should be retrieved from cache without delay")
+		}
+	})
+}
+
 type testInstance struct {
-	orgID    int64
-	updated  time.Time
-	disposed bool
+	orgID         int64
+	updated       time.Time
+	disposed      bool
+	disposedTimes int64
 }
 
 func (ti *testInstance) Dispose() {
 	ti.disposed = true
+	atomic.AddInt64(&ti.disposedTimes, 1)
 }
 
 type testInstanceProvider struct {
+	delay time.Duration
 }
 
 func (tip *testInstanceProvider) GetKey(pluginContext backend.PluginContext) (interface{}, error) {
@@ -83,6 +223,9 @@ func (tip *testInstanceProvider) NeedsUpdate(pluginContext backend.PluginContext
 }
 
 func (tip *testInstanceProvider) NewInstance(pluginContext backend.PluginContext) (Instance, error) {
+	if tip.delay > 0 {
+		time.Sleep(tip.delay)
+	}
 	return &testInstance{
 		orgID:   pluginContext.OrgID,
 		updated: pluginContext.AppInstanceSettings.Updated,

--- a/backend/instancemgmt/locker.go
+++ b/backend/instancemgmt/locker.go
@@ -1,0 +1,70 @@
+package instancemgmt
+
+import (
+	"fmt"
+	"sync"
+)
+
+type locker struct {
+	locks   map[interface{}]*sync.RWMutex
+	locksRW *sync.RWMutex
+}
+
+func newLocker() *locker {
+	return &locker{
+		locks:   make(map[interface{}]*sync.RWMutex),
+		locksRW: new(sync.RWMutex),
+	}
+}
+
+func (lkr *locker) Lock(key interface{}) {
+	lk, ok := lkr.getLock(key)
+	if !ok {
+		lk = lkr.newLock(key)
+	}
+	lk.Lock()
+}
+
+func (lkr *locker) Unlock(key interface{}) {
+	lk, ok := lkr.getLock(key)
+	if !ok {
+		panic(fmt.Errorf("lock for key '%s' not initialized", key))
+	}
+	lk.Unlock()
+}
+
+func (lkr *locker) RLock(key interface{}) {
+	lk, ok := lkr.getLock(key)
+	if !ok {
+		lk = lkr.newLock(key)
+	}
+	lk.RLock()
+}
+
+func (lkr *locker) RUnlock(key interface{}) {
+	lk, ok := lkr.getLock(key)
+	if !ok {
+		panic(fmt.Errorf("lock for key '%s' not initialized", key))
+	}
+	lk.RUnlock()
+}
+
+func (lkr *locker) newLock(key interface{}) *sync.RWMutex {
+	lkr.locksRW.Lock()
+	defer lkr.locksRW.Unlock()
+
+	if lk, ok := lkr.locks[key]; ok {
+		return lk
+	}
+	lk := new(sync.RWMutex)
+	lkr.locks[key] = lk
+	return lk
+}
+
+func (lkr *locker) getLock(key interface{}) (*sync.RWMutex, bool) {
+	lkr.locksRW.RLock()
+	defer lkr.locksRW.RUnlock()
+
+	lock, ok := lkr.locks[key]
+	return lock, ok
+}

--- a/backend/instancemgmt/locker_test.go
+++ b/backend/instancemgmt/locker_test.go
@@ -1,0 +1,48 @@
+package instancemgmt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocker(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Tests with Sleep")
+	}
+	const notUpdated = "not_updated"
+	const atThread1 = "at_thread_1"
+	const atThread2 = "at_thread_2"
+	t.Run("Should lock for same keys", func(t *testing.T) {
+		updated := notUpdated
+		locker := newLocker()
+		locker.Lock(1)
+		defer locker.Unlock(1)
+		go func() {
+			locker.RLock(1)
+			defer locker.RUnlock(1)
+			require.Equal(t, atThread1, updated, "Value should be updated in different thread")
+			updated = atThread2
+		}()
+		time.Sleep(time.Millisecond * 10)
+		require.Equal(t, notUpdated, updated, "Value should not be updated in different thread")
+		updated = atThread1
+	})
+
+	t.Run("Should not lock for different keys", func(t *testing.T) {
+		updated := notUpdated
+		locker := newLocker()
+		locker.Lock(1)
+		defer locker.Unlock(1)
+		go func() {
+			locker.RLock(2)
+			defer locker.RUnlock(2)
+			require.Equal(t, notUpdated, updated, "Value should not be updated in different thread")
+			updated = atThread2
+		}()
+		time.Sleep(time.Millisecond * 10)
+		require.Equal(t, atThread2, updated, "Value should be updated in different thread")
+		updated = atThread1
+	})
+}


### PR DESCRIPTION
This PR changes how InstanceManager creates, caches and disposes of datasource instances. 

Fixes https://github.com/grafana/grafana-plugin-sdk-go/issues/248

**Special notes for your reviewer**:
Changes:
1. I added tests which could clarify the issues reported in bug. Without the changes from this PR this tests should fail. 
2. I put the Dispose and code for checking the value existence in the lock section. To optimize it (99.999...% of calls will be just getting the value from cache and returning to the caller after config check) I implemented the double-check locking.
3. I have replaced simple sync.RWMutex with implementation of named RWMutex, which allow to process instances with different id in parallel without locking.
4. Since I replaced RWMutex with Named RWMutex we starting to have a situation with parallel read/write call to map with cached instances (for example read instance id#1 and write instance id#2), so I had to replace map with sync.Map