### PR TITLE
Add field name to the panic message about unssuported field type

### DIFF
--- a/data/field.go
+++ b/data/field.go
@@ -180,7 +180,7 @@ func NewField(name string, labels Labels, values interface{}) *Field {
 			vec.Set(i, v[i])
 		}
 	default:
-		panic(fmt.Errorf("unsupported field type %T", v))
+		panic(fmt.Errorf("field '%s' specified with unsupported type %T", name, v))
 	}
 
 	return &Field{


### PR DESCRIPTION
Makes it a bit easier to find out what is wrong.