### PR TITLE
Allow custom build args

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -94,6 +94,17 @@ func buildBackend(cfg Config) error {
 	args := []string{
 		"build", "-o", filepath.Join("dist", exeName),
 	}
+	var customVars []string
+	if len(cfg.CustomVars) > 0 {
+		for k, v := range cfg.CustomVars {
+			customVars = append(customVars, fmt.Sprintf("-X '%s=%s'", k, v))
+		}
+		prefix := ""
+		if ldFlags != "" {
+			prefix = " "
+		}
+		ldFlags = fmt.Sprintf("%s%s%s", strings.Join(customVars, " "), prefix, ldFlags)
+	}
 	if ldFlags != "" {
 		args = append(args, "-ldflags", ldFlags)
 	}

--- a/build/types.go
+++ b/build/types.go
@@ -4,6 +4,7 @@ package build
 type Config struct {
 	OS          string // GOOS
 	Arch        string // GOOS
+	CustomVars  map[string]string
 	EnableDebug bool
 	Env         map[string]string
 	EnableCGo   bool


### PR DESCRIPTION
**What this PR does / why we need it**:

If #321 is deemed a decent enhancement, here is a PR that accomplishes what we are looking for.

A sample usage:

```go
func init() {
	build.SetBeforeBuildCallback(func(cfg build.Config) (build.Config, error) {
		appVersion := os.Getenv("APP_VERSION")
		if appVersion == "" {
			appVersion = "master"
		}

		releaseEnv := os.Getenv("RELEASE_STAGE")
		if releaseEnv == "" {
			releaseEnv = "development"
		}
		cfg.CustomVars = map[string]string{
			"main.AppVersion": appVersion,
			"main.ReleaseStage": releaseEnv,
		}
		return cfg, nil
	})
}

// Default configures the default target.
var Default = build.BuildAll
```

**Which issue(s) this PR fixes**:

Fixes #321 

**Special notes for your reviewer**:
