### PR TITLE
Actions: move actions from grafana-edge app to experimental

### DIFF
--- a/experimental/actions/models.go
+++ b/experimental/actions/models.go
@@ -1,0 +1,22 @@
+package actions
+
+import "context"
+
+// ActionCommand write the values
+type ActionCommand struct {
+	ID      string      `json:"id,omitempty"`      // Identify the command (optional)
+	Path    string      `json:"path,omitempty"`    // Path for the value
+	Value   interface{} `json:"value,omitempty"`   // Write values
+	Comment string      `json:"comment,omitempty"` // Write all values or
+	From    string      `json:"from,omitempty"`    // optional say where the command was listed from
+}
+
+type ActionResponse struct {
+	Code  int         `json:"code,omitempty"` // Match HTTP response code
+	Error string      `json:"error,omitempty"`
+	State interface{} `json:"state,omitempty"`
+}
+
+type ActionHandler interface {
+	ExecuteAction(ctx context.Context, cmd ActionCommand) ActionResponse
+}

--- a/experimental/actions/service.go
+++ b/experimental/actions/service.go
@@ -1,0 +1,40 @@
+package actions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func DoActionCommand(ctx context.Context, req *backend.CallResourceRequest, handler ActionHandler, sender backend.CallResourceResponseSender) error {
+	rsp := ActionResponse{}
+	cmd := &ActionCommand{}
+
+	if req.Method == "POST" {
+		if err := json.Unmarshal(req.Body, cmd); err != nil {
+			return fmt.Errorf("error read")
+		}
+		rsp = handler.ExecuteAction(ctx, *cmd)
+	} else {
+		return sender.Send(&backend.CallResourceResponse{
+			Status: http.StatusMethodNotAllowed,
+			Body:   []byte("Expects GET|POST"),
+		})
+	}
+
+	json, err := json.Marshal(rsp)
+	if err != nil {
+		return err
+	}
+
+	// Log results somewhere
+	backend.Logger.Info("ACTION", "user", req.PluginContext.User, "cmd", cmd, "result", rsp)
+
+	return sender.Send(&backend.CallResourceResponse{
+		Status: rsp.Code,
+		Body:   json,
+	})
+}


### PR DESCRIPTION
We have been working with a private api for a while -- it is not totally ready for prime time, but would be nice to have in a public repo so we can make the raspberry-pi repo public and still support actions. 