### PR TITLE
DataFrameJSON: frontend expects "boolean" not "bool" type

### DIFF
--- a/backend/json_test.go
+++ b/backend/json_test.go
@@ -38,7 +38,7 @@ func TestResponseEncoder(t *testing.T) {
 	require.NoError(t, err)
 
 	str := string(b)
-	require.Equal(t, `{"frames":[{"schema":{"name":"simple","fields":[{"name":"time","type":"time","typeInfo":{"frame":"time.Time"}},{"name":"valid","type":"bool","typeInfo":{"frame":"bool"}}]},"data":{"values":[[1577934240000,1577934300000],[true,false]]}},{"schema":{"name":"other","fields":[{"name":"value","type":"number","typeInfo":{"frame":"float64"}}]},"data":{"values":[[1]]}}]}`, str)
+	require.Equal(t, `{"frames":[{"schema":{"name":"simple","fields":[{"name":"time","type":"time","typeInfo":{"frame":"time.Time"}},{"name":"valid","type":"boolean","typeInfo":{"frame":"bool"}}]},"data":{"values":[[1577934240000,1577934300000],[true,false]]}},{"schema":{"name":"other","fields":[{"name":"value","type":"number","typeInfo":{"frame":"float64"}}]},"data":{"values":[[1]]}}]}`, str)
 
 	b2, err := json.Marshal(&dr)
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestResponseEncoder(t *testing.T) {
 	require.NoError(t, err)
 
 	str = string(b)
-	require.Equal(t, `{"results":{"A":{"frames":[{"schema":{"name":"simple","fields":[{"name":"time","type":"time","typeInfo":{"frame":"time.Time"}},{"name":"valid","type":"bool","typeInfo":{"frame":"bool"}}]},"data":{"values":[[1577934240000,1577934300000],[true,false]]}},{"schema":{"name":"other","fields":[{"name":"value","type":"number","typeInfo":{"frame":"float64"}}]},"data":{"values":[[1]]}}]}}}`, str)
+	require.Equal(t, `{"results":{"A":{"frames":[{"schema":{"name":"simple","fields":[{"name":"time","type":"time","typeInfo":{"frame":"time.Time"}},{"name":"valid","type":"boolean","typeInfo":{"frame":"bool"}}]},"data":{"values":[[1577934240000,1577934300000],[true,false]]}},{"schema":{"name":"other","fields":[{"name":"value","type":"number","typeInfo":{"frame":"float64"}}]},"data":{"values":[[1]]}}]}}}`, str)
 
 	// Read the parsed result and make sure it is the same
 	copy := &backend.QueryDataResponse{}

--- a/data/field_type.go
+++ b/data/field_type.go
@@ -298,7 +298,7 @@ func FieldTypeFromItemTypeString(s string) (FieldType, bool) {
 	case "*string":
 		return FieldTypeNullableString, true
 
-	case "bool":
+	case "bool", "boolean":
 		return FieldTypeBool, true
 	case "*bool":
 		return FieldTypeNullableBool, true

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -18,7 +18,7 @@ import (
 
 const simpleTypeString = "string"
 const simpleTypeNumber = "number"
-const simpleTypeBool = "bool"
+const simpleTypeBool = "boolean"
 const simpleTypeTime = "time"
 
 const jsonKeySchema = "schema"

--- a/data/testdata/all_types.golden.json
+++ b/data/testdata/all_types.golden.json
@@ -69,8 +69,8 @@
         "type": "number",
         "typeInfo": { "frame": "float64", "nullable": true }
       },
-      { "name": "bool_values", "type": "bool", "typeInfo": { "frame": "bool" } },
-      { "name": "nullable_bool_values", "type": "bool", "typeInfo": { "frame": "bool", "nullable": true } },
+      { "name": "bool_values", "type": "boolean", "typeInfo": { "frame": "bool" } },
+      { "name": "nullable_bool_values", "type": "boolean", "typeInfo": { "frame": "bool", "nullable": true } },
       { "name": "timestamps", "type": "time", "typeInfo": { "frame": "time.Time" } },
       { "name": "timestamps", "type": "time", "typeInfo": { "frame": "time.Time" } },
       { "name": "nullable_timestamps", "type": "time", "typeInfo": { "frame": "time.Time", "nullable": true } }


### PR DESCRIPTION
This fixes an issue where the fronted expects boolean types to be identified as "boolean" not "bool"