### PR TITLE
FrameMeta: Adds IsWideTimeSeries

### DIFF
--- a/data/frame.go
+++ b/data/frame.go
@@ -206,13 +206,13 @@ func (f *Frame) SetMeta(m *FrameMeta) *Frame {
 	return f
 }
 
-// SetTimeSeriesType sets the Frame's Meta's TimeSeriesType attribute to t and returns the Frame.
+// SetIsWideTimeSeries sets the Frame's Meta's IsWideTimeSeries attribute to b and returns the Frame.
 // It will create Meta if it is missing.
-func (f *Frame) SetTimeSeriesType(t TimeSeriesType) *Frame {
+func (f *Frame) SetIsWideTimeSeries(b bool) *Frame {
 	if f.Meta != nil {
-		f.Meta.TimeSeriesType = t
+		f.Meta.IsWideTimeSeries = b
 	} else {
-		f.Meta = &FrameMeta{TimeSeriesType: t}
+		f.Meta = &FrameMeta{IsWideTimeSeries: b}
 	}
 	return f
 }

--- a/data/frame.go
+++ b/data/frame.go
@@ -206,6 +206,17 @@ func (f *Frame) SetMeta(m *FrameMeta) *Frame {
 	return f
 }
 
+// SetTimeSeriesType sets the Frame's Meta's TimeSeriesType attribute to t and returns the Frame.
+// It will create Meta if it is missing.
+func (f *Frame) SetTimeSeriesType(t TimeSeriesType) *Frame {
+	if f.Meta != nil {
+		f.Meta.TimeSeriesType = t
+	} else {
+		f.Meta = &FrameMeta{TimeSeriesType: t}
+	}
+	return f
+}
+
 // Rows returns the number of rows in the frame.
 func (f *Frame) Rows() int {
 	if len(f.Fields) > 0 {

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -35,6 +35,9 @@ type FrameMeta struct {
 	// ExecutedQueryString is the raw query sent to the underlying system. All macros and templating
 	// have been applied.  When metadata contains this value, it will be shown in the query inspector.
 	ExecutedQueryString string `json:"executedQueryString,omitempty"`
+
+	// TimeSeriesType is the type of time series used in the data frame.
+	TimeSeriesType TimeSeriesType `json:"timeSeriesType,omitempty"`
 }
 
 // Should be kept in sync with grafana/packages/grafana-data/src/types/data.ts#PreferredVisualisationType

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -36,8 +36,8 @@ type FrameMeta struct {
 	// have been applied.  When metadata contains this value, it will be shown in the query inspector.
 	ExecutedQueryString string `json:"executedQueryString,omitempty"`
 
-	// TimeSeriesType is the type of time series used in the data frame.
-	TimeSeriesType TimeSeriesType `json:"timeSeriesType,omitempty"`
+	// IsWideTimeSeries is true when the the when the Frame is a wide data frame.
+	IsWideTimeSeries bool `json:"isWideTimeSeries,omitempty"`
 }
 
 // Should be kept in sync with grafana/packages/grafana-data/src/types/data.ts#PreferredVisualisationType

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -36,7 +36,7 @@ type FrameMeta struct {
 	// have been applied.  When metadata contains this value, it will be shown in the query inspector.
 	ExecutedQueryString string `json:"executedQueryString,omitempty"`
 
-	// IsWideTimeSeries is true when the the when the Frame is a wide data frame.
+	// IsWideTimeSeries is true when the Frame is a wide data frame.
 	IsWideTimeSeries bool `json:"isWideTimeSeries,omitempty"`
 }
 

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -219,6 +219,7 @@ func LongToWide(longFrame *Frame, fillMissing *FillMissing) (*Frame, error) {
 
 	wideFrame := NewFrame(longFrame.Name, NewField(longFrame.Fields[tsSchema.TimeIndex].Name, nil, []time.Time{}))
 	wideFrame.Meta = longFrame.Meta
+	wideFrame.SetTimeSeriesType(TimeSeriesTypeWide)
 
 	sortKeys := make([]string, len(tsSchema.FactorIndices))
 	for i, v := range tsSchema.FactorIndices { // set dimension key order for final sort

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -219,7 +219,7 @@ func LongToWide(longFrame *Frame, fillMissing *FillMissing) (*Frame, error) {
 
 	wideFrame := NewFrame(longFrame.Name, NewField(longFrame.Fields[tsSchema.TimeIndex].Name, nil, []time.Time{}))
 	wideFrame.Meta = longFrame.Meta
-	wideFrame.SetTimeSeriesType(TimeSeriesTypeWide)
+	wideFrame.SetIsWideTimeSeries(true)
 
 	sortKeys := make([]string, len(tsSchema.FactorIndices))
 	for i, v := range tsSchema.FactorIndices { // set dimension key order for final sort

--- a/data/time_series_test.go
+++ b/data/time_series_test.go
@@ -1006,6 +1006,7 @@ func TestLongToWide(t *testing.T) {
 	}
 	for i := range tests {
 		tt := tests[i]
+		tt.wideFrame.Meta = &data.FrameMeta{TimeSeriesType: data.TimeSeriesTypeWide}
 		t.Run(tt.name, func(t *testing.T) {
 			frame, err := data.LongToWide(tt.longFrame, tt.tsFillMissing)
 			tt.Err(t, err)
@@ -1064,6 +1065,7 @@ func TestLongToWideBool(t *testing.T) {
 	}
 	for i := range tests {
 		tt := tests[i]
+		tt.wideFrame.Meta = &data.FrameMeta{TimeSeriesType: data.TimeSeriesTypeWide}
 		t.Run(tt.name, func(t *testing.T) {
 			frame, err := data.LongToWide(tt.longFrame, tt.tsFillMissing)
 			tt.Err(t, err)

--- a/data/time_series_test.go
+++ b/data/time_series_test.go
@@ -1006,7 +1006,7 @@ func TestLongToWide(t *testing.T) {
 	}
 	for i := range tests {
 		tt := tests[i]
-		tt.wideFrame.Meta = &data.FrameMeta{TimeSeriesType: data.TimeSeriesTypeWide}
+		tt.wideFrame.Meta = &data.FrameMeta{IsWideTimeSeries: true}
 		t.Run(tt.name, func(t *testing.T) {
 			frame, err := data.LongToWide(tt.longFrame, tt.tsFillMissing)
 			tt.Err(t, err)
@@ -1065,7 +1065,7 @@ func TestLongToWideBool(t *testing.T) {
 	}
 	for i := range tests {
 		tt := tests[i]
-		tt.wideFrame.Meta = &data.FrameMeta{TimeSeriesType: data.TimeSeriesTypeWide}
+		tt.wideFrame.Meta = &data.FrameMeta{IsWideTimeSeries: true}
 		t.Run(tt.name, func(t *testing.T) {
 			frame, err := data.LongToWide(tt.longFrame, tt.tsFillMissing)
 			tt.Err(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of fixing wide data frame related issues for older plugins, this PR will add `TimeSeriesType` to the `DataFrame` `Meta` object. Next steps are to use this new meta field in the frontend so we can better identify wide data frames in `toLegacyResponseData`:
https://github.com/grafana/grafana/blob/503c3b8f66343f4bc49e0985081c810764f18b66/packages/grafana-data/src/dataframe/processDataFrame.ts#L320

**Which issue(s) this PR fixes**:
Relates #https://github.com/grafana/grafana/issues/35599

**Special notes for your reviewer**:
