### PR TITLE
JSON: add a json structure with both data and schema

### DIFF
--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -215,7 +215,9 @@ func (f ConvertFromProtobuf) SubscribeStreamRequest(protoReq *pluginv2.Subscribe
 func (f ConvertFromProtobuf) SubscribeStreamResponse(protoReq *pluginv2.SubscribeStreamResponse) *SubscribeStreamResponse {
 	return &SubscribeStreamResponse{
 		Status: SubscribeStreamStatus(protoReq.GetStatus()),
-		Data:   protoReq.GetData(),
+		InitialData: &InitialData{
+			data: protoReq.Data,
+		},
 	}
 }
 

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -205,14 +205,6 @@ func (t ConvertToProtobuf) RunStreamRequest(req *RunStreamRequest) *pluginv2.Run
 	return protoReq
 }
 
-// StreamPacket ...
-func (t ConvertToProtobuf) StreamPacket(p *StreamPacket) *pluginv2.StreamPacket {
-	protoReq := &pluginv2.StreamPacket{
-		Data: p.Data,
-	}
-	return protoReq
-}
-
 // SubscribeStreamRequest ...
 func (t ConvertToProtobuf) SubscribeStreamRequest(req *SubscribeStreamRequest) *pluginv2.SubscribeStreamRequest {
 	return &pluginv2.SubscribeStreamRequest{
@@ -223,10 +215,13 @@ func (t ConvertToProtobuf) SubscribeStreamRequest(req *SubscribeStreamRequest) *
 
 // SubscribeStreamResponse ...
 func (t ConvertToProtobuf) SubscribeStreamResponse(req *SubscribeStreamResponse) *pluginv2.SubscribeStreamResponse {
-	return &pluginv2.SubscribeStreamResponse{
+	resp := &pluginv2.SubscribeStreamResponse{
 		Status: pluginv2.SubscribeStreamResponse_Status(req.Status),
-		Data:   req.Data,
 	}
+	if req.InitialData != nil {
+		resp.Data = req.InitialData.data
+	}
+	return resp
 }
 
 // PublishStreamRequest ...
@@ -244,4 +239,12 @@ func (t ConvertToProtobuf) PublishStreamResponse(req *PublishStreamResponse) *pl
 		Status: pluginv2.PublishStreamResponse_Status(req.Status),
 		Data:   req.Data,
 	}
+}
+
+// StreamPacket ...
+func (t ConvertToProtobuf) StreamPacket(p *StreamPacket) *pluginv2.StreamPacket {
+	protoReq := &pluginv2.StreamPacket{
+		Data: p.Data,
+	}
+	return protoReq
 }

--- a/data/frame.go
+++ b/data/frame.go
@@ -51,7 +51,16 @@ func (f *Frame) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON marshals Frame to JSON.
 func (f *Frame) MarshalJSON() ([]byte, error) {
-	return FrameToJSON(f, true, true)
+	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	stream := cfg.BorrowStream(nil)
+	defer cfg.ReturnStream(stream)
+
+	writeDataFrame(f, stream, true, true)
+	if stream.Error != nil {
+		return nil, stream.Error
+	}
+
+	return append([]byte(nil), stream.Buffer()...), nil
 }
 
 // Frames is a slice of Frame pointers.

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -75,7 +75,13 @@ type FrameJSON struct {
 	data   json.RawMessage
 }
 
-// Body returns the bytes to both schema and data (if they exist)
+// Body will return everything saved in the json cache
+func (f *FrameJSON) Body() []byte {
+	return f.Bytes(IncludeAll)
+}
+
+// Bytes can return a subset of the cached frame json.  Note that requesting a section
+// that was not serialized on creation will return an empty value
 func (f *FrameJSON) Bytes(args FrameInclude) []byte {
 	if f.schema != nil && (args == IncludeAll || args == IncludeSchemaOnly) {
 		out := append([]byte(`{"`+jsonKeySchema+`":`), f.schema...)
@@ -146,7 +152,9 @@ func (f *FrameJSON) MarshalJSON() ([]byte, error) {
 	return f.Bytes(IncludeAll), nil
 }
 
-// FrameToJSON writes a frame to JSON.
+// FrameToJSON creates an object that holds schema and data independently.  This is
+// useful for explicit control between the data and schema.
+//
 // NOTE: the format should be considered experimental until grafana 8 is released.
 func FrameToJSON(frame *Frame, include FrameInclude) (FrameJSON, error) {
 	wrap := FrameJSON{}

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -61,9 +61,9 @@ type FrameJSONArg int
 
 // Declare related constants for each weekday starting with index 1
 const (
-	WithSchemaAndData FrameJSONArg = iota // EnumIndex = 0
-	WithData                              // EnumIndex = 1
-	WithSchema                            // EnumIndex = 2
+	WithSchemaAndData FrameJSONArg = iota + 1 // EnumIndex = 1
+	WithData                                  // EnumIndex = 2
+	WithSchema                                // EnumIndex = 3
 )
 
 // FrameJSON holds a byte representation of the schema separate from the data

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -73,11 +73,11 @@ type FrameJSON struct {
 }
 
 // Body returns the bytes to both schema and data (if they exist)
-func (f *FrameJSON) Body() []byte {
-	if f.schema != nil {
+func (f *FrameJSON) Bytes(args FrameJSONArg) []byte {
+	if f.schema != nil && (args == WithSchemaAndData || args == WithSchema) {
 		out := append([]byte(`{"`+jsonKeySchema+`": `), f.schema...)
 
-		if f.data != nil {
+		if f.data != nil && (args == WithSchemaAndData || args == WithData) {
 			out = append(out, (`, "` + jsonKeyData + `": `)...)
 			out = append(out, f.data...)
 		}
@@ -85,33 +85,13 @@ func (f *FrameJSON) Body() []byte {
 	}
 
 	// only data
-	if f.data != nil {
+	if f.data != nil && (args == WithSchemaAndData || args == WithData) {
 		out := []byte(`{"` + jsonKeyData + `": `)
 		out = append(out, f.data...)
 		return append(out, []byte("}")...)
 	}
 
 	return []byte("{}")
-}
-
-// Schema returns the bytes to the schema or nil if not definedd
-func (f *FrameJSON) Schema() []byte {
-	if f.schema != nil {
-		out := []byte(`{"` + jsonKeySchema + `": `)
-		out = append(out, f.schema...)
-		return append(out, []byte("}")...)
-	}
-	return nil
-}
-
-// Schema returns the bytes to the data or nil if not definedd
-func (f *FrameJSON) Data() []byte {
-	if f.data != nil {
-		out := []byte(`{"` + jsonKeyData + `": `)
-		out = append(out, f.data...)
-		return append(out, []byte("}")...)
-	}
-	return nil
 }
 
 // SameSchema checks if both structures have the same schema
@@ -160,7 +140,7 @@ func (f *FrameJSON) SetSchema(frame *Frame) error {
 
 // MarshalJSON marshals Frame to JSON.
 func (f *FrameJSON) MarshalJSON() ([]byte, error) {
-	return f.Body(), nil
+	return f.Bytes(WithSchemaAndData), nil
 }
 
 // FrameToJSON writes a frame to JSON.

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -154,24 +154,20 @@ func (f *FrameJSON) MarshalJSON() ([]byte, error) {
 
 // FrameToJSON creates an object that holds schema and data independently.  This is
 // useful for explicit control between the data and schema.
-// For simple json serialization use `json.Marshal(frame)`
+// For standard json serialization use `json.Marshal(frame)`
 //
 // NOTE: the format should be considered experimental until grafana 8 is released.
-func FrameToJSON(frame *Frame, include FrameInclude) (FrameJSON, error) {
+func FrameToJSON(frame *Frame) (FrameJSON, error) {
 	wrap := FrameJSON{}
 
-	if include == IncludeAll || include == IncludeSchemaOnly {
-		err := wrap.SetSchema(frame)
-		if err != nil {
-			return wrap, err
-		}
+	err := wrap.SetSchema(frame)
+	if err != nil {
+		return wrap, err
 	}
 
-	if include == IncludeAll || include == IncludeDataOnly {
-		err := wrap.SetData(frame)
-		if err != nil {
-			return wrap, err
-		}
+	err = wrap.SetData(frame)
+	if err != nil {
+		return wrap, err
 	}
 
 	return wrap, nil

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -38,10 +40,7 @@ func (codec *dataFrameCodec) IsEmpty(ptr unsafe.Pointer) bool {
 
 func (codec *dataFrameCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	f := (*Frame)(ptr)
-	err := writeDataFrame(f, stream, true, true)
-	if stream.Error == nil && err != nil {
-		stream.Error = err
-	}
+	writeDataFrame(f, stream, true, true)
 }
 
 func (codec *dataFrameCodec) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
@@ -57,23 +56,133 @@ func (codec *dataFrameCodec) Decode(ptr unsafe.Pointer, iter *jsoniter.Iterator)
 	*((*Frame)(ptr)) = frame
 }
 
-// FrameToJSON writes a frame to JSON.
-// NOTE: the format should be considered experimental until grafana 8 is released.
-func FrameToJSON(frame *Frame, includeSchema bool, includeData bool) ([]byte, error) {
+// FrameJSONArg - Custom type to hold value for weekday ranging from 1-7
+type FrameJSONArg int
+
+// Declare related constants for each weekday starting with index 1
+const (
+	WithSchemaAndData FrameJSONArg = iota // EnumIndex = 0
+	WithData                              // EnumIndex = 1
+	WithSchema                            // EnumIndex = 2
+)
+
+// FrameJSON holds a byte representation of the schema separate from the data
+type FrameJSON struct {
+	schema json.RawMessage
+	data   json.RawMessage
+}
+
+// Body returns the bytes to both schema and data (if they exist)
+func (f *FrameJSON) Body() []byte {
+	if f.schema != nil {
+		out := append([]byte(`{"`+jsonKeySchema+`": `), f.schema...)
+
+		if f.data != nil {
+			out = append(out, (`, "` + jsonKeyData + `": `)...)
+			out = append(out, f.data...)
+		}
+		return append(out, "}"...)
+	}
+
+	// only data
+	if f.data != nil {
+		out := []byte(`{"` + jsonKeyData + `": `)
+		out = append(out, f.data...)
+		return append(out, []byte("}")...)
+	}
+
+	return []byte("{}")
+}
+
+// Schema returns the bytes to the schema or nil if not definedd
+func (f *FrameJSON) Schema() []byte {
+	if f.schema != nil {
+		out := []byte(`{"` + jsonKeySchema + `": `)
+		out = append(out, f.schema...)
+		return append(out, []byte("}")...)
+	}
+	return nil
+}
+
+// Schema returns the bytes to the data or nil if not definedd
+func (f *FrameJSON) Data() []byte {
+	if f.data != nil {
+		out := []byte(`{"` + jsonKeyData + `": `)
+		out = append(out, f.data...)
+		return append(out, []byte("}")...)
+	}
+	return nil
+}
+
+// SameSchema checks if both structures have the same schema
+func (f *FrameJSON) SameSchema(dst *FrameJSON) bool {
+	if f == nil || dst == nil {
+		return false
+	}
+	return bytes.Equal(f.schema, dst.schema)
+}
+
+// SetData updates the data bytes with new values
+func (f *FrameJSON) SetData(frame *Frame) error {
 	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
-	err := writeDataFrame(frame, stream, includeSchema, includeData)
-	if err != nil {
-		return nil, err
-	}
-
+	writeDataFrameData(frame, stream)
 	if stream.Error != nil {
-		return nil, stream.Error
+		return stream.Error
 	}
 
-	return append([]byte(nil), stream.Buffer()...), nil
+	buf := stream.Buffer()
+	data := make([]byte, len(buf))
+	copy(data, buf) // don't hold the internal jsoniter buffer
+	f.data = data
+	return nil
+}
+
+// SetSchema updates the schema bytes with new values
+func (f *FrameJSON) SetSchema(frame *Frame) error {
+	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	stream := cfg.BorrowStream(nil)
+	defer cfg.ReturnStream(stream)
+
+	writeDataFrameSchema(frame, stream)
+	if stream.Error != nil {
+		return stream.Error
+	}
+
+	buf := stream.Buffer()
+	data := make([]byte, len(buf))
+	copy(data, buf) // don't hold the internal jsoniter buffer
+	f.schema = data
+	return nil
+}
+
+// MarshalJSON marshals Frame to JSON.
+func (f *FrameJSON) MarshalJSON() ([]byte, error) {
+	return f.Body(), nil
+}
+
+// FrameToJSON writes a frame to JSON.
+// NOTE: the format should be considered experimental until grafana 8 is released.
+func FrameToJSON(frame *Frame, with FrameJSONArg) (FrameJSON, error) {
+	wrap := FrameJSON{}
+
+	if with == WithSchemaAndData || with == WithSchema {
+		err := wrap.SetSchema(frame)
+		if err != nil {
+			return wrap, err
+		}
+	}
+
+	if with == WithSchemaAndData || with == WithData {
+		err := wrap.SetData(frame)
+		if err != nil {
+			return wrap, err
+		}
+	}
+
+	return wrap, nil
 }
 
 type frameSchema struct {
@@ -506,105 +615,11 @@ func isSpecialEntity(v float64) (string, bool) {
 	}
 }
 
-func writeDataFrame(frame *Frame, stream *jsoniter.Stream, includeSchema bool, includeData bool) error { //nolint:gocyclo
-	started := false
+func writeDataFrame(frame *Frame, stream *jsoniter.Stream, includeSchema bool, includeData bool) {
 	stream.WriteObjectStart()
 	if includeSchema {
 		stream.WriteObjectField(jsonKeySchema)
-		stream.WriteObjectStart()
-
-		if len(frame.Name) > 0 {
-			stream.WriteObjectField("name")
-			stream.WriteString(frame.Name)
-			started = true
-		}
-
-		if len(frame.RefID) > 0 {
-			if started {
-				stream.WriteMore()
-			}
-			stream.WriteObjectField("refId")
-			stream.WriteString(frame.RefID)
-			started = true
-		}
-
-		if frame.Meta != nil {
-			if started {
-				stream.WriteMore()
-			}
-			stream.WriteObjectField("meta")
-			stream.WriteVal(frame.Meta)
-			started = true
-		}
-
-		if started {
-			stream.WriteMore()
-		}
-		stream.WriteObjectField("fields")
-		stream.WriteArrayStart()
-		for i, f := range frame.Fields {
-			if i > 0 {
-				stream.WriteMore()
-			}
-			started = false
-			stream.WriteObjectStart()
-			if len(f.Name) > 0 {
-				stream.WriteObjectField("name")
-				stream.WriteString(f.Name)
-				started = true
-			}
-
-			t, ok := getSimpleTypeString(f.Type())
-			if ok {
-				if started {
-					stream.WriteMore()
-				}
-				stream.WriteObjectField("type")
-				stream.WriteString(t)
-				started = true
-			}
-
-			if true {
-				ft := f.Type()
-				nnt := ft.NonNullableType()
-				if started {
-					stream.WriteMore()
-				}
-				stream.WriteObjectField("typeInfo")
-				stream.WriteObjectStart()
-				stream.WriteObjectField("frame")
-				stream.WriteString(nnt.ItemTypeString())
-				if ft.Nullable() {
-					stream.WriteMore()
-					stream.WriteObjectField("nullable")
-					stream.WriteBool(true)
-				}
-				stream.WriteObjectEnd()
-				started = true
-			}
-
-			if f.Labels != nil {
-				if started {
-					stream.WriteMore()
-				}
-				stream.WriteObjectField("labels")
-				stream.WriteVal(f.Labels)
-				started = true
-			}
-
-			if f.Config != nil {
-				if started {
-					stream.WriteMore()
-				}
-				stream.WriteObjectField("config")
-				stream.WriteVal(f.Config)
-			}
-
-			stream.WriteObjectEnd()
-		}
-		stream.WriteArrayEnd()
-
-		stream.WriteObjectEnd()
+		writeDataFrameSchema(frame, stream)
 	}
 
 	if includeData {
@@ -612,85 +627,187 @@ func writeDataFrame(frame *Frame, stream *jsoniter.Stream, includeSchema bool, i
 			stream.WriteMore()
 		}
 
-		rowCount, err := frame.RowLen()
-		if err != nil {
-			stream.Error = err
-			return err
+		stream.WriteObjectField(jsonKeyData)
+		writeDataFrameData(frame, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+func writeDataFrameSchema(frame *Frame, stream *jsoniter.Stream) {
+	started := false
+	stream.WriteObjectStart()
+
+	if len(frame.Name) > 0 {
+		stream.WriteObjectField("name")
+		stream.WriteString(frame.Name)
+		started = true
+	}
+
+	if len(frame.RefID) > 0 {
+		if started {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("refId")
+		stream.WriteString(frame.RefID)
+		started = true
+	}
+
+	if frame.Meta != nil {
+		if started {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("meta")
+		stream.WriteVal(frame.Meta)
+		started = true
+	}
+
+	if started {
+		stream.WriteMore()
+	}
+	stream.WriteObjectField("fields")
+	stream.WriteArrayStart()
+	for i, f := range frame.Fields {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		started = false
+		stream.WriteObjectStart()
+		if len(f.Name) > 0 {
+			stream.WriteObjectField("name")
+			stream.WriteString(f.Name)
+			started = true
 		}
 
-		stream.WriteObjectField(jsonKeyData)
-		stream.WriteObjectStart()
-
-		entities := make([]*fieldEntityLookup, len(frame.Fields))
-		entityCount := 0
-
-		stream.WriteObjectField("values")
-		stream.WriteArrayStart()
-		for fidx, f := range frame.Fields {
-			if fidx > 0 {
+		t, ok := getSimpleTypeString(f.Type())
+		if ok {
+			if started {
 				stream.WriteMore()
 			}
-			isTime := f.Type().Time()
-			isFloat := f.Type() == FieldTypeFloat64 || f.Type() == FieldTypeNullableFloat64 ||
-				f.Type() == FieldTypeFloat32 || f.Type() == FieldTypeNullableFloat32
-
-			stream.WriteArrayStart()
-			for i := 0; i < rowCount; i++ {
-				if i > 0 {
-					stream.WriteRaw(",")
-				}
-				if v, ok := f.ConcreteAt(i); ok {
-					switch {
-					case isTime:
-						vTyped := v.(time.Time).UnixNano() / int64(time.Millisecond) // Milliseconds precision.
-						stream.WriteVal(vTyped)
-					case isFloat:
-						// For float and nullable float we check whether a value is a special
-						// entity (NaN, -Inf, +Inf) not supported by JSON spec, we then encode this
-						// information into a separate field to restore on a consumer side (setting
-						// null to the entity position in data). Since we are using f.ConcreteAt
-						// above the value is always float64 or float32 types, and never a *float64
-						// or *float32.
-						var f64 float64
-						switch vt := v.(type) {
-						case float64:
-							f64 = vt
-						case float32:
-							f64 = float64(vt)
-						default:
-							return fmt.Errorf("unsupported float type: %T", v)
-						}
-						if entityType, found := isSpecialEntity(f64); found {
-							if entities[fidx] == nil {
-								entities[fidx] = &fieldEntityLookup{}
-							}
-							entities[fidx].add(entityType, i)
-							entityCount++
-							stream.WriteNil()
-						} else {
-							stream.WriteVal(v)
-						}
-					default:
-						stream.WriteVal(v)
-					}
-				} else {
-					stream.WriteNil()
-				}
-			}
-			stream.WriteArrayEnd()
+			stream.WriteObjectField("type")
+			stream.WriteString(t)
+			started = true
 		}
-		stream.WriteArrayEnd()
 
-		if entityCount > 0 {
-			stream.WriteMore()
-			stream.WriteObjectField("entities")
-			stream.WriteVal(entities)
+		if true {
+			ft := f.Type()
+			nnt := ft.NonNullableType()
+			if started {
+				stream.WriteMore()
+			}
+			stream.WriteObjectField("typeInfo")
+			stream.WriteObjectStart()
+			stream.WriteObjectField("frame")
+			stream.WriteString(nnt.ItemTypeString())
+			if ft.Nullable() {
+				stream.WriteMore()
+				stream.WriteObjectField("nullable")
+				stream.WriteBool(true)
+			}
+			stream.WriteObjectEnd()
+			started = true
+		}
+
+		if f.Labels != nil {
+			if started {
+				stream.WriteMore()
+			}
+			stream.WriteObjectField("labels")
+			stream.WriteVal(f.Labels)
+			started = true
+		}
+
+		if f.Config != nil {
+			if started {
+				stream.WriteMore()
+			}
+			stream.WriteObjectField("config")
+			stream.WriteVal(f.Config)
 		}
 
 		stream.WriteObjectEnd()
 	}
+	stream.WriteArrayEnd()
+
 	stream.WriteObjectEnd()
-	return nil
+}
+
+func writeDataFrameData(frame *Frame, stream *jsoniter.Stream) {
+	rowCount, err := frame.RowLen()
+	if err != nil {
+		stream.Error = err
+		return
+	}
+
+	stream.WriteObjectStart()
+
+	entities := make([]*fieldEntityLookup, len(frame.Fields))
+	entityCount := 0
+
+	stream.WriteObjectField("values")
+	stream.WriteArrayStart()
+	for fidx, f := range frame.Fields {
+		if fidx > 0 {
+			stream.WriteMore()
+		}
+		isTime := f.Type().Time()
+		isFloat := f.Type() == FieldTypeFloat64 || f.Type() == FieldTypeNullableFloat64 ||
+			f.Type() == FieldTypeFloat32 || f.Type() == FieldTypeNullableFloat32
+
+		stream.WriteArrayStart()
+		for i := 0; i < rowCount; i++ {
+			if i > 0 {
+				stream.WriteRaw(",")
+			}
+			if v, ok := f.ConcreteAt(i); ok {
+				switch {
+				case isTime:
+					vTyped := v.(time.Time).UnixNano() / int64(time.Millisecond) // Milliseconds precision.
+					stream.WriteVal(vTyped)
+				case isFloat:
+					// For float and nullable float we check whether a value is a special
+					// entity (NaN, -Inf, +Inf) not supported by JSON spec, we then encode this
+					// information into a separate field to restore on a consumer side (setting
+					// null to the entity position in data). Since we are using f.ConcreteAt
+					// above the value is always float64 or float32 types, and never a *float64
+					// or *float32.
+					var f64 float64
+					switch vt := v.(type) {
+					case float64:
+						f64 = vt
+					case float32:
+						f64 = float64(vt)
+					default:
+						stream.Error = fmt.Errorf("unsupported float type: %T", v)
+						return
+					}
+					if entityType, found := isSpecialEntity(f64); found {
+						if entities[fidx] == nil {
+							entities[fidx] = &fieldEntityLookup{}
+						}
+						entities[fidx].add(entityType, i)
+						entityCount++
+						stream.WriteNil()
+					} else {
+						stream.WriteVal(v)
+					}
+				default:
+					stream.WriteVal(v)
+				}
+			} else {
+				stream.WriteNil()
+			}
+		}
+		stream.WriteArrayEnd()
+	}
+	stream.WriteArrayEnd()
+
+	if entityCount > 0 {
+		stream.WriteMore()
+		stream.WriteObjectField("entities")
+		stream.WriteVal(entities)
+	}
+
+	stream.WriteObjectEnd()
 }
 
 // ArrowBufferToJSON writes a frame to JSON

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -69,7 +69,8 @@ const (
 	IncludeSchemaOnly
 )
 
-// FrameJSON holds a byte representation of the schema separate from the data
+// FrameJSON holds a byte representation of the schema separate from the data.
+// Methods of FrameJSON are not goroutine-safe.
 type FrameJSON struct {
 	schema json.RawMessage
 	data   json.RawMessage

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -75,10 +75,10 @@ type FrameJSON struct {
 // Body returns the bytes to both schema and data (if they exist)
 func (f *FrameJSON) Bytes(args FrameJSONArg) []byte {
 	if f.schema != nil && (args == WithSchemaAndData || args == WithSchema) {
-		out := append([]byte(`{"`+jsonKeySchema+`": `), f.schema...)
+		out := append([]byte(`{"`+jsonKeySchema+`":`), f.schema...)
 
 		if f.data != nil && (args == WithSchemaAndData || args == WithData) {
-			out = append(out, (`, "` + jsonKeyData + `": `)...)
+			out = append(out, (`,"` + jsonKeyData + `":`)...)
 			out = append(out, f.data...)
 		}
 		return append(out, "}"...)
@@ -86,7 +86,7 @@ func (f *FrameJSON) Bytes(args FrameJSONArg) []byte {
 
 	// only data
 	if f.data != nil && (args == WithSchemaAndData || args == WithData) {
-		out := []byte(`{"` + jsonKeyData + `": `)
+		out := []byte(`{"` + jsonKeyData + `":`)
 		out = append(out, f.data...)
 		return append(out, []byte("}")...)
 	}

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -154,6 +154,7 @@ func (f *FrameJSON) MarshalJSON() ([]byte, error) {
 
 // FrameToJSON creates an object that holds schema and data independently.  This is
 // useful for explicit control between the data and schema.
+// For simple json serialization use `json.Marshal(frame)`
 //
 // NOTE: the format should be considered experimental until grafana 8 is released.
 func FrameToJSON(frame *Frame, include FrameInclude) (FrameJSON, error) {

--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -27,7 +27,7 @@ func TestGoldenFrameJSON(t *testing.T) {
 
 	fjs, err := data.FrameToJSON(f, data.WithSchemaAndData) // json.Marshal(f2)
 	require.NoError(t, err)
-	b := fjs.Body()
+	b := fjs.Bytes(data.WithSchemaAndData)
 	strF := string(b)
 
 	b, err = data.ArrowBufferToJSON(a, true, true)
@@ -163,7 +163,7 @@ func TestFrame_UnmarshalJSON_SchemaOnly(t *testing.T) {
 	_, err = json.Marshal(testWrapper{Data: d})
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Body(), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.WithSchemaAndData), &newFrame)
 	require.NoError(t, err)
 	require.Equal(t, 0, newFrame.Fields[0].Len())
 }
@@ -175,7 +175,7 @@ func TestFrameMarshalJSON_DataOnly(t *testing.T) {
 	_, err = json.Marshal(testWrapper{Data: d})
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Body(), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.WithSchemaAndData), &newFrame)
 	require.Error(t, err)
 }
 
@@ -193,7 +193,7 @@ func TestFrame_UnmarshalJSON_DataOnly(t *testing.T) {
 
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Body(), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.WithSchemaAndData), &newFrame)
 	require.Error(t, err)
 }
 

--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -25,12 +25,12 @@ func TestGoldenFrameJSON(t *testing.T) {
 	a, err := f.MarshalArrow()
 	require.NoError(t, err)
 
-	fjs, err := data.FrameToJSON(f, data.WithSchemaAndData) // json.Marshal(f2)
+	fjs, err := data.FrameToJSON(f, data.SchemaAndData) // json.Marshal(f2)
 	require.NoError(t, err)
-	b := fjs.Bytes(data.WithSchemaAndData)
+	b := fjs.Bytes(data.SchemaAndData)
 	strF := string(b)
 
-	b, err = data.ArrowBufferToJSON(a, true, true)
+	b, err = data.ArrowBufferToJSON(a, data.SchemaAndData)
 	require.NoError(t, err)
 	strA := string(b)
 
@@ -102,7 +102,7 @@ func BenchmarkFrameToJSON(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := data.FrameToJSON(f, data.WithSchemaAndData)
+		_, err := data.FrameToJSON(f, data.SchemaAndData)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -158,24 +158,24 @@ type testWrapper struct {
 
 func TestFrame_UnmarshalJSON_SchemaOnly(t *testing.T) {
 	f := data.NewFrame("test", data.NewField("test", nil, []int64{1}))
-	d, err := data.FrameToJSON(f, data.WithSchema)
+	d, err := data.FrameToJSON(f, data.OnlySchema)
 	require.NoError(t, err)
 	_, err = json.Marshal(testWrapper{Data: d})
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Bytes(data.WithSchemaAndData), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.SchemaAndData), &newFrame)
 	require.NoError(t, err)
 	require.Equal(t, 0, newFrame.Fields[0].Len())
 }
 
 func TestFrameMarshalJSON_DataOnly(t *testing.T) {
 	f := goldenDF()
-	d, err := data.FrameToJSON(f, data.WithData)
+	d, err := data.FrameToJSON(f, data.OnlyData)
 	require.NoError(t, err)
 	_, err = json.Marshal(testWrapper{Data: d})
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Bytes(data.WithSchemaAndData), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.SchemaAndData), &newFrame)
 	require.Error(t, err)
 }
 
@@ -189,11 +189,11 @@ func TestFrame_UnmarshalJSON_SchemaAndData_WrongOrder(t *testing.T) {
 
 func TestFrame_UnmarshalJSON_DataOnly(t *testing.T) {
 	f := data.NewFrame("test", data.NewField("test", nil, []int64{}))
-	d, err := data.FrameToJSON(f, data.WithData)
+	d, err := data.FrameToJSON(f, data.OnlyData)
 
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Bytes(data.WithSchemaAndData), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.SchemaAndData), &newFrame)
 	require.Error(t, err)
 }
 

--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -25,7 +25,7 @@ func TestGoldenFrameJSON(t *testing.T) {
 	a, err := f.MarshalArrow()
 	require.NoError(t, err)
 
-	fjs, err := data.FrameToJSON(f, data.IncludeAll) // json.Marshal(f2)
+	fjs, err := data.FrameToJSON(f) // json.Marshal(f2)
 	require.NoError(t, err)
 	b := fjs.Bytes(data.IncludeAll)
 	strF := string(b)
@@ -102,7 +102,7 @@ func BenchmarkFrameToJSON(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := data.FrameToJSON(f, data.IncludeAll)
+		_, err := data.FrameToJSON(f)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -153,29 +153,29 @@ func TestFrameMarshalJSONConcurrent(t *testing.T) {
 }
 
 type testWrapper struct {
-	Data data.FrameJSON
+	Data []byte
 }
 
 func TestFrame_UnmarshalJSON_SchemaOnly(t *testing.T) {
 	f := data.NewFrame("test", data.NewField("test", nil, []int64{1}))
-	d, err := data.FrameToJSON(f, data.IncludeSchemaOnly)
+	d, err := data.FrameToJSON(f)
 	require.NoError(t, err)
-	_, err = json.Marshal(testWrapper{Data: d})
+	_, err = json.Marshal(testWrapper{Data: d.Bytes(data.IncludeSchemaOnly)})
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Bytes(data.IncludeAll), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.IncludeSchemaOnly), &newFrame)
 	require.NoError(t, err)
 	require.Equal(t, 0, newFrame.Fields[0].Len())
 }
 
 func TestFrameMarshalJSON_DataOnly(t *testing.T) {
 	f := goldenDF()
-	d, err := data.FrameToJSON(f, data.IncludeDataOnly)
+	d, err := data.FrameToJSON(f)
 	require.NoError(t, err)
-	_, err = json.Marshal(testWrapper{Data: d})
+	_, err = json.Marshal(testWrapper{Data: d.Bytes(data.IncludeDataOnly)})
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Bytes(data.IncludeAll), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.IncludeDataOnly), &newFrame)
 	require.Error(t, err)
 }
 
@@ -189,11 +189,11 @@ func TestFrame_UnmarshalJSON_SchemaAndData_WrongOrder(t *testing.T) {
 
 func TestFrame_UnmarshalJSON_DataOnly(t *testing.T) {
 	f := data.NewFrame("test", data.NewField("test", nil, []int64{}))
-	d, err := data.FrameToJSON(f, data.IncludeDataOnly)
+	d, err := data.FrameToJSON(f)
 
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Bytes(data.IncludeAll), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.IncludeDataOnly), &newFrame)
 	require.Error(t, err)
 }
 

--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -25,12 +25,12 @@ func TestGoldenFrameJSON(t *testing.T) {
 	a, err := f.MarshalArrow()
 	require.NoError(t, err)
 
-	fjs, err := data.FrameToJSON(f, data.SchemaAndData) // json.Marshal(f2)
+	fjs, err := data.FrameToJSON(f, data.IncludeAll) // json.Marshal(f2)
 	require.NoError(t, err)
-	b := fjs.Bytes(data.SchemaAndData)
+	b := fjs.Bytes(data.IncludeAll)
 	strF := string(b)
 
-	b, err = data.ArrowBufferToJSON(a, data.SchemaAndData)
+	b, err = data.ArrowBufferToJSON(a, data.IncludeAll)
 	require.NoError(t, err)
 	strA := string(b)
 
@@ -102,7 +102,7 @@ func BenchmarkFrameToJSON(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := data.FrameToJSON(f, data.SchemaAndData)
+		_, err := data.FrameToJSON(f, data.IncludeAll)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -158,24 +158,24 @@ type testWrapper struct {
 
 func TestFrame_UnmarshalJSON_SchemaOnly(t *testing.T) {
 	f := data.NewFrame("test", data.NewField("test", nil, []int64{1}))
-	d, err := data.FrameToJSON(f, data.OnlySchema)
+	d, err := data.FrameToJSON(f, data.IncludeSchemaOnly)
 	require.NoError(t, err)
 	_, err = json.Marshal(testWrapper{Data: d})
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Bytes(data.SchemaAndData), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.IncludeAll), &newFrame)
 	require.NoError(t, err)
 	require.Equal(t, 0, newFrame.Fields[0].Len())
 }
 
 func TestFrameMarshalJSON_DataOnly(t *testing.T) {
 	f := goldenDF()
-	d, err := data.FrameToJSON(f, data.OnlyData)
+	d, err := data.FrameToJSON(f, data.IncludeDataOnly)
 	require.NoError(t, err)
 	_, err = json.Marshal(testWrapper{Data: d})
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Bytes(data.SchemaAndData), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.IncludeAll), &newFrame)
 	require.Error(t, err)
 }
 
@@ -189,11 +189,11 @@ func TestFrame_UnmarshalJSON_SchemaAndData_WrongOrder(t *testing.T) {
 
 func TestFrame_UnmarshalJSON_DataOnly(t *testing.T) {
 	f := data.NewFrame("test", data.NewField("test", nil, []int64{}))
-	d, err := data.FrameToJSON(f, data.OnlyData)
+	d, err := data.FrameToJSON(f, data.IncludeDataOnly)
 
 	require.NoError(t, err)
 	var newFrame data.Frame
-	err = json.Unmarshal(d.Bytes(data.SchemaAndData), &newFrame)
+	err = json.Unmarshal(d.Bytes(data.IncludeAll), &newFrame)
 	require.Error(t, err)
 }
 

--- a/internal/automanagement/manager.go
+++ b/internal/automanagement/manager.go
@@ -79,7 +79,7 @@ func (m *Manager) PublishStream(ctx context.Context, req *backend.PublishStreamR
 	return nil, status.Error(codes.Unimplemented, "unimplemented")
 }
 
-func (m *Manager) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender backend.StreamPacketSender) error {
+func (m *Manager) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	h, err := m.Get(req.PluginContext)
 	if err != nil {
 		return err


### PR DESCRIPTION
This will restructure the json encoding to return an object with independent access to schema+data bytes.

This is required so that streaming can easily check if the schema has changed without needing to encode/decode the schema independently.  See: https://github.com/grafana/grafana/pull/34548

This also updates function signature to take an enum rather than set of boolean flags:
![image](https://user-images.githubusercontent.com/705951/119239857-d140a180-bb00-11eb-9994-b223c59abe1f.png)




