### PR TITLE
Live: channel length validation

### DIFF
--- a/live/channel.go
+++ b/live/channel.go
@@ -6,10 +6,7 @@ import (
 	"strings"
 )
 
-// ErrInvalidChannelID returned when channel ID does not have valid
-// format. Valid channel IDs have 3 parts (scope, namespace, path)
-// delimited by "/". Scope and namespace parts can only have alphanumeric
-// ascii symbols, underscore and dash. Path can additionally have "/", "=" and ".".
+// ErrInvalidChannelID returned when channel ID does not have valid format.
 var ErrInvalidChannelID = errors.New("invalid channel ID")
 
 // Channel is the channel ID split by parts.
@@ -29,11 +26,21 @@ type Channel struct {
 	Path string `json:"path,omitempty"`
 }
 
-// ParseChannel parses the parts from a channel ID:
-//   ${scope} / ${namespace} / ${path}.
-// Channel parts allowed to have alphanumeric symbols, underscore and dash.
+const (
+	maxChannelLength = 160
+)
+
+// ParseChannel parses the parts from a channel ID.
+// Valid channel IDs have length <= 160 characters and consist
+// of 3 parts (scope, namespace, path) delimited by "/": like
+// "${scope}/${namespace}/${path}".
+// Scope and namespace parts can only have alphanumeric ascii symbols,
+// underscore and dash. Path can additionally have "/", "=" and ".".
 // For invalid channel IDs function returns ErrInvalidChannelID.
 func ParseChannel(chID string) (Channel, error) {
+	if chID == "" || len(chID) > maxChannelLength {
+		return Channel{}, ErrInvalidChannelID
+	}
 	parts := strings.SplitN(chID, "/", 3)
 	if len(parts) != 3 {
 		return Channel{}, ErrInvalidChannelID

--- a/live/channel_test.go
+++ b/live/channel_test.go
@@ -2,6 +2,7 @@ package live
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -21,6 +22,17 @@ func TestParseChannel(t *testing.T) {
 	if diff := cmp.Diff(channel, ex); diff != "" {
 		t.Fatalf("Result mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func TestParseChannel_ChannelTooLong(t *testing.T) {
+	prefix := "grafana/dashboard/"
+	b := make([]byte, 0, maxChannelLength+1)
+	for i := 0; i < maxChannelLength+1-len(prefix); i++ {
+		b = append(b, 'a')
+	}
+	chID := fmt.Sprintf("grafana/dashboard/%s", string(b))
+	_, err := ParseChannel(chID)
+	require.ErrorIs(t, err, ErrInvalidChannelID)
 }
 
 func TestParseChannel_IsValid(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Limit a max length of channels to 160 characters. The limit have been chosen with assumption that we may have some internal prefixes/suffixes in the future and may need to save channel to database where compound index allows us to have only 189 chars for a channel string.  