### PR TITLE
Feat: framestruct should nil-pad DataFrame fields

### DIFF
--- a/data/framestruct/converter.go
+++ b/data/framestruct/converter.go
@@ -173,7 +173,12 @@ func (c *converter) upsertField(v reflect.Value, fieldName string) error {
 
 		c.fields[fieldName] = data.NewField(fieldName, nil, v)
 	}
-	c.fields[fieldName].Append(v.Interface())
+
+	ptr, err := toPointer(v.Interface())
+	if err != nil {
+		return err
+	}
+	c.fields[fieldName].Append(ptr)
 	return nil
 }
 

--- a/data/framestruct/converter_test.go
+++ b/data/framestruct/converter_test.go
@@ -19,9 +19,9 @@ func TestStructs(t *testing.T) {
 		require.Equal(t, "Results", frame.Name)
 		require.Len(t, frame.Fields, 3)
 
-		require.Equal(t, "foo", frame.Fields[0].At(0))
-		require.Equal(t, int32(36), frame.Fields[1].At(0))
-		require.Equal(t, "baz", frame.Fields[2].At(0))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
+		require.Equal(t, "baz", fromPointer(frame.Fields[2].At(0)))
 	})
 
 	t.Run("it treats times as a value", func(t *testing.T) {
@@ -33,7 +33,7 @@ func TestStructs(t *testing.T) {
 
 		require.Equal(t, "Results", frame.Name)
 		require.Len(t, frame.Fields, 1)
-		require.Equal(t, tme, frame.Fields[0].At(0))
+		require.Equal(t, tme, fromPointer(frame.Fields[0].At(0)))
 	})
 
 	t.Run("it treats time pointers as a value", func(t *testing.T) {
@@ -57,9 +57,9 @@ func TestStructs(t *testing.T) {
 		require.Equal(t, "Results", frame.Name)
 		require.Len(t, frame.Fields, 3)
 
-		require.Equal(t, "foo", frame.Fields[0].At(0))
-		require.Equal(t, int32(36), frame.Fields[1].At(0))
-		require.Equal(t, "baz", frame.Fields[2].At(0))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
+		require.Equal(t, "baz", fromPointer(frame.Fields[2].At(0)))
 	})
 
 	t.Run("it flattens structs with maps", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestStructs(t *testing.T) {
 
 		require.Len(t, frame.Fields, 1)
 		require.Equal(t, "Foo.Thing1", frame.Fields[0].Name)
-		require.Equal(t, "foo", frame.Fields[0].At(0))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
 	})
 
 	t.Run("it properly handles pointers", func(t *testing.T) {
@@ -86,8 +86,7 @@ func TestStructs(t *testing.T) {
 
 		require.Len(t, frame.Fields, 1)
 
-		val := frame.Fields[0].At(0).(*string)
-		require.Equal(t, "foo", *val)
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
 	})
 
 	t.Run("it ignores unexported fields", func(t *testing.T) {
@@ -120,24 +119,24 @@ func TestStructs(t *testing.T) {
 		require.Equal(t, 2, frame.Fields[4].Len())
 
 		require.Equal(t, "Thing1", frame.Fields[0].Name)
-		require.Equal(t, "foo", frame.Fields[0].At(0))
-		require.Equal(t, "foo1", frame.Fields[0].At(1))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
+		require.Equal(t, "foo1", fromPointer(frame.Fields[0].At(1)))
 
 		require.Equal(t, "Thing2", frame.Fields[1].Name)
-		require.Equal(t, int32(36), frame.Fields[1].At(0))
-		require.Equal(t, int32(37), frame.Fields[1].At(1))
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
+		require.Equal(t, int32(37), fromPointer(frame.Fields[1].At(1)))
 
 		require.Equal(t, "Thing3", frame.Fields[2].Name)
-		require.Equal(t, "baz", frame.Fields[2].At(0))
-		require.Equal(t, "baz1", frame.Fields[2].At(1))
+		require.Equal(t, "baz", fromPointer(frame.Fields[2].At(0)))
+		require.Equal(t, "baz1", fromPointer(frame.Fields[2].At(1)))
 
 		require.Equal(t, "Thing4.Thing7", frame.Fields[3].Name)
-		require.Equal(t, true, frame.Fields[3].At(0))
-		require.Equal(t, false, frame.Fields[3].At(1))
+		require.Equal(t, true, fromPointer(frame.Fields[3].At(0)))
+		require.Equal(t, false, fromPointer(frame.Fields[3].At(1)))
 
 		require.Equal(t, "Thing4.Thing8", frame.Fields[4].Name)
-		require.Equal(t, int64(100), frame.Fields[4].At(0))
-		require.Equal(t, int64(101), frame.Fields[4].At(1))
+		require.Equal(t, int64(100), fromPointer(frame.Fields[4].At(0)))
+		require.Equal(t, int64(101), fromPointer(frame.Fields[4].At(1)))
 	})
 
 	t.Run("it returns an error when the struct contains an unsupported type", func(t *testing.T) {
@@ -209,14 +208,14 @@ func TestSlices(t *testing.T) {
 		require.Equal(t, 2, frame.Fields[1].Len())
 		require.Equal(t, 2, frame.Fields[2].Len())
 
-		require.Equal(t, "foo", frame.Fields[0].At(0))
-		require.Equal(t, "foo1", frame.Fields[0].At(1))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
+		require.Equal(t, "foo1", fromPointer(frame.Fields[0].At(1)))
 
-		require.Equal(t, int32(36), frame.Fields[1].At(0))
-		require.Equal(t, int32(37), frame.Fields[1].At(1))
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
+		require.Equal(t, int32(37), fromPointer(frame.Fields[1].At(1)))
 
-		require.Equal(t, "baz", frame.Fields[2].At(0))
-		require.Equal(t, "baz1", frame.Fields[2].At(1))
+		require.Equal(t, "baz", fromPointer(frame.Fields[2].At(0)))
+		require.Equal(t, "baz1", fromPointer(frame.Fields[2].At(1)))
 	})
 
 	t.Run("it flattens a pointer to a slice of structs", func(t *testing.T) {
@@ -233,14 +232,14 @@ func TestSlices(t *testing.T) {
 		require.Equal(t, 2, frame.Fields[1].Len())
 		require.Equal(t, 2, frame.Fields[2].Len())
 
-		require.Equal(t, "foo", frame.Fields[0].At(0))
-		require.Equal(t, "foo1", frame.Fields[0].At(1))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
+		require.Equal(t, "foo1", fromPointer(frame.Fields[0].At(1)))
 
-		require.Equal(t, int32(36), frame.Fields[1].At(0))
-		require.Equal(t, int32(37), frame.Fields[1].At(1))
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
+		require.Equal(t, int32(37), fromPointer(frame.Fields[1].At(1)))
 
-		require.Equal(t, "baz", frame.Fields[2].At(0))
-		require.Equal(t, "baz1", frame.Fields[2].At(1))
+		require.Equal(t, "baz", fromPointer(frame.Fields[2].At(0)))
+		require.Equal(t, "baz1", fromPointer(frame.Fields[2].At(1)))
 	})
 
 	t.Run("it flattens a slice of maps", func(t *testing.T) {
@@ -265,14 +264,14 @@ func TestSlices(t *testing.T) {
 		require.Equal(t, 2, frame.Fields[1].Len())
 		require.Equal(t, 2, frame.Fields[2].Len())
 
-		require.Equal(t, "foo", frame.Fields[0].At(0))
-		require.Equal(t, "foo1", frame.Fields[0].At(1))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
+		require.Equal(t, "foo1", fromPointer(frame.Fields[0].At(1)))
 
-		require.Equal(t, int32(36), frame.Fields[1].At(0))
-		require.Equal(t, int32(37), frame.Fields[1].At(1))
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
+		require.Equal(t, int32(37), fromPointer(frame.Fields[1].At(1)))
 
-		require.Equal(t, "baz", frame.Fields[2].At(0))
-		require.Equal(t, "baz1", frame.Fields[2].At(1))
+		require.Equal(t, "baz", fromPointer(frame.Fields[2].At(0)))
+		require.Equal(t, "baz1", fromPointer(frame.Fields[2].At(1)))
 	})
 }
 
@@ -288,9 +287,9 @@ func TestMaps(t *testing.T) {
 		require.Nil(t, err)
 
 		require.Len(t, frame.Fields, 3)
-		require.Equal(t, "foo", frame.Fields[0].At(0))
-		require.Equal(t, int32(36), frame.Fields[1].At(0))
-		require.Equal(t, "baz", frame.Fields[2].At(0))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
+		require.Equal(t, "baz", fromPointer(frame.Fields[2].At(0)))
 	})
 
 	t.Run("it flattens nested maps with dot-names", func(t *testing.T) {
@@ -308,16 +307,16 @@ func TestMaps(t *testing.T) {
 
 		require.Len(t, frame.Fields, 4)
 		require.Equal(t, "Thing1", frame.Fields[0].Name)
-		require.Equal(t, "foo", frame.Fields[0].At(0))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
 
 		require.Equal(t, "Thing2", frame.Fields[1].Name)
-		require.Equal(t, int32(36), frame.Fields[1].At(0))
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
 
 		require.Equal(t, "Thing3.Thing4", frame.Fields[2].Name)
-		require.Equal(t, true, frame.Fields[2].At(0))
+		require.Equal(t, true, fromPointer(frame.Fields[2].At(0)))
 
 		require.Equal(t, "Thing3.Thing5", frame.Fields[3].Name)
-		require.Equal(t, int32(100), frame.Fields[3].At(0))
+		require.Equal(t, int32(100), fromPointer(frame.Fields[3].At(0)))
 	})
 
 	t.Run("it flattens maps with structs", func(t *testing.T) {
@@ -335,16 +334,16 @@ func TestMaps(t *testing.T) {
 
 		require.Len(t, frame.Fields, 4)
 		require.Equal(t, "Thing1", frame.Fields[0].Name)
-		require.Equal(t, "foo", frame.Fields[0].At(0))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
 
 		require.Equal(t, "Thing2", frame.Fields[1].Name)
-		require.Equal(t, int32(36), frame.Fields[1].At(0))
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
 
 		require.Equal(t, "Thing3.Thing7", frame.Fields[2].Name)
-		require.Equal(t, false, frame.Fields[2].At(0))
+		require.Equal(t, false, fromPointer(frame.Fields[2].At(0)))
 
 		require.Equal(t, "Thing3.Thing8", frame.Fields[3].Name)
-		require.Equal(t, int64(100), frame.Fields[3].At(0))
+		require.Equal(t, int64(100), fromPointer(frame.Fields[3].At(0)))
 	})
 
 	t.Run("it flattens maps with slices of structs", func(t *testing.T) {
@@ -362,16 +361,16 @@ func TestMaps(t *testing.T) {
 
 		require.Len(t, frame.Fields, 4)
 		require.Equal(t, "Thing1", frame.Fields[0].Name)
-		require.Equal(t, "foo", frame.Fields[0].At(0))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
 
 		require.Equal(t, "Thing2", frame.Fields[1].Name)
-		require.Equal(t, int32(36), frame.Fields[1].At(0))
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
 
 		require.Equal(t, "Thing3.Thing7", frame.Fields[2].Name)
-		require.Equal(t, false, frame.Fields[2].At(0))
+		require.Equal(t, false, fromPointer(frame.Fields[2].At(0)))
 
 		require.Equal(t, "Thing3.Thing8", frame.Fields[3].Name)
-		require.Equal(t, int64(100), frame.Fields[3].At(0))
+		require.Equal(t, int64(100), fromPointer(frame.Fields[3].At(0)))
 	})
 
 	t.Run("it returns an error when any map contains an unsupported type", func(t *testing.T) {
@@ -429,10 +428,10 @@ func TestStructTags(t *testing.T) {
 
 		require.Len(t, frame.Fields, 2)
 		require.Equal(t, "first-thing", frame.Fields[0].Name)
-		require.Equal(t, "foo", frame.Fields[0].At(0))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
 
 		require.Equal(t, "third-thing", frame.Fields[1].Name)
-		require.Equal(t, "baz", frame.Fields[1].At(0))
+		require.Equal(t, "baz", fromPointer(frame.Fields[1].At(0)))
 	})
 
 	t.Run("it uses struct tags if they're present", func(t *testing.T) {
@@ -450,16 +449,16 @@ func TestStructTags(t *testing.T) {
 
 		require.Len(t, frame.Fields, 4)
 		require.Equal(t, "first-thing", frame.Fields[0].Name)
-		require.Equal(t, "foo", frame.Fields[0].At(0))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
 
 		require.Equal(t, "second-thing", frame.Fields[1].Name)
-		require.Equal(t, "bar", frame.Fields[1].At(0))
+		require.Equal(t, "bar", fromPointer(frame.Fields[1].At(0)))
 
 		require.Equal(t, "third-thing.Thing7", frame.Fields[2].Name)
-		require.Equal(t, true, frame.Fields[2].At(0))
+		require.Equal(t, true, fromPointer(frame.Fields[2].At(0)))
 
 		require.Equal(t, "third-thing.Thing8", frame.Fields[3].Name)
-		require.Equal(t, int64(100), frame.Fields[3].At(0))
+		require.Equal(t, int64(100), fromPointer(frame.Fields[3].At(0)))
 	})
 
 	t.Run("omits the parent struct name if omitparent is present", func(t *testing.T) {
@@ -481,22 +480,22 @@ func TestStructTags(t *testing.T) {
 
 		require.Len(t, frame.Fields, 6)
 		require.Equal(t, "first-thing", frame.Fields[0].Name)
-		require.Equal(t, "foo", frame.Fields[0].At(0))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
 
 		require.Equal(t, "second-thing", frame.Fields[1].Name)
-		require.Equal(t, "bar", frame.Fields[1].At(0))
+		require.Equal(t, "bar", fromPointer(frame.Fields[1].At(0)))
 
 		require.Equal(t, "Thing5", frame.Fields[2].Name)
-		require.Equal(t, true, frame.Fields[2].At(0))
+		require.Equal(t, true, fromPointer(frame.Fields[2].At(0)))
 
 		require.Equal(t, "Thing6", frame.Fields[3].Name)
-		require.Equal(t, int64(100), frame.Fields[3].At(0))
+		require.Equal(t, int64(100), fromPointer(frame.Fields[3].At(0)))
 
 		require.Equal(t, "omitparent.Thing7", frame.Fields[4].Name)
-		require.Equal(t, false, frame.Fields[4].At(0))
+		require.Equal(t, false, fromPointer(frame.Fields[4].At(0)))
 
 		require.Equal(t, "omitparent.Thing8", frame.Fields[5].Name)
-		require.Equal(t, int64(200), frame.Fields[5].At(0))
+		require.Equal(t, int64(200), fromPointer(frame.Fields[5].At(0)))
 	})
 
 	t.Run("sets the column with col0 to be the 0th column", func(t *testing.T) {
@@ -578,16 +577,16 @@ func TestStructTags(t *testing.T) {
 
 		require.Len(t, frame.Fields, 4)
 		require.Equal(t, "Thing1", frame.Fields[0].Name)
-		require.Equal(t, "foo", frame.Fields[0].At(0))
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
 
 		require.Equal(t, "Thing2", frame.Fields[1].Name)
-		require.Equal(t, int32(36), frame.Fields[1].At(0))
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
 
 		require.Equal(t, "Thing5", frame.Fields[2].Name)
-		require.Equal(t, false, frame.Fields[2].At(0))
+		require.Equal(t, false, fromPointer(frame.Fields[2].At(0)))
 
 		require.Equal(t, "Thing6", frame.Fields[3].Name)
-		require.Equal(t, int64(100), frame.Fields[3].At(0))
+		require.Equal(t, int64(100), fromPointer(frame.Fields[3].At(0)))
 	})
 }
 func TestToDataframe(t *testing.T) {
@@ -790,4 +789,37 @@ func (f *mockFramer) Frames() (data.Frames, error) {
 	f.called = true
 	frame := data.NewFrame("New Frame")
 	return []*data.Frame{frame}, nil
+}
+
+func fromPointer(value interface{}) interface{} {
+	switch v := value.(type) {
+	case *int8:
+		return *v
+	case *int16:
+		return *v
+	case *int32:
+		return *v
+	case *int64:
+		return *v
+	case *uint8:
+		return *v
+	case *uint16:
+		return *v
+	case *uint32:
+		return *v
+	case *uint64:
+		return *v
+	case *float32:
+		return *v
+	case *float64:
+		return *v
+	case *string:
+		return *v
+	case *bool:
+		return *v
+	case *time.Time:
+		return *v
+	default:
+		return nil
+	}
 }

--- a/data/framestruct/converter_test.go
+++ b/data/framestruct/converter_test.go
@@ -273,6 +273,42 @@ func TestSlices(t *testing.T) {
 		require.Equal(t, "baz", fromPointer(frame.Fields[2].At(0)))
 		require.Equal(t, "baz1", fromPointer(frame.Fields[2].At(1)))
 	})
+
+	t.Run("it flattens a slice of maps that are different sizes", func(t *testing.T) {
+		maps := []map[string]interface{}{
+			{
+				"Thing1": "foo",
+				"Thing2": int32(36),
+			},
+			{
+				"Thing1": "foo1",
+				"Thing3": "baz1",
+			},
+		}
+
+		// result
+		// | Thing1 | Thing2 | Thing3 |
+		// |--------+--------+--------|
+		// | foo    | 36     | nil    |
+		// | foo1   | nil    | baz1   |
+
+		frame, err := framestruct.ToDataFrame("results", maps)
+		require.Nil(t, err)
+
+		require.Len(t, frame.Fields, 3)
+		require.Equal(t, 2, frame.Fields[0].Len())
+		require.Equal(t, 2, frame.Fields[1].Len())
+		require.Equal(t, 2, frame.Fields[2].Len())
+
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
+		require.Equal(t, "foo1", fromPointer(frame.Fields[0].At(1)))
+
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
+		require.Nil(t, frame.Fields[1].At(1))
+
+		require.Nil(t, frame.Fields[2].At(0))
+		require.Equal(t, "baz1", fromPointer(frame.Fields[2].At(1)))
+	})
 }
 
 func TestMaps(t *testing.T) {

--- a/data/framestruct/types.go
+++ b/data/framestruct/types.go
@@ -9,59 +9,131 @@ import (
 func sliceFor(value interface{}) (interface{}, error) {
 	switch v := value.(type) {
 	case int8:
-		return []int8{}, nil
+		return []*int8{}, nil
 	case *int8:
 		return []*int8{}, nil
 	case int16:
-		return []int16{}, nil
+		return []*int16{}, nil
 	case *int16:
 		return []*int16{}, nil
 	case int32:
-		return []int32{}, nil
+		return []*int32{}, nil
 	case *int32:
 		return []*int32{}, nil
 	case int64:
-		return []int64{}, nil
+		return []*int64{}, nil
 	case *int64:
 		return []*int64{}, nil
 	case uint8:
-		return []uint8{}, nil
+		return []*uint8{}, nil
 	case *uint8:
 		return []*uint8{}, nil
 	case uint16:
-		return []uint16{}, nil
+		return []*uint16{}, nil
 	case *uint16:
 		return []*uint16{}, nil
 	case uint32:
-		return []uint32{}, nil
+		return []*uint32{}, nil
 	case *uint32:
 		return []*uint32{}, nil
 	case uint64:
-		return []uint64{}, nil
+		return []*uint64{}, nil
 	case *uint64:
 		return []*uint64{}, nil
 	case float32:
-		return []float32{}, nil
+		return []*float32{}, nil
 	case *float32:
 		return []*float32{}, nil
 	case float64:
-		return []float64{}, nil
+		return []*float64{}, nil
 	case *float64:
 		return []*float64{}, nil
 	case string:
-		return []string{}, nil
+		return []*string{}, nil
 	case *string:
 		return []*string{}, nil
 	case bool:
-		return []bool{}, nil
+		return []*bool{}, nil
 	case *bool:
 		return []*bool{}, nil
 	case time.Time:
-		return []time.Time{}, nil
+		return []*time.Time{}, nil
 	case *time.Time:
 		return []*time.Time{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported type %T", v)
+	}
+}
+
+func toPointer(value interface{}) (interface{}, error) {
+	switch t := value.(type) {
+	case int8:
+		v := value.(int8)
+		return &v, nil
+	case *int8:
+		return value, nil
+	case int16:
+		v := value.(int16)
+		return &v, nil
+	case *int16:
+		return value, nil
+	case int32:
+		v := value.(int32)
+		return &v, nil
+	case *int32:
+		return value, nil
+	case int64:
+		v := value.(int64)
+		return &v, nil
+	case *int64:
+		return value, nil
+	case uint8:
+		v := value.(uint8)
+		return &v, nil
+	case *uint8:
+		return value, nil
+	case uint16:
+		v := value.(uint16)
+		return &v, nil
+	case *uint16:
+		return value, nil
+	case uint32:
+		v := value.(uint32)
+		return &v, nil
+	case *uint32:
+		return value, nil
+	case uint64:
+		v := value.(uint64)
+		return &v, nil
+	case *uint64:
+		return value, nil
+	case float32:
+		v := value.(float32)
+		return &v, nil
+	case *float32:
+		return value, nil
+	case float64:
+		v := value.(float64)
+		return &v, nil
+	case *float64:
+		return value, nil
+	case string:
+		v := value.(string)
+		return &v, nil
+	case *string:
+		return value, nil
+	case bool:
+		v := value.(bool)
+		return &v, nil
+	case *bool:
+		return value, nil
+	case time.Time:
+		v := value.(time.Time)
+		return &v, nil
+	case *time.Time:
+		return value, nil
+	default:
+		return nil, fmt.Errorf("unsupported type %T", t)
 	}
 }
 

--- a/data/framestruct/types.go
+++ b/data/framestruct/types.go
@@ -65,75 +65,62 @@ func sliceFor(value interface{}) (interface{}, error) {
 	}
 }
 
-func toPointer(value interface{}) (interface{}, error) {
-	switch t := value.(type) {
+func toPointer(value interface{}) interface{} {
+	switch v := value.(type) {
 	case int8:
-		v := value.(int8)
-		return &v, nil
+		return &v
 	case *int8:
-		return value, nil
+		return value
 	case int16:
-		v := value.(int16)
-		return &v, nil
+		return &v
 	case *int16:
-		return value, nil
+		return value
 	case int32:
-		v := value.(int32)
-		return &v, nil
+		return &v
 	case *int32:
-		return value, nil
+		return value
 	case int64:
-		v := value.(int64)
-		return &v, nil
+		return &v
 	case *int64:
-		return value, nil
+		return value
 	case uint8:
-		v := value.(uint8)
-		return &v, nil
+		return &v
 	case *uint8:
-		return value, nil
+		return value
 	case uint16:
-		v := value.(uint16)
-		return &v, nil
+		return &v
 	case *uint16:
-		return value, nil
+		return value
 	case uint32:
-		v := value.(uint32)
-		return &v, nil
+		return &v
 	case *uint32:
-		return value, nil
+		return value
 	case uint64:
-		v := value.(uint64)
-		return &v, nil
+		return &v
 	case *uint64:
-		return value, nil
+		return value
 	case float32:
-		v := value.(float32)
-		return &v, nil
+		return &v
 	case *float32:
-		return value, nil
+		return value
 	case float64:
-		v := value.(float64)
-		return &v, nil
+		return &v
 	case *float64:
-		return value, nil
+		return value
 	case string:
-		v := value.(string)
-		return &v, nil
+		return &v
 	case *string:
-		return value, nil
+		return value
 	case bool:
-		v := value.(bool)
-		return &v, nil
+		return &v
 	case *bool:
-		return value, nil
+		return value
 	case time.Time:
-		v := value.(time.Time)
-		return &v, nil
+		return &v
 	case *time.Time:
-		return value, nil
+		return value
 	default:
-		return nil, fmt.Errorf("unsupported type %T", t)
+		return nil
 	}
 }
 


### PR DESCRIPTION
When returned as arbitrary maps from an API, results sometimes contain subsets of possible data that we'd like to be part of a single dataframe. In this case, to keep the data aligned, framestruct needs to pad the fields.

example:
```
api response:
[
    {
        "Thing1": "foo",
        "Thing2": 36
    },
    {
        "Thing1": "foo1",
        "Thing3": "baz1"
    }
]

Dataframe result
| Thing1 | Thing2 | Thing3 |
|--------+--------+--------|
| foo    | 36     | nil    |
| foo1   | nil    | baz1   |
```

To achieve this, there are two main changed:
- Framestruct not converts all values to pointers
- prepend or pad nils as necessary to ensure that fields are always the same length
