### PR TITLE
Fix JSON marshal, add test cases

### DIFF
--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -599,7 +599,6 @@ func writeDataFrame(frame *Frame, stream *jsoniter.Stream, includeSchema bool, i
 				}
 				stream.WriteObjectField("config")
 				stream.WriteVal(f.Config)
-				started = true
 			}
 
 			stream.WriteObjectEnd()


### PR DESCRIPTION
**What this PR does / why we need it**:

* fix malformed json marshal with schema only and existing entities
* test case to show that we can't unmarshal frame with `data` key before `schema` key (previously caused panic)
* test case to show that data only JSON can't be converted to frame (previously caused panic)

In general I think we should take a closer look at this encoding/decoding because in current form it's not easily portable between languages.