### PR TITLE
add json,omitempty tags to QueryData requests / response structs

### DIFF
--- a/backend/data.go
+++ b/backend/data.go
@@ -35,39 +35,39 @@ func (fn QueryDataHandlerFunc) QueryData(ctx context.Context, req *QueryDataRequ
 // QueryDataRequest contains a single request which contains multiple queries.
 // It is the input type for a QueryData call.
 type QueryDataRequest struct {
-	PluginContext PluginContext
-	Headers       map[string]string
-	Queries       []DataQuery
+	PluginContext PluginContext     `json:"plugin_context,omitempty"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	Queries       []DataQuery       `json:"queries,omitempty"`
 }
 
 // DataQuery represents a single query as sent from the frontend.
 // A slice of DataQuery makes up the Queries property of a QueryDataRequest.
 type DataQuery struct {
 	// RefID is the unique identifier of the query, set by the frontend call.
-	RefID string
+	RefID string `json:"ref_id,omitempty"`
 
 	// QueryType is an optional identifier for the type of query.
 	// It can be used to distinguish different types of queries.
-	QueryType string
+	QueryType string `json:"query_type,omitempty"`
 
 	// MaxDataPoints is the maximum number of datapoints that should be returned from a time series query.
-	MaxDataPoints int64
+	MaxDataPoints int64 `json:"max_data_points,omitempty"`
 
 	// Interval is the suggested duration between time points in a time series query.
-	Interval time.Duration
+	Interval time.Duration `json:"interval,omitempty"`
 
 	// TimeRange is the Start and End of the query as sent by the frontend.
-	TimeRange TimeRange
+	TimeRange TimeRange `json:"time_range,omitempty"`
 
 	// JSON is the raw JSON query and includes the above properties as well as custom properties.
-	JSON json.RawMessage
+	JSON json.RawMessage `json:"json,omitempty"`
 }
 
 // QueryDataResponse contains the results from a QueryDataRequest.
 // It is the return type of a QueryData call.
 type QueryDataResponse struct {
 	// Responses is a map of RefIDs (Unique Query ID) to *DataResponse.
-	Responses Responses
+	Responses Responses `json:"responses,omitempty"`
 }
 
 // NewQueryDataResponse returns a QueryDataResponse with the Responses property initialized.
@@ -87,19 +87,19 @@ type Responses map[string]DataResponse
 // The Error property is used to allow for partial success responses from the containing QueryDataResponse.
 type DataResponse struct {
 	// The data returned from the Query. Each Frame repeats the RefID.
-	Frames data.Frames
+	Frames data.Frames `json:"frames,omitempty"`
 
 	// Error is a property to be set if the the corresponding DataQuery has an error.
-	Error error
+	Error error `json:"error,omitempty"`
 }
 
 // TimeRange represents a time range for a query and is a property of DataQuery.
 type TimeRange struct {
 	// From is the start time of the query.
-	From time.Time
+	From time.Time `json:"from,omitempty"`
 
 	// To is the end time of the query.
-	To time.Time
+	To time.Time `json:"to,omitempty"`
 }
 
 // Duration returns a time.Duration representing the amount of time between From and To.


### PR DESCRIPTION
I added these because I'm writing a middleware for Grafana's `/api/ds/query` endpoint. The request body isn't exactly a `QueryDataRequest`, as it gets wrapped by some other process in Grafana, however the response is always a `QueryDataResponse`, which I would have to define my own type in order to unmarshal, or add struct tags to this one.