### PR TITLE
Fix concurrent frame marshaling

### DIFF
--- a/data/frame.go
+++ b/data/frame.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -50,19 +49,7 @@ func (f *Frame) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON marshals Frame to JSON.
 func (f *Frame) MarshalJSON() ([]byte, error) {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
-	stream := cfg.BorrowStream(nil)
-	defer cfg.ReturnStream(stream)
-
-	err := writeDataFrame(f, stream, true, true)
-	if err != nil {
-		return nil, err
-	}
-
-	if stream.Error != nil {
-		return nil, stream.Error
-	}
-	return stream.Buffer(), nil
+	return FrameToJSON(f, true, true)
 }
 
 // Frames is a slice of Frame pointers.

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -58,7 +58,8 @@ func FrameToJSON(frame *Frame, includeSchema bool, includeData bool) ([]byte, er
 	if stream.Error != nil {
 		return nil, stream.Error
 	}
-	return stream.Buffer(), nil
+
+	return append([]byte(nil), stream.Buffer()...), nil
 }
 
 type frameSchema struct {
@@ -731,7 +732,7 @@ func ArrowToJSON(record array.Record, includeSchema bool, includeData bool) ([]b
 	if stream.Error != nil {
 		return nil, stream.Error
 	}
-	return stream.Buffer(), nil
+	return append([]byte(nil), stream.Buffer()...), nil
 }
 
 func writeArrowSchema(stream *jsoniter.Stream, record array.Record) {

--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -134,7 +134,7 @@ func BenchmarkFrameMarshalJSONIter(b *testing.B) {
 
 func TestFrameMarshalJSONConcurrent(t *testing.T) {
 	f := goldenDF()
-	d, err := json.Marshal(f)
+	initialJSON, err := json.Marshal(f)
 	require.NoError(t, err)
 	var wg sync.WaitGroup
 	for i := 0; i < 2; i++ {
@@ -142,9 +142,9 @@ func TestFrameMarshalJSONConcurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 100; j++ {
-				b, err := json.Marshal(f)
+				jsonData, err := json.Marshal(f)
 				require.NoError(t, err)
-				require.JSONEq(t, string(d), string(b))
+				require.JSONEq(t, string(initialJSON), string(jsonData))
 			}
 		}()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Without this copy of `stream.Buffer` we could get bytes in a dirty state when accessing later on. `TestFrameMarshalJSONConcurrent` demonstrates this. Also added similar tests for catch possible problems with DataResponse and QueryDataResponse marshaling in the future (those are marshalled fine at the moment).

Overall performance is comparable:

```
name                     old time/op    new time/op    delta
FrameToJSON-12             26.2µs ± 2%    26.5µs ± 1%      ~     (p=0.481 n=10+10)
FrameMarshalJSONStd-12     59.5µs ± 4%    59.7µs ± 0%      ~     (p=0.237 n=10+8)

name                     old alloc/op   new alloc/op   delta
FrameToJSON-12             2.96kB ± 0%    7.85kB ± 0%  +165.41%  (p=0.000 n=10+9)
FrameMarshalJSONStd-12     7.86kB ± 0%   12.76kB ± 0%   +62.32%  (p=0.000 n=8+10)

name                     old allocs/op  new allocs/op  delta
FrameToJSON-12                148 ± 0%       149 ± 0%    +0.68%  (p=0.000 n=10+10)
FrameMarshalJSONStd-12        149 ± 0%       150 ± 0%    +0.67%  (p=0.000 n=10+10)
```
