### PR TITLE
Chore: Remove debug logs in query type mux

### DIFF
--- a/backend/datasource/query_type_mux.go
+++ b/backend/datasource/query_type_mux.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 // QueryTypeMux is a query type multiplexer.
@@ -40,12 +39,10 @@ func (mux *QueryTypeMux) Handle(queryType string, handler backend.QueryDataHandl
 	}
 
 	if queryType == "" {
-		log.DefaultLogger.Debug("datasource: registering query type fallback handler")
 		mux.fallbackHandler = handler
 		return
 	}
 
-	log.DefaultLogger.Debug("datasource: registering query type handler", "queryType", queryType)
 	mux.m[queryType] = handler
 }
 

--- a/backend/resource/httpadapter/response_writer.go
+++ b/backend/resource/httpadapter/response_writer.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 // callResourceResponseWriter is an implementation of http.ResponseWriter that
@@ -121,7 +122,7 @@ func (rw *callResourceResponseWriter) Flush() {
 	resp := rw.getResponse()
 	if resp != nil {
 		if err := rw.stream.Send(resp); err != nil {
-			backend.Logger.Error("Failed to send resource response", "error", err)
+			log.DefaultLogger.Error("Failed to send resource response", "error", err)
 		}
 	}
 


### PR DESCRIPTION
Ref https://github.com/grafana/grafana/issues/33779

There's still a log line left in httpadapter package, but should "never" happen. Longer term we might do something more future proof.