### PR TITLE
marshal data.FieldType to json nicely

### DIFF
--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -1,6 +1,7 @@
 package data_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -47,6 +48,34 @@ func TestGoldenFrameJSON(t *testing.T) {
 
 	strG := string(b)
 	assert.JSONEq(t, strF, strG, "saved json must match produced json")
+}
+
+type simpleTestObj struct {
+	Name   string          `json:"name,omitempty"`
+	FType  data.FieldType  `json:"type,omitempty"`
+	FType2 *data.FieldType `json:"typePtr,omitempty"`
+}
+
+// TestFieldTypeToJSON makes sure field type will read/write to json
+func TestFieldTypeToJSON(t *testing.T) {
+	v := simpleTestObj{
+		Name: "hello",
+	}
+
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	assert.Equal(t, data.FieldTypeUnknown, v.FType)
+
+	assert.Equal(t, `{"name":"hello"}`, string(b))
+
+	ft := data.FieldTypeInt8
+
+	v.FType = data.FieldTypeFloat64
+	v.FType2 = &ft
+	v.Name = ""
+	b, err = json.Marshal(v)
+	require.NoError(t, err)
+	assert.Equal(t, `{"type":"float64","typePtr":"int8"}`, string(b))
 }
 
 func BenchmarkFrameToJSON(b *testing.B) {

--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -76,6 +76,11 @@ func TestFieldTypeToJSON(t *testing.T) {
 	b, err = json.Marshal(v)
 	require.NoError(t, err)
 	assert.Equal(t, `{"type":"float64","typePtr":"int8"}`, string(b))
+
+	err = json.Unmarshal([]byte(`{"type":"int8","typePtr":"time"}`), &v)
+	require.NoError(t, err)
+	assert.Equal(t, data.FieldTypeInt8, v.FType)
+	assert.Equal(t, data.FieldTypeTime, *v.FType2)
 }
 
 func BenchmarkFrameToJSON(b *testing.B) {

--- a/data/vector.go
+++ b/data/vector.go
@@ -159,8 +159,11 @@ func ValidFieldType(t interface{}) bool {
 type FieldType int
 
 const (
+	// FieldTypeUnknown indicates that we do not know the field type
+	FieldTypeUnknown FieldType = iota
+
 	// FieldTypeInt8 indicates the underlying primitive is a []int8.
-	FieldTypeInt8 FieldType = iota
+	FieldTypeInt8
 	// FieldTypeNullableInt8 indicates the underlying primitive is a []*int8.
 	FieldTypeNullableInt8
 
@@ -226,7 +229,7 @@ const (
 )
 
 // MarshalJSON marshals the enum as a quoted json string
-func (p *FieldType) MarshalJSON() ([]byte, error) {
+func (p FieldType) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)
 	buffer.WriteString(p.ItemTypeString())
 	buffer.WriteString(`"`)
@@ -317,11 +320,11 @@ func vectorFieldType(v vector) FieldType {
 		return FieldTypeNullableTime
 	}
 
-	return FieldType(-1)
+	return FieldTypeUnknown
 }
 
 func (p FieldType) String() string {
-	if p < 0 {
+	if p <= 0 {
 		return "invalid/unsupported"
 	}
 	return fmt.Sprintf("[]%v", p.ItemTypeString())


### PR DESCRIPTION
Currently data.FieldType defaults to `FieldTypeInt8` because that is enum value 0 -- this means you can not use ``json:"type,omitempty"`` 

This PR changes to root value to "unknown" and now supports marshaling both as a pointer and as a value.

Since the internal enum value is not stored anywhere, shifting the values should not make a difference 