### PR TITLE
WIP: add config to debug header

### DIFF
--- a/data/frame.go
+++ b/data/frame.go
@@ -433,7 +433,14 @@ func (f *Frame) StringTable(maxFields, maxRows int) (string, error) {
 			headers[colIdx] = fmt.Sprintf("...+%v field...", len(f.Fields)-colIdx)
 			break
 		}
-		headers[colIdx] = fmt.Sprintf("Name: %v\nLabels: %s\nType: %s", field.Name, field.Labels, field.Type())
+		txt := fmt.Sprintf("Name: %v\nLabels: %s\nType: %s", field.Name, field.Labels, field.Type())
+		if field.Config != nil {
+			bytes, err := json.MarshalIndent(field.Config, "", " ")
+			if err != nil {
+				txt += "\n" + string(bytes)
+			}
+		}
+		headers[colIdx] = txt
 	}
 	table.SetHeader(headers)
 

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -161,6 +161,13 @@ func ExampleNewFrame() {
 		data.NewField("Temp", data.Labels{"place": "Ecuador"}, []float64{1, math.NaN()}),
 		data.NewField("Count", data.Labels{"place": "Ecuador"}, []*int64{&anInt64, nil}),
 	)
+	frame.Fields[1].Config = &data.FieldConfig{
+		Unit:        "f",
+		DisplayName: "disp",
+	}
+	frame.Fields[2].Config = &data.FieldConfig{
+		Unit: "fixed",
+	}
 	st, _ := frame.StringTable(-1, -1)
 	fmt.Println(st)
 	// Output:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the FieldConfig to the text table -- this is helpful for seeing what is in each field.  Super helpful for the human readable section of golden files

Closes https://github.com/grafana/grafana-plugin-sdk-go/issues/228