### PR TITLE
Refactor Stream send API

### DIFF
--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -242,10 +242,3 @@ func (f ConvertFromProtobuf) RunStreamRequest(protoReq *pluginv2.RunStreamReques
 		Path:          protoReq.GetPath(),
 	}
 }
-
-// StreamPacket ...
-func (f ConvertFromProtobuf) StreamPacket(protoReq *pluginv2.StreamPacket) *StreamPacket {
-	return &StreamPacket{
-		Data: protoReq.GetData(),
-	}
-}

--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -215,7 +215,9 @@ func (f ConvertFromProtobuf) SubscribeStreamRequest(protoReq *pluginv2.Subscribe
 func (f ConvertFromProtobuf) SubscribeStreamResponse(protoReq *pluginv2.SubscribeStreamResponse) *SubscribeStreamResponse {
 	return &SubscribeStreamResponse{
 		Status: SubscribeStreamStatus(protoReq.GetStatus()),
-		Data:   protoReq.GetData(),
+		InitialData: &InitialData{
+			data: protoReq.Data,
+		},
 	}
 }
 

--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -244,3 +244,10 @@ func (f ConvertFromProtobuf) RunStreamRequest(protoReq *pluginv2.RunStreamReques
 		Path:          protoReq.GetPath(),
 	}
 }
+
+// StreamPacket ...
+func (f ConvertFromProtobuf) StreamPacket(protoReq *pluginv2.StreamPacket) *StreamPacket {
+	return &StreamPacket{
+		Data: protoReq.GetData(),
+	}
+}

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -240,3 +240,11 @@ func (t ConvertToProtobuf) PublishStreamResponse(req *PublishStreamResponse) *pl
 		Data:   req.Data,
 	}
 }
+
+// StreamPacket ...
+func (t ConvertToProtobuf) StreamPacket(p *StreamPacket) *pluginv2.StreamPacket {
+	protoReq := &pluginv2.StreamPacket{
+		Data: p.Data,
+	}
+	return protoReq
+}

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -205,14 +205,6 @@ func (t ConvertToProtobuf) RunStreamRequest(req *RunStreamRequest) *pluginv2.Run
 	return protoReq
 }
 
-// StreamPacket ...
-func (t ConvertToProtobuf) StreamPacket(p *StreamPacket) *pluginv2.StreamPacket {
-	protoReq := &pluginv2.StreamPacket{
-		Data: p.Data,
-	}
-	return protoReq
-}
-
 // SubscribeStreamRequest ...
 func (t ConvertToProtobuf) SubscribeStreamRequest(req *SubscribeStreamRequest) *pluginv2.SubscribeStreamRequest {
 	return &pluginv2.SubscribeStreamRequest{

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -215,10 +215,13 @@ func (t ConvertToProtobuf) SubscribeStreamRequest(req *SubscribeStreamRequest) *
 
 // SubscribeStreamResponse ...
 func (t ConvertToProtobuf) SubscribeStreamResponse(req *SubscribeStreamResponse) *pluginv2.SubscribeStreamResponse {
-	return &pluginv2.SubscribeStreamResponse{
+	resp := &pluginv2.SubscribeStreamResponse{
 		Status: pluginv2.SubscribeStreamResponse_Status(req.Status),
-		Data:   req.Data,
 	}
+	if req.InitialData != nil {
+		resp.Data = req.InitialData.data
+	}
+	return resp
 }
 
 // PublishStreamRequest ...

--- a/backend/stream.go
+++ b/backend/stream.go
@@ -64,11 +64,6 @@ func (d *InitialData) Data() []byte {
 	return d.data
 }
 
-// InitialFrameOptions can modify frame initial data construction.
-type InitialFrameOptions struct {
-	include data.FrameInclude
-}
-
 // NewInitialFrame allows creating frame as subscription InitialData.
 func NewInitialFrame(frame *data.Frame, include data.FrameInclude) (*InitialData, error) {
 	frameJSON, err := data.FrameToJSON(frame)

--- a/backend/stream.go
+++ b/backend/stream.go
@@ -65,24 +65,24 @@ func (d *InitialData) Data() []byte {
 
 // InitialFrameOptions can modify frame initial data construction.
 type InitialFrameOptions struct {
-	excludeSchema bool
-	excludeData   bool
+	schemaOnly bool
+	dataOnly   bool
 }
 
 // InitialFrameOption modifies creation of frame initial data.
 type InitialFrameOption func(options *InitialFrameOptions)
 
-// InitialFrameExcludeData ...
-func InitialFrameExcludeData(enabled bool) InitialFrameOption {
+// InitialFrameSchemaOnly ...
+func InitialFrameSchemaOnly(enabled bool) InitialFrameOption {
 	return func(h *InitialFrameOptions) {
-		h.excludeData = enabled
+		h.schemaOnly = enabled
 	}
 }
 
-// InitialFrameExcludeSchema ...
-func InitialFrameExcludeSchema(enabled bool) InitialFrameOption {
+// InitialFrameDataOnly ...
+func InitialFrameDataOnly(enabled bool) InitialFrameOption {
 	return func(h *InitialFrameOptions) {
-		h.excludeSchema = enabled
+		h.dataOnly = enabled
 	}
 }
 
@@ -92,7 +92,7 @@ func NewInitialFrame(frame *data.Frame, opts ...InitialFrameOption) (*InitialDat
 	for _, opt := range opts {
 		opt(initialDataOpts)
 	}
-	frameJSON, err := data.FrameToJSON(frame, !initialDataOpts.excludeSchema, !initialDataOpts.excludeData)
+	frameJSON, err := data.FrameToJSON(frame, !initialDataOpts.dataOnly, !initialDataOpts.schemaOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -154,24 +154,24 @@ func NewStreamSender(packetSender StreamPacketSender) *StreamSender {
 
 // SendFrameOptions can modify SendFrame behaviour.
 type SendFrameOptions struct {
-	excludeSchema bool
-	excludeData   bool
+	schemaOnly bool
+	dataOnly   bool
 }
 
 // SendFrameOption ...
 type SendFrameOption func(*SendFrameOptions)
 
-// SendFrameExcludeData excludes data from frame when serializing it.
-func SendFrameExcludeData(enabled bool) SendFrameOption {
+// SendFrameDataOnly excludes data from frame when serializing it.
+func SendFrameDataOnly(enabled bool) SendFrameOption {
 	return func(h *SendFrameOptions) {
-		h.excludeData = !enabled
+		h.dataOnly = enabled
 	}
 }
 
-// SendFrameExcludeSchema excludes schema from frame when serializing it.
-func SendFrameExcludeSchema(enabled bool) SendFrameOption {
+// SendFrameSchemaOnly excludes schema from frame when serializing it.
+func SendFrameSchemaOnly(enabled bool) SendFrameOption {
 	return func(h *SendFrameOptions) {
-		h.excludeSchema = enabled
+		h.schemaOnly = enabled
 	}
 }
 
@@ -181,7 +181,7 @@ func (s *StreamSender) SendFrame(frame *data.Frame, opts ...SendFrameOption) err
 	for _, opt := range opts {
 		opt(sendOptions)
 	}
-	frameJSON, err := data.FrameToJSON(frame, !sendOptions.excludeSchema, !sendOptions.excludeData)
+	frameJSON, err := data.FrameToJSON(frame, !sendOptions.dataOnly, !sendOptions.schemaOnly)
 	if err != nil {
 		return err
 	}

--- a/backend/stream.go
+++ b/backend/stream.go
@@ -113,14 +113,19 @@ type RunStreamRequest struct {
 	Path          string
 }
 
+// StreamSender allows sending data to a stream.
+// StreamSender is EXPERIMENTAL and is a subject to change till Grafana 8.
 type StreamSender interface {
-	SendFrame(frame *data.Frame) error
-	SendFrameSchema(frame *data.Frame) error
-	SendFrameData(frame *data.Frame) error
-	SendJSON(data []byte) error
+	// SendFrame allows sending the entire data frame to a stream.
+	SendFrame(*data.Frame) error
+	// SendFrameSchema allows sending the schema part of data frame to a stream (without data).
+	SendFrameSchema(*data.Frame) error
+	// SendFrameData allows sending the data part of data frame to a stream (without schema).
+	SendFrameData(*data.Frame) error
+	// SendJSON allows sending arbitrary JSON payload to a stream.
+	SendJSON([]byte) error
 }
 
-// StreamSender is EXPERIMENTAL and is a subject to change till Grafana 8.
 type streamSender struct {
 	srv pluginv2.Stream_RunStreamServer
 }

--- a/backend/stream.go
+++ b/backend/stream.go
@@ -49,8 +49,36 @@ const (
 
 // SubscribeStreamResponse is EXPERIMENTAL and is a subject to change till Grafana 8.
 type SubscribeStreamResponse struct {
-	Status SubscribeStreamStatus
-	Data   json.RawMessage
+	Status      SubscribeStreamStatus
+	InitialData *InitialData
+}
+
+type InitialData struct {
+	data []byte
+}
+
+func (d *InitialData) Data() []byte {
+	return d.data
+}
+
+func FrameInitialData(frame *data.Frame) (*InitialData, error) {
+	frameJSON, err := json.Marshal(frame)
+	if err != nil {
+		return nil, err
+	}
+	return &InitialData{
+		data: frameJSON,
+	}, nil
+}
+
+func FrameSchemaInitialData(frame *data.Frame) (*InitialData, error) {
+	jsonData, err := data.FrameToJSON(frame, true, false)
+	if err != nil {
+		return nil, err
+	}
+	return &InitialData{
+		data: jsonData,
+	}, nil
 }
 
 // PublishStreamRequest is EXPERIMENTAL and is a subject to change till Grafana 8.

--- a/backend/stream.go
+++ b/backend/stream.go
@@ -59,45 +59,24 @@ type InitialData struct {
 	data []byte
 }
 
+// Data allows to get prepared bytes of initial data.
 func (d *InitialData) Data() []byte {
 	return d.data
 }
 
 // InitialFrameOptions can modify frame initial data construction.
 type InitialFrameOptions struct {
-	schemaOnly bool
-	dataOnly   bool
-}
-
-// InitialFrameOption modifies creation of frame initial data.
-type InitialFrameOption func(options *InitialFrameOptions)
-
-// InitialFrameSchemaOnly ...
-func InitialFrameSchemaOnly(enabled bool) InitialFrameOption {
-	return func(h *InitialFrameOptions) {
-		h.schemaOnly = enabled
-	}
-}
-
-// InitialFrameDataOnly ...
-func InitialFrameDataOnly(enabled bool) InitialFrameOption {
-	return func(h *InitialFrameOptions) {
-		h.dataOnly = enabled
-	}
+	include data.FrameInclude
 }
 
 // NewInitialFrame allows creating frame as subscription InitialData.
-func NewInitialFrame(frame *data.Frame, opts ...InitialFrameOption) (*InitialData, error) {
-	initialDataOpts := &InitialFrameOptions{}
-	for _, opt := range opts {
-		opt(initialDataOpts)
-	}
-	frameJSON, err := data.FrameToJSON(frame, !initialDataOpts.dataOnly, !initialDataOpts.schemaOnly)
+func NewInitialFrame(frame *data.Frame, include data.FrameInclude) (*InitialData, error) {
+	frameJSON, err := data.FrameToJSON(frame)
 	if err != nil {
 		return nil, err
 	}
 	return &InitialData{
-		data: frameJSON,
+		data: frameJSON.Bytes(include),
 	}, nil
 }
 
@@ -152,41 +131,14 @@ func NewStreamSender(packetSender StreamPacketSender) *StreamSender {
 	return &StreamSender{packetSender: packetSender}
 }
 
-// SendFrameOptions can modify SendFrame behaviour.
-type SendFrameOptions struct {
-	schemaOnly bool
-	dataOnly   bool
-}
-
-// SendFrameOption ...
-type SendFrameOption func(*SendFrameOptions)
-
-// SendFrameDataOnly excludes data from frame when serializing it.
-func SendFrameDataOnly(enabled bool) SendFrameOption {
-	return func(h *SendFrameOptions) {
-		h.dataOnly = enabled
-	}
-}
-
-// SendFrameSchemaOnly excludes schema from frame when serializing it.
-func SendFrameSchemaOnly(enabled bool) SendFrameOption {
-	return func(h *SendFrameOptions) {
-		h.schemaOnly = enabled
-	}
-}
-
 // SendFrame allows sending data.Frame to a stream.
-func (s *StreamSender) SendFrame(frame *data.Frame, opts ...SendFrameOption) error {
-	sendOptions := &SendFrameOptions{}
-	for _, opt := range opts {
-		opt(sendOptions)
-	}
-	frameJSON, err := data.FrameToJSON(frame, !sendOptions.dataOnly, !sendOptions.schemaOnly)
+func (s *StreamSender) SendFrame(frame *data.Frame, include data.FrameInclude) error {
+	frameJSON, err := data.FrameToJSON(frame)
 	if err != nil {
 		return err
 	}
 	packet := &pluginv2.StreamPacket{
-		Data: frameJSON,
+		Data: frameJSON.Bytes(include),
 	}
 	return s.packetSender.Send(FromProto().StreamPacket(packet))
 }

--- a/backend/stream_adapter.go
+++ b/backend/stream_adapter.go
@@ -47,7 +47,7 @@ func (a *streamSDKAdapter) RunStream(protoReq *pluginv2.RunStreamRequest, protoS
 		return status.Error(codes.Unimplemented, "not implemented")
 	}
 
-	sender := &StreamSender{
+	sender := &streamSender{
 		srv: protoSrv,
 	}
 

--- a/backend/stream_adapter.go
+++ b/backend/stream_adapter.go
@@ -42,14 +42,18 @@ func (a *streamSDKAdapter) PublishStream(ctx context.Context, protoReq *pluginv2
 	return ToProto().PublishStreamResponse(resp), nil
 }
 
+type runStreamServer struct {
+	protoSrv pluginv2.Stream_RunStreamServer
+}
+
+func (r *runStreamServer) Send(packet *StreamPacket) error {
+	return r.protoSrv.Send(ToProto().StreamPacket(packet))
+}
+
 func (a *streamSDKAdapter) RunStream(protoReq *pluginv2.RunStreamRequest, protoSrv pluginv2.Stream_RunStreamServer) error {
 	if a.streamHandler == nil {
 		return status.Error(codes.Unimplemented, "not implemented")
 	}
-
-	sender := &streamSender{
-		srv: protoSrv,
-	}
-
+	sender := NewStreamSender(&runStreamServer{protoSrv: protoSrv})
 	return a.streamHandler.RunStream(protoSrv.Context(), FromProto().RunStreamRequest(protoReq), sender)
 }

--- a/internal/automanagement/manager.go
+++ b/internal/automanagement/manager.go
@@ -79,7 +79,7 @@ func (m *Manager) PublishStream(ctx context.Context, req *backend.PublishStreamR
 	return nil, status.Error(codes.Unimplemented, "unimplemented")
 }
 
-func (m *Manager) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender backend.StreamPacketSender) error {
+func (m *Manager) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	h, err := m.Get(req.PluginContext)
 	if err != nil {
 		return err

--- a/internal/automanagement/manager.go
+++ b/internal/automanagement/manager.go
@@ -79,7 +79,7 @@ func (m *Manager) PublishStream(ctx context.Context, req *backend.PublishStreamR
 	return nil, status.Error(codes.Unimplemented, "unimplemented")
 }
 
-func (m *Manager) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender backend.StreamSender) error {
+func (m *Manager) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	h, err := m.Get(req.PluginContext)
 	if err != nil {
 		return err

--- a/internal/automanagement/manager.go
+++ b/internal/automanagement/manager.go
@@ -79,7 +79,7 @@ func (m *Manager) PublishStream(ctx context.Context, req *backend.PublishStreamR
 	return nil, status.Error(codes.Unimplemented, "unimplemented")
 }
 
-func (m *Manager) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
+func (m *Manager) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender backend.StreamSender) error {
 	h, err := m.Get(req.PluginContext)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:

Should remove the need to marshal Frame into JSON manually before sending. Uses latest refactoring of Frame JSON conversion added in #355 .