### PR TITLE
JSON: read/write QueryDataResponse to match existing structure

### DIFF
--- a/backend/data.go
+++ b/backend/data.go
@@ -77,7 +77,10 @@ func (r QueryDataResponse) MarshalJSON() ([]byte, error) {
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
-	writeQueryDataResponseJSON(&r, stream)
+	s := &QueryDataResults{
+		Results: r.Responses,
+	}
+	writeQueryDataResultsJSON(s, stream)
 	return stream.Buffer(), stream.Error
 }
 
@@ -110,7 +113,7 @@ func (r DataResponse) MarshalJSON() ([]byte, error) {
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
-	writeDataResponseJSON(&r, stream)
+	writeDataResponseJSON(&r, "", stream)
 	return stream.Buffer(), stream.Error
 }
 

--- a/backend/data.go
+++ b/backend/data.go
@@ -77,21 +77,14 @@ func (r QueryDataResponse) MarshalJSON() ([]byte, error) {
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
-	s := &QueryDataResults{
-		Results: r.Responses,
-	}
-	writeQueryDataResultsJSON(s, stream)
+	writeQueryDataResponseJSON(&r, stream)
 	return stream.Buffer(), stream.Error
 }
 
 // UnmarshalJSON will read JSON into a QueryDataResponse
 func (r *QueryDataResponse) UnmarshalJSON(b []byte) error {
 	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, b)
-	qdr := QueryDataResults{}
-	readQueryDataResultsJSON(&qdr, iter)
-	if iter.Error == nil {
-		r.Responses = qdr.Results
-	}
+	readQueryDataResultsJSON(r, iter)
 	return iter.Error
 }
 
@@ -124,7 +117,7 @@ func (r DataResponse) MarshalJSON() ([]byte, error) {
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
-	writeDataResponseJSON(&r, "", stream)
+	writeDataResponseJSON(&r, stream)
 	return stream.Buffer(), stream.Error
 }
 

--- a/backend/data.go
+++ b/backend/data.go
@@ -84,6 +84,17 @@ func (r QueryDataResponse) MarshalJSON() ([]byte, error) {
 	return stream.Buffer(), stream.Error
 }
 
+// UnmarshalJSON will read JSON into a QueryDataResponse
+func (r *QueryDataResponse) UnmarshalJSON(b []byte) error {
+	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, b)
+	qdr := QueryDataResults{}
+	readQueryDataResultsJSON(&qdr, iter)
+	if iter.Error == nil {
+		r.Responses = qdr.Results
+	}
+	return iter.Error
+}
+
 // NewQueryDataResponse returns a QueryDataResponse with the Responses property initialized.
 func NewQueryDataResponse() *QueryDataResponse {
 	return &QueryDataResponse{

--- a/backend/json.go
+++ b/backend/json.go
@@ -12,7 +12,9 @@ func init() { //nolint:gochecknoinits
 	jsoniter.RegisterTypeEncoder("backend.QueryDataResponse", &queryDataResponseCodec{})
 }
 
-// QueryDataResults is a flavor of
+// QueryDataResults adds key order as an input so that results can match query refId order
+// This struct is not part of the gRPC API, rather a utility structure to help produce
+// better looking JSON output
 type QueryDataResults struct {
 	Order   []string
 	Results Responses

--- a/backend/json.go
+++ b/backend/json.go
@@ -9,48 +9,9 @@ import (
 )
 
 func init() { //nolint:gochecknoinits
-	jsoniter.RegisterTypeEncoder("backend.QueryDataResults", &dataQueryResultsCodec{})
 	jsoniter.RegisterTypeEncoder("backend.DataResponse", &dataResponseCodec{})
 	jsoniter.RegisterTypeEncoder("backend.QueryDataResponse", &queryDataResponseCodec{})
 }
-
-// QueryDataResults adds key order as an input so that results can match query refId order
-// This struct is not part of the gRPC API, rather a utility structure to help produce
-// better looking JSON output
-type QueryDataResults struct {
-	Order   []string
-	Results Responses
-}
-
-// MarshalJSON writes the results as json
-func (r QueryDataResults) MarshalJSON() ([]byte, error) {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
-	stream := cfg.BorrowStream(nil)
-	defer cfg.ReturnStream(stream)
-
-	writeQueryDataResultsJSON(&r, stream)
-	return stream.Buffer(), stream.Error
-}
-
-type dataQueryResultsCodec struct{}
-
-func (codec *dataQueryResultsCodec) IsEmpty(ptr unsafe.Pointer) bool {
-	qdr := (*QueryDataResults)(ptr)
-	return qdr.Results == nil
-}
-
-func (codec *dataQueryResultsCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
-	qdr := (*QueryDataResults)(ptr)
-	writeQueryDataResultsJSON(qdr, stream)
-}
-
-func (codec *dataQueryResultsCodec) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-	qdr := QueryDataResults{}
-	readQueryDataResultsJSON(&qdr, iter)
-	*((*QueryDataResults)(ptr)) = qdr
-}
-
-// readQueryDataResultsJSON
 
 type dataResponseCodec struct{}
 
@@ -61,7 +22,7 @@ func (codec *dataResponseCodec) IsEmpty(ptr unsafe.Pointer) bool {
 
 func (codec *dataResponseCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	dr := (*DataResponse)(ptr)
-	writeDataResponseJSON(dr, "", stream)
+	writeDataResponseJSON(dr, stream)
 }
 
 type queryDataResponseCodec struct{}
@@ -73,33 +34,22 @@ func (codec *queryDataResponseCodec) IsEmpty(ptr unsafe.Pointer) bool {
 
 func (codec *queryDataResponseCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	qdr := (*QueryDataResponse)(ptr)
-	r := &QueryDataResults{
-		Results: qdr.Responses,
-	}
-	writeQueryDataResultsJSON(r, stream)
+	writeQueryDataResponseJSON(qdr, stream)
 }
 
 func (codec *queryDataResponseCodec) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-	qdr := QueryDataResults{}
+	qdr := QueryDataResponse{}
 	readQueryDataResultsJSON(&qdr, iter)
-	*((*QueryDataResponse)(ptr)) = QueryDataResponse{
-		Responses: qdr.Results,
-	}
+	*((*QueryDataResponse)(ptr)) = qdr
 }
 
 //-----------------------------------------------------------------
 // Private stream readers
 //-----------------------------------------------------------------
 
-func writeDataResponseJSON(dr *DataResponse, refID string, stream *jsoniter.Stream) {
+func writeDataResponseJSON(dr *DataResponse, stream *jsoniter.Stream) {
 	stream.WriteObjectStart()
 	started := false
-
-	if refID != "" {
-		stream.WriteObjectField("refId")
-		stream.WriteString(refID)
-		started = true
-	}
 
 	if dr.Error != nil {
 		if started {
@@ -131,49 +81,24 @@ func writeDataResponseJSON(dr *DataResponse, refID string, stream *jsoniter.Stre
 	stream.WriteObjectEnd()
 }
 
-func writeQueryDataResultsJSON(qdr *QueryDataResults, stream *jsoniter.Stream) {
+func writeQueryDataResponseJSON(qdr *QueryDataResponse, stream *jsoniter.Stream) {
 	stream.WriteObjectStart()
-	if qdr.Results != nil {
-		wrote := make(map[string]struct{}, len(qdr.Results))
-		stream.WriteObjectField("results")
-		stream.WriteArrayStart()
-		started := false
-		if len(qdr.Order) > 0 {
-			for _, id := range qdr.Order {
-				_, ok := wrote[id]
-				if ok {
-					continue // already wrote that key
-				}
+	stream.WriteObjectField("results")
+	stream.WriteObjectStart()
+	started := false
 
-				if started {
-					stream.WriteMore()
-				}
-				res, ok := qdr.Results[id]
-				if ok {
-					writeDataResponseJSON(&res, id, stream)
-					wrote[id] = struct{}{}
-					started = true
-				}
-			}
+	// Make sure all keys in the result are written
+	for id, res := range qdr.Responses {
+		if started {
+			stream.WriteMore()
 		}
-
-		// Make sure all keys in the result are written
-		for id, res := range qdr.Results {
-			_, ok := wrote[id]
-			if ok {
-				continue // already wrote that key
-			}
-
-			if started {
-				stream.WriteMore()
-			}
-			obj := res // avoid implicit memory
-			writeDataResponseJSON(&obj, id, stream)
-			wrote[id] = struct{}{}
-			started = true
-		}
-		stream.WriteArrayEnd()
+		stream.WriteObjectField(id)
+		obj := res // avoid implicit memory
+		writeDataResponseJSON(&obj, stream)
+		started = true
 	}
+	stream.WriteObjectEnd()
+
 	stream.WriteObjectEnd()
 }
 
@@ -181,7 +106,7 @@ func writeQueryDataResultsJSON(qdr *QueryDataResults, stream *jsoniter.Stream) {
 // Private stream readers
 //-----------------------------------------------------------------
 
-func readQueryDataResultsJSON(qdr *QueryDataResults, iter *jsoniter.Iterator) {
+func readQueryDataResultsJSON(qdr *QueryDataResponse, iter *jsoniter.Iterator) {
 	found := false
 
 	for l1Field := iter.ReadObject(); l1Field != ""; l1Field = iter.ReadObject() {
@@ -193,43 +118,39 @@ func readQueryDataResultsJSON(qdr *QueryDataResults, iter *jsoniter.Iterator) {
 			}
 			found = true
 
-			qdr.Order = make([]string, 0)
-			qdr.Results = make(Responses)
+			qdr.Responses = make(Responses)
 
-			for iter.ReadArray() {
-				refID := ""
-				res := DataResponse{}
-
-				for l2Field := iter.ReadObject(); l2Field != ""; l2Field = iter.ReadObject() {
-					switch l2Field {
-					case "refId":
-						refID = iter.ReadString()
-						qdr.Order = append(qdr.Order, refID)
-
-					case "error":
-						res.Error = fmt.Errorf(iter.ReadString())
-
-					case "frames":
-						for iter.ReadArray() {
-							frame := &data.Frame{}
-							iter.ReadVal(frame)
-							if iter.Error != nil {
-								return
-							}
-							res.Frames = append(res.Frames, frame)
-						}
-
-					default:
-						iter.ReportError("bind l2", "unexpected field: "+l1Field)
-						return
-					}
-				}
-
-				qdr.Results[refID] = res
+			for l2Field := iter.ReadObject(); l2Field != ""; l2Field = iter.ReadObject() {
+				dr := DataResponse{}
+				readDataResponseJSON(&dr, iter)
+				qdr.Responses[l2Field] = dr
 			}
 
 		default:
 			iter.ReportError("bind l1", "unexpected field: "+l1Field)
+			return
+		}
+	}
+}
+
+func readDataResponseJSON(rsp *DataResponse, iter *jsoniter.Iterator) {
+	for l2Field := iter.ReadObject(); l2Field != ""; l2Field = iter.ReadObject() {
+		switch l2Field {
+		case "error":
+			rsp.Error = fmt.Errorf(iter.ReadString())
+
+		case "frames":
+			for iter.ReadArray() {
+				frame := &data.Frame{}
+				iter.ReadVal(frame)
+				if iter.Error != nil {
+					return
+				}
+				rsp.Frames = append(rsp.Frames, frame)
+			}
+
+		default:
+			iter.ReportError("bind l2", "unexpected field: "+l2Field)
 			return
 		}
 	}

--- a/backend/json.go
+++ b/backend/json.go
@@ -7,8 +7,37 @@ import (
 )
 
 func init() { //nolint:gochecknoinits
+	jsoniter.RegisterTypeEncoder("backend.QueryDataResults", &dataQueryResultsCodec{})
 	jsoniter.RegisterTypeEncoder("backend.DataResponse", &dataResponseCodec{})
 	jsoniter.RegisterTypeEncoder("backend.QueryDataResponse", &queryDataResponseCodec{})
+}
+
+// QueryDataResults is a flavor of
+type QueryDataResults struct {
+	Order   []string
+	Results Responses
+}
+
+// MarshalJSON writes the results as json
+func (r QueryDataResults) MarshalJSON() ([]byte, error) {
+	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	stream := cfg.BorrowStream(nil)
+	defer cfg.ReturnStream(stream)
+
+	writeQueryDataResultsJSON(&r, stream)
+	return stream.Buffer(), stream.Error
+}
+
+type dataQueryResultsCodec struct{}
+
+func (codec *dataQueryResultsCodec) IsEmpty(ptr unsafe.Pointer) bool {
+	qdr := (*QueryDataResults)(ptr)
+	return qdr.Results == nil
+}
+
+func (codec *dataQueryResultsCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	qdr := (*QueryDataResults)(ptr)
+	writeQueryDataResultsJSON(qdr, stream)
 }
 
 type dataResponseCodec struct{}
@@ -20,7 +49,7 @@ func (codec *dataResponseCodec) IsEmpty(ptr unsafe.Pointer) bool {
 
 func (codec *dataResponseCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	dr := (*DataResponse)(ptr)
-	writeDataResponseJSON(dr, stream)
+	writeDataResponseJSON(dr, "", stream)
 }
 
 type queryDataResponseCodec struct{}
@@ -32,17 +61,30 @@ func (codec *queryDataResponseCodec) IsEmpty(ptr unsafe.Pointer) bool {
 
 func (codec *queryDataResponseCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	qdr := (*QueryDataResponse)(ptr)
-	writeQueryDataResponseJSON(qdr, stream)
+	r := &QueryDataResults{
+		Results: qdr.Responses,
+	}
+	writeQueryDataResultsJSON(r, stream)
 }
 
 //-----------------------------------------------------------------
 // Private stream readers
 //-----------------------------------------------------------------
 
-func writeDataResponseJSON(dr *DataResponse, stream *jsoniter.Stream) {
+func writeDataResponseJSON(dr *DataResponse, refID string, stream *jsoniter.Stream) {
 	stream.WriteObjectStart()
 	started := false
+
+	if refID != "" {
+		stream.WriteObjectField("refId")
+		stream.WriteString(refID)
+		started = true
+	}
+
 	if dr.Error != nil {
+		if started {
+			stream.WriteMore()
+		}
 		stream.WriteObjectField("error")
 		stream.WriteString(dr.Error.Error())
 		started = true
@@ -69,21 +111,34 @@ func writeDataResponseJSON(dr *DataResponse, stream *jsoniter.Stream) {
 	stream.WriteObjectEnd()
 }
 
-func writeQueryDataResponseJSON(qdr *QueryDataResponse, stream *jsoniter.Stream) {
+func writeQueryDataResultsJSON(qdr *QueryDataResults, stream *jsoniter.Stream) {
 	stream.WriteObjectStart()
-	if qdr.Responses != nil {
-		stream.WriteObjectField("responses")
-		stream.WriteObjectStart()
+	if qdr.Results != nil {
+		stream.WriteObjectField("results")
+		stream.WriteArrayStart()
 		started := false
-		for id, res := range qdr.Responses {
-			if started {
-				stream.WriteMore()
+		if len(qdr.Order) > 0 {
+			for _, id := range qdr.Order {
+				if started {
+					stream.WriteMore()
+				}
+				res, ok := qdr.Results[id]
+				if ok {
+					writeDataResponseJSON(&res, id, stream)
+					started = true
+				}
 			}
-			stream.WriteObjectField(id)
-			stream.WriteVal(res)
-			started = true
+		} else {
+			for id, res := range qdr.Results {
+				if started {
+					stream.WriteMore()
+				}
+				obj := res // avoid implicit memory
+				writeDataResponseJSON(&obj, id, stream)
+				started = true
+			}
 		}
-		stream.WriteObjectEnd()
+		stream.WriteArrayEnd()
 	}
 	stream.WriteObjectEnd()
 }

--- a/backend/json_test.go
+++ b/backend/json_test.go
@@ -50,7 +50,7 @@ func TestResponseEncoder(t *testing.T) {
 	require.NoError(t, err)
 
 	str = string(b)
-	require.Equal(t, `{"responses":{"A":{"frames":[{"schema":{"name":"simple","fields":[{"name":"time","type":"time","typeInfo":{"frame":"time.Time"}},{"name":"valid","type":"bool","typeInfo":{"frame":"bool"}}]},"data":{"values":[[1577934240000,1577934300000],[true,false]]}},{"schema":{"name":"other","fields":[{"name":"value","type":"number","typeInfo":{"frame":"float64"}}]},"data":{"values":[[1]]}}]}}}`, str)
+	require.Equal(t, `{"results":[{"refId":"A","frames":[{"schema":{"name":"simple","fields":[{"name":"time","type":"time","typeInfo":{"frame":"time.Time"}},{"name":"valid","type":"bool","typeInfo":{"frame":"bool"}}]},"data":{"values":[[1577934240000,1577934300000],[true,false]]}},{"schema":{"name":"other","fields":[{"name":"value","type":"number","typeInfo":{"frame":"float64"}}]},"data":{"values":[[1]]}}]}]}`, str)
 }
 
 func TestDataResponseMarshalJSONConcurrent(t *testing.T) {

--- a/backend/json_test.go
+++ b/backend/json_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/require"
 )
@@ -51,6 +52,27 @@ func TestResponseEncoder(t *testing.T) {
 
 	str = string(b)
 	require.Equal(t, `{"results":[{"refId":"A","frames":[{"schema":{"name":"simple","fields":[{"name":"time","type":"time","typeInfo":{"frame":"time.Time"}},{"name":"valid","type":"bool","typeInfo":{"frame":"bool"}}]},"data":{"values":[[1577934240000,1577934300000],[true,false]]}},{"schema":{"name":"other","fields":[{"name":"value","type":"number","typeInfo":{"frame":"float64"}}]},"data":{"values":[[1]]}}]}]}`, str)
+
+	// Read the parsed result and make sure it is the same
+	copy := &QueryDataResponse{}
+	err = json.Unmarshal(b, copy)
+	require.NoError(t, err)
+	require.Equal(t, len(qdr.Responses), len(copy.Responses))
+
+	// Check the final result
+	for k, val := range qdr.Responses {
+		other := copy.Responses[k]
+		require.Equal(t, len(val.Frames), len(other.Frames))
+
+		for idx := range val.Frames {
+			a := val.Frames[idx]
+			b := other.Frames[idx]
+
+			if diff := cmp.Diff(a, b, data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+		}
+	}
 }
 
 func TestDataResponseMarshalJSONConcurrent(t *testing.T) {

--- a/backend/json_test.go
+++ b/backend/json_test.go
@@ -77,6 +77,8 @@ func TestResponseEncoder(t *testing.T) {
 }
 
 func checkResultOrder(t *testing.T, qdr *backend.QueryDataResults, expectedOrder ...string) {
+	t.Helper()
+
 	raw, err := json.Marshal(qdr)
 	require.NoError(t, err)
 

--- a/data/frame.go
+++ b/data/frame.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -44,7 +45,8 @@ type Frame struct {
 
 // UnmarshalJSON allows unmarshalling Frame from JSON.
 func (f *Frame) UnmarshalJSON(b []byte) error {
-	return readDataFrameJSON(f, b)
+	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, b)
+	return readDataFrameJSON(f, iter)
 }
 
 // MarshalJSON marshals Frame to JSON.


### PR DESCRIPTION
This modifies the json read/write for `QueryDataResponse` to closer match the existing format

See https://github.com/grafana/grafana/pull/32303