### PR TITLE
read/write field type as string and marshal

### DIFF
--- a/data/vector.go
+++ b/data/vector.go
@@ -233,7 +233,7 @@ func (p *FieldType) MarshalJSON() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// UnmarshalJSON unmashals a quoted json string to the enum value
+// UnmarshalJSON unmarshals a quoted json string to the enum value
 func (p *FieldType) UnmarshalJSON(b []byte) error {
 	var j string
 	err := json.Unmarshal(b, &j)

--- a/data/vector.go
+++ b/data/vector.go
@@ -241,7 +241,7 @@ func (p *FieldType) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	f, ok := FieldTypeFromString(j)
+	f, ok := FieldTypeFromItemTypeString(j)
 	if !ok {
 		return fmt.Errorf("unknown field type")
 	}
@@ -455,79 +455,9 @@ func (p FieldType) NullableType() FieldType {
 	}
 }
 
-// ItemTypeString returns the string representation of the type of element within in the vector
-func (p FieldType) ItemTypeString() string {
-	switch p {
-	case FieldTypeInt8:
-		return "int8"
-	case FieldTypeNullableInt8:
-		return "*int8"
-
-	case FieldTypeInt16:
-		return "int16"
-	case FieldTypeNullableInt16:
-		return "*int16"
-
-	case FieldTypeInt32:
-		return "int32"
-	case FieldTypeNullableInt32:
-		return "*int32"
-
-	case FieldTypeInt64:
-		return "int64"
-	case FieldTypeNullableInt64:
-		return "*int64"
-
-	case FieldTypeUint8:
-		return "unit8"
-	case FieldTypeNullableUint8:
-		return "*uint8"
-
-	case FieldTypeUint16:
-		return "uint16"
-	case FieldTypeNullableUint16:
-		return "*uint16"
-
-	case FieldTypeUint32:
-		return "uint32"
-	case FieldTypeNullableUint32:
-		return "*uint32"
-
-	case FieldTypeUint64:
-		return "uint64"
-	case FieldTypeNullableUint64:
-		return "*uint64"
-
-	case FieldTypeFloat32:
-		return "float32"
-	case FieldTypeNullableFloat32:
-		return "*float32"
-
-	case FieldTypeFloat64:
-		return "float64"
-	case FieldTypeNullableFloat64:
-		return "*float64"
-
-	case FieldTypeString:
-		return "string"
-	case FieldTypeNullableString:
-		return "*string"
-
-	case FieldTypeBool:
-		return "bool"
-	case FieldTypeNullableBool:
-		return "*bool"
-
-	case FieldTypeTime:
-		return "time.Time"
-	case FieldTypeNullableTime:
-		return "*time.Time"
-	}
-	return "invalid/unsupported type"
-}
-
-// FieldTypeFromString returns a field type from the current string
-func FieldTypeFromString(s string) (FieldType, bool) {
+// FieldTypeFromItemTypeString returns a field type from the current string
+//nolint:goconst,gocyclo
+func FieldTypeFromItemTypeString(s string) (FieldType, bool) {
 	switch s {
 	case "int8":
 		return FieldTypeInt8, true
@@ -603,6 +533,77 @@ func FieldTypeFromString(s string) (FieldType, bool) {
 		return FieldTypeNullableTime, true
 	}
 	return FieldTypeNullableString, false
+}
+
+// ItemTypeString returns the string representation of the type of element within in the vector
+func (p FieldType) ItemTypeString() string {
+	switch p {
+	case FieldTypeInt8:
+		return "int8"
+	case FieldTypeNullableInt8:
+		return "*int8"
+
+	case FieldTypeInt16:
+		return "int16"
+	case FieldTypeNullableInt16:
+		return "*int16"
+
+	case FieldTypeInt32:
+		return "int32"
+	case FieldTypeNullableInt32:
+		return "*int32"
+
+	case FieldTypeInt64:
+		return "int64"
+	case FieldTypeNullableInt64:
+		return "*int64"
+
+	case FieldTypeUint8:
+		return "unit8"
+	case FieldTypeNullableUint8:
+		return "*uint8"
+
+	case FieldTypeUint16:
+		return "uint16"
+	case FieldTypeNullableUint16:
+		return "*uint16"
+
+	case FieldTypeUint32:
+		return "uint32"
+	case FieldTypeNullableUint32:
+		return "*uint32"
+
+	case FieldTypeUint64:
+		return "uint64"
+	case FieldTypeNullableUint64:
+		return "*uint64"
+
+	case FieldTypeFloat32:
+		return "float32"
+	case FieldTypeNullableFloat32:
+		return "*float32"
+
+	case FieldTypeFloat64:
+		return "float64"
+	case FieldTypeNullableFloat64:
+		return "*float64"
+
+	case FieldTypeString:
+		return "string"
+	case FieldTypeNullableString:
+		return "*string"
+
+	case FieldTypeBool:
+		return "bool"
+	case FieldTypeNullableBool:
+		return "*bool"
+
+	case FieldTypeTime:
+		return "time.Time"
+	case FieldTypeNullableTime:
+		return "*time.Time"
+	}
+	return "invalid/unsupported type"
 }
 
 // Nullable returns if Field type is a nullable type

--- a/data/vector.go
+++ b/data/vector.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -222,6 +224,30 @@ const (
 	// FieldTypeNullableTime indicates the underlying primitive is a []*time.Time.
 	FieldTypeNullableTime
 )
+
+// MarshalJSON marshals the enum as a quoted json string
+func (p *FieldType) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(p.ItemTypeString())
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON unmashals a quoted json string to the enum value
+func (p *FieldType) UnmarshalJSON(b []byte) error {
+	var j string
+	err := json.Unmarshal(b, &j)
+	if err != nil {
+		return err
+	}
+
+	f, ok := FieldTypeFromString(j)
+	if !ok {
+		return fmt.Errorf("unknown field type")
+	}
+	*p = f
+	return nil
+}
 
 func vectorFieldType(v vector) FieldType {
 	switch v.(type) {
@@ -498,6 +524,85 @@ func (p FieldType) ItemTypeString() string {
 		return "*time.Time"
 	}
 	return "invalid/unsupported type"
+}
+
+// FieldTypeFromString returns a field type from the current string
+func FieldTypeFromString(s string) (FieldType, bool) {
+	switch s {
+	case "int8":
+		return FieldTypeInt8, true
+	case "*int8":
+		return FieldTypeNullableInt8, true
+
+	case "int16":
+		return FieldTypeInt16, true
+	case "*int16":
+		return FieldTypeNullableInt16, true
+
+	case "int32":
+		return FieldTypeInt32, true
+	case "*int32":
+		return FieldTypeNullableInt32, true
+
+	case "int":
+		fallthrough
+	case "int64":
+		return FieldTypeInt64, true
+	case "*int64":
+		return FieldTypeNullableInt64, true
+
+	case "unit8":
+		return FieldTypeUint8, true
+	case "*uint8":
+		return FieldTypeNullableUint8, true
+
+	case "uint16":
+		return FieldTypeUint16, true
+	case "*uint16":
+		return FieldTypeNullableUint16, true
+
+	case "uint32":
+		return FieldTypeUint32, true
+	case "*uint32":
+		return FieldTypeNullableUint32, true
+
+	case "uint64":
+		return FieldTypeUint64, true
+	case "*uint64":
+		return FieldTypeNullableUint64, true
+
+	case "float32":
+		return FieldTypeFloat32, true
+	case "*float32":
+		return FieldTypeNullableFloat32, true
+
+	case "double":
+		fallthrough
+	case "float":
+		fallthrough
+	case "float64":
+		return FieldTypeFloat64, true
+	case "*float64":
+		return FieldTypeNullableFloat64, true
+
+	case "string":
+		return FieldTypeString, true
+	case "*string":
+		return FieldTypeNullableString, true
+
+	case "bool":
+		return FieldTypeBool, true
+	case "*bool":
+		return FieldTypeNullableBool, true
+
+	case "time":
+		fallthrough
+	case "time.Time":
+		return FieldTypeTime, true
+	case "*time.Time":
+		return FieldTypeNullableTime, true
+	}
+	return FieldTypeNullableString, false
 }
 
 // Nullable returns if Field type is a nullable type

--- a/data/vector_test.go
+++ b/data/vector_test.go
@@ -2,7 +2,6 @@ package data_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"

--- a/data/vector_test.go
+++ b/data/vector_test.go
@@ -61,7 +61,6 @@ func TestFieldTypeConversion(t *testing.T) {
 	}
 	body, err := json.Marshal(obj)
 	require.NoError(t, err)
-	fmt.Printf("JSON: %s\n", string(body))
 
 	copy := &simpleFieldInfo{}
 	err = json.Unmarshal(body, &copy)

--- a/data/vector_test.go
+++ b/data/vector_test.go
@@ -44,14 +44,14 @@ func TestFieldTypeConversion(t *testing.T) {
 	f := data.FieldTypeBool
 	s := f.ItemTypeString()
 	assert.Equal(t, "bool", s)
-	c, ok := data.FieldTypeFromString(s)
+	c, ok := data.FieldTypeFromItemTypeString(s)
 	require.Equal(t, true, ok, "must parse ok")
 	assert.Equal(t, f, c)
 
-	c, ok = data.FieldTypeFromString("????")
+	_, ok = data.FieldTypeFromItemTypeString("????")
 	require.Equal(t, false, ok, "unknown type")
 
-	c, ok = data.FieldTypeFromString("float")
+	c, ok = data.FieldTypeFromItemTypeString("float")
 	require.Equal(t, true, ok, "must parse ok")
 	assert.Equal(t, data.FieldTypeFloat64, c)
 

--- a/data/vector_test.go
+++ b/data/vector_test.go
@@ -1,9 +1,12 @@
 package data_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,4 +32,40 @@ func TestCopyAtDoesNotMutateVector(t *testing.T) {
 	}
 	frameB.Set(0, 0, 2.0)
 	require.Equal(t, frameA.At(0, 0), (1.0))
+}
+
+// The slice data in the Field is a not exported, so methods on the Field are used to to manipulate its data.
+type simpleFieldInfo struct {
+	Name      string
+	FieldType data.FieldType
+}
+
+func TestFieldTypeConversion(t *testing.T) {
+	f := data.FieldTypeBool
+	s := f.ItemTypeString()
+	assert.Equal(t, "bool", s)
+	c, ok := data.FieldTypeFromString(s)
+	require.Equal(t, true, ok, "must parse ok")
+	assert.Equal(t, f, c)
+
+	c, ok = data.FieldTypeFromString("????")
+	require.Equal(t, false, ok, "unknown type")
+
+	c, ok = data.FieldTypeFromString("float")
+	require.Equal(t, true, ok, "must parse ok")
+	assert.Equal(t, data.FieldTypeFloat64, c)
+
+	obj := &simpleFieldInfo{
+		Name:      "hello",
+		FieldType: data.FieldTypeFloat64,
+	}
+	body, err := json.Marshal(obj)
+	require.NoError(t, err)
+	fmt.Printf("JSON: %s\n", string(body))
+
+	copy := &simpleFieldInfo{}
+	err = json.Unmarshal(body, &copy)
+	require.NoError(t, err)
+
+	assert.Equal(t, obj.FieldType, copy.FieldType)
 }

--- a/data/vector_test.go
+++ b/data/vector_test.go
@@ -52,7 +52,7 @@ func TestFieldTypeConversion(t *testing.T) {
 	require.False(t, ok, "unknown type")
 
 	c, ok = data.FieldTypeFromItemTypeString("float")
-	require.Equal(t, true, ok, "must parse ok")
+	require.True(t, ok, "must parse ok")
 	assert.Equal(t, data.FieldTypeFloat64, c)
 
 	obj := &simpleFieldInfo{

--- a/data/vector_test.go
+++ b/data/vector_test.go
@@ -45,7 +45,7 @@ func TestFieldTypeConversion(t *testing.T) {
 	s := f.ItemTypeString()
 	assert.Equal(t, "bool", s)
 	c, ok := data.FieldTypeFromItemTypeString(s)
-	require.Equal(t, true, ok, "must parse ok")
+	require.True(t, ok, "must parse ok")
 	assert.Equal(t, f, c)
 
 	_, ok = data.FieldTypeFromItemTypeString("????")

--- a/data/vector_test.go
+++ b/data/vector_test.go
@@ -49,7 +49,7 @@ func TestFieldTypeConversion(t *testing.T) {
 	assert.Equal(t, f, c)
 
 	_, ok = data.FieldTypeFromItemTypeString("????")
-	require.Equal(t, false, ok, "unknown type")
+	require.False(t, ok, "unknown type")
 
 	c, ok = data.FieldTypeFromItemTypeString("float")
 	require.Equal(t, true, ok, "must parse ok")


### PR DESCRIPTION
I am working on a system to configure how we capture values from an external system and want to load the FieldType from a json configuration.

This PR does two things:
1. Adds a `FieldTypeFromString` that takes the string from `ItemTypeString` and returns the original value
2. adds JSON read/write support for FieldType