### PR TITLE
build: allow custom output path

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -95,8 +95,12 @@ func buildBackend(cfg Config) error {
 		ldFlags = fmt.Sprintf("-w -s%s%s", prefix, ldFlags)
 	}
 
+	outputPath := cfg.OutputBinaryPath
+	if outputPath == "" {
+		outputPath = "dist"
+	}
 	args := []string{
-		"build", "-o", filepath.Join("dist", exeName),
+		"build", "-o", filepath.Join(outputPath, exeName),
 	}
 
 	info := getBuildInfoFromEnvironment()

--- a/build/types.go
+++ b/build/types.go
@@ -2,13 +2,14 @@ package build
 
 // Config holds the setup variables required for a build
 type Config struct {
-	OS              string // GOOS
-	Arch            string // GOOS
-	EnableDebug     bool
-	CustomVars      map[string]string
-	Env             map[string]string
-	EnableCGo       bool
-	RootPackagePath string
+	OS               string // GOOS
+	Arch             string // GOOS
+	EnableDebug      bool
+	CustomVars       map[string]string
+	Env              map[string]string
+	EnableCGo        bool
+	RootPackagePath  string
+	OutputBinaryPath string
 }
 
 // BeforeBuildCallback hooks into the build process


### PR DESCRIPTION
When building an app plugin with the Go package in the root folder and
the datasource in `src/datasources/somesource` it becomes necessary to
output the binary to `dist/datasources/somesource`. 