### PR TITLE
SQLUtil: Add default converter for nullable bool

### DIFF
--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -247,27 +247,6 @@ var (
 		},
 	}
 
-
-	// NullInt64Converter creates a *int64 using the scan type of `sql.NullInt64`
-	NullInt642Converter = Converter{
-		Name:          "NULLABLE int64 converter",
-		InputScanType: reflect.TypeOf(sql.NullBool{}),
-		InputTypeName: "INTEGER",
-		FrameConverter: FrameConverter{
-			FieldType: data.FieldTypeNullableInt64,
-			ConverterFunc: func(n interface{}) (interface{}, error) {
-				v := n.(*sql.NullInt64)
-
-				if !v.Valid {
-					return (*int64)(nil), nil
-				}
-
-				f := v.Int64
-				return &f, nil
-			},
-		},
-	}
-
 	// NullInt32Converter creates a *int32 using the scan type of `sql.NullInt32`
 	NullInt32Converter = Converter{
 		Name:          "NULLABLE int32 converter",

--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -247,6 +247,27 @@ var (
 		},
 	}
 
+
+	// NullInt64Converter creates a *int64 using the scan type of `sql.NullInt64`
+	NullInt642Converter = Converter{
+		Name:          "NULLABLE int64 converter",
+		InputScanType: reflect.TypeOf(sql.NullBool{}),
+		InputTypeName: "INTEGER",
+		FrameConverter: FrameConverter{
+			FieldType: data.FieldTypeNullableInt64,
+			ConverterFunc: func(n interface{}) (interface{}, error) {
+				v := n.(*sql.NullInt64)
+
+				if !v.Valid {
+					return (*int64)(nil), nil
+				}
+
+				f := v.Int64
+				return &f, nil
+			},
+		},
+	}
+
 	// NullInt32Converter creates a *int32 using the scan type of `sql.NullInt32`
 	NullInt32Converter = Converter{
 		Name:          "NULLABLE int32 converter",
@@ -286,6 +307,25 @@ var (
 			},
 		},
 	}
+
+	// NullBoolConverter creates a *bool using the scan type of `sql.NullBool`
+	NullBoolConverter = Converter{
+		Name:          "nullable bool converter",
+		InputScanType: reflect.TypeOf(sql.NullBool{}),
+		InputTypeName: "BOOLEAN",
+		FrameConverter: FrameConverter{
+			FieldType: data.FieldTypeNullableBool,
+			ConverterFunc: func(n interface{}) (interface{}, error) {
+				v := n.(*sql.NullBool)
+
+				if !v.Valid {
+					return (*bool)(nil), nil
+				}
+
+				return &v.Bool, nil
+			},
+		},
+	}
 )
 
 // NullConverters is a map of data type names (from reflect.TypeOf(...).String()) to converters
@@ -296,4 +336,5 @@ var NullConverters = map[reflect.Type]Converter{
 	reflect.TypeOf(int32(0)):    NullInt32Converter,
 	reflect.TypeOf(""):          NullStringConverter,
 	reflect.TypeOf(time.Time{}): NullTimeConverter,
+	reflect.TypeOf(false):       NullBoolConverter,
 }

--- a/data/sqlutil/converter_test.go
+++ b/data/sqlutil/converter_test.go
@@ -87,6 +87,17 @@ func TestDefaultConverter(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:     "nullable bool",
+			Type:     reflect.TypeOf(false),
+			Nullable: true,
+			Expected: sqlutil.Converter{
+				InputScanType: reflect.TypeOf(sql.NullBool{}),
+				FrameConverter: sqlutil.FrameConverter{
+					FieldType: data.FieldTypeBool.NullableType(),
+				},
+			},
+		},
 	}
 
 	for i, v := range suite {


### PR DESCRIPTION
**What this PR does / why we need it**:
Nullable bool aren't handled by SQLUtil.

**Which issue(s) this PR fixes**:
Fixes #368

**Special notes for your reviewer**:
This problem was found when developing the Redshift data source. It's temporary solved by providing a custom converter in the plugin. However, external plugins shouldn't have to provide default converters IMO.  
