### PR TITLE
Ensure stable key order when iterating maps.

### DIFF
--- a/data/framestruct/converter.go
+++ b/data/framestruct/converter.go
@@ -152,13 +152,7 @@ func (c *converter) convertMap(toConvert interface{}, tags, prefix string) error
 		return errors.New("map must be map[string]interface{}")
 	}
 
-	var names []string
-	for name := range m {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
+	for _, name := range sortedKeys(m) {
 		value := m[name]
 		fieldName := c.fieldName(name, tags, prefix)
 		v := c.ensureValue(reflect.ValueOf(value))
@@ -168,6 +162,19 @@ func (c *converter) convertMap(toConvert interface{}, tags, prefix string) error
 	}
 
 	return nil
+}
+
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, len(m))
+
+	var idx int
+	for key := range m {
+		keys[idx] = key
+		idx++
+	}
+	sort.Strings(keys)
+
+	return keys
 }
 
 func (c *converter) upsertField(v reflect.Value, fieldName string) error {

--- a/data/framestruct/converter.go
+++ b/data/framestruct/converter.go
@@ -152,7 +152,14 @@ func (c *converter) convertMap(toConvert interface{}, tags, prefix string) error
 		return errors.New("map must be map[string]interface{}")
 	}
 
-	for name, value := range m {
+	var names []string
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		value := m[name]
 		fieldName := c.fieldName(name, tags, prefix)
 		v := c.ensureValue(reflect.ValueOf(value))
 		if err := c.handleValue(v, "", fieldName); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
When converting maps, sort the keys so the resulting dataframes are created deterministically.

**Which issue(s) this PR fixes**:
Fixes #348