### PR TITLE
Live: remove push scope

### DIFF
--- a/live/channel.go
+++ b/live/channel.go
@@ -17,7 +17,7 @@ type Channel struct {
 	// * when ScopeStream, namespace is the stream ID.
 	Namespace string `json:"namespace,omitempty"`
 
-	// Within each namespace, the handler can process the path as needed.
+	// Within each scope and namespace, the handler can process the path as needed.
 	Path string `json:"path,omitempty"`
 }
 
@@ -52,9 +52,5 @@ func (c Channel) String() string {
 
 // IsValid checks if all parts of the address are valid.
 func (c *Channel) IsValid() bool {
-	if c.Scope == ScopePush {
-		// Push scope channels supposed to be like push/{$stream_id}.
-		return c.Namespace != "" && c.Path == ""
-	}
 	return c.Scope != "" && c.Namespace != "" && c.Path != ""
 }

--- a/live/channel_test.go
+++ b/live/channel_test.go
@@ -48,16 +48,6 @@ func TestParseChannel_IsValid(t *testing.T) {
 			id:      "grafana",
 			isValid: false,
 		},
-		{
-			name:    "push_scope_no_path_valid",
-			id:      "push/telegraf",
-			isValid: true,
-		},
-		{
-			name:    "push_scope_with_path_invalid",
-			id:      "push/telegraf/test",
-			isValid: false,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/live/doc.go
+++ b/live/doc.go
@@ -1,2 +1,2 @@
-// Package live provides access to the GrafanaLive server [ALPHA]
+// Package live provides types for the Grafana Live server.
 package live

--- a/live/scope.go
+++ b/live/scope.go
@@ -1,7 +1,7 @@
 package live
 
 const (
-	// ScopeGrafana contains builtin features of Grafana Core.
+	// ScopeGrafana contains builtin real-time features of Grafana Core.
 	ScopeGrafana = "grafana"
 	// ScopePlugin passes control to a plugin.
 	ScopePlugin = "plugin"
@@ -9,6 +9,4 @@ const (
 	ScopeDatasource = "ds"
 	// ScopeStream is a managed data frame stream.
 	ScopeStream = "stream"
-	// ScopePush allows sending data into managed streams. It does not support subscriptions.
-	ScopePush = "push"
 )


### PR DESCRIPTION
Looks like with WebSocket output plugin we don't really need to have this scope.