### PR TITLE
HTTP Client: Fix provider middleware not forwarded to client

### DIFF
--- a/backend/httpclient/provider.go
+++ b/backend/httpclient/provider.go
@@ -159,6 +159,7 @@ func (p *Provider) createClientOptions(providedOpts ...Options) Options {
 		}
 	case 1:
 		clientOpts = providedOpts[0]
+		clientOpts.Middlewares = append(clientOpts.Middlewares, p.Opts.Middlewares...)
 	default:
 		panic("only an empty or one Options is valid as argument")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a problem where middlewares from provider was not propagated when creating client/transport.

Used by https://github.com/grafana/grafana/pull/33439

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
