### PR TITLE
build: Allow custom package path

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -122,7 +122,11 @@ func buildBackend(cfg Config) error {
 	if cfg.EnableDebug {
 		args = append(args, "-gcflags=all=-N -l")
 	}
-	args = append(args, "./pkg")
+	rootPackage := "./pkg"
+	if cfg.RootPackagePath != "" {
+		rootPackage = cfg.RootPackagePath
+	}
+	args = append(args, rootPackage)
 
 	cfg.Env["GOARCH"] = cfg.Arch
 	cfg.Env["GOOS"] = cfg.OS

--- a/build/types.go
+++ b/build/types.go
@@ -2,12 +2,13 @@ package build
 
 // Config holds the setup variables required for a build
 type Config struct {
-	OS          string // GOOS
-	Arch        string // GOOS
-	EnableDebug bool
-	CustomVars  map[string]string
-	Env         map[string]string
-	EnableCGo   bool
+	OS              string // GOOS
+	Arch            string // GOOS
+	EnableDebug     bool
+	CustomVars      map[string]string
+	Env             map[string]string
+	EnableCGo       bool
+	RootPackagePath string
 }
 
 // BeforeBuildCallback hooks into the build process


### PR DESCRIPTION
**What this PR does / why we need it**:

We would like to allow for a more standard go project layout by moving our `main` package out of `./pkg`. This PR allows setting a custom path to be used when building the binaries instead only allowing `./pkg`