### PR TITLE
Build: support building app datasources (in sub-folder)

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -2,16 +2,15 @@ package build
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
 
+	"github.com/grafana/grafana-plugin-sdk-go/internal"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 )
@@ -31,7 +30,7 @@ var exname string
 
 func getExecutableName(os string, arch string) (string, error) {
 	if exname == "" {
-		exename, err := getExecutableFromPluginJSON()
+		exename, err := internal.GetExecutableFromPluginJSON("src")
 		if err != nil {
 			return "", err
 		}
@@ -44,29 +43,6 @@ func getExecutableName(os string, arch string) (string, error) {
 		exeName = fmt.Sprintf("%s.exe", exeName)
 	}
 	return exeName, nil
-}
-
-func getValueFromJSON(fpath string, key string) (string, error) {
-	byteValue, err := ioutil.ReadFile(fpath)
-	if err != nil {
-		return "", err
-	}
-
-	var result map[string]interface{}
-	err = json.Unmarshal(byteValue, &result)
-	if err != nil {
-		return "", err
-	}
-	executable := result[key]
-	name, ok := executable.(string)
-	if !ok || name == "" {
-		return "", fmt.Errorf("plugin.json is missing: %s", key)
-	}
-	return name, nil
-}
-
-func getExecutableFromPluginJSON() (string, error) {
-	return getValueFromJSON(path.Join("src", "plugin.json"), "executable")
 }
 
 func buildBackend(cfg Config) error {
@@ -104,7 +80,7 @@ func buildBackend(cfg Config) error {
 	}
 
 	info := getBuildInfoFromEnvironment()
-	version, err := getValueFromJSON("package.json", "version")
+	version, err := internal.GetStringValueFromJSON("package.json", "version")
 	if err == nil && len(version) > 0 {
 		info.Version = version
 	}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,0 +1,43 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"strings"
+)
+
+func GetStringValueFromJSON(fpath string, key string) (string, error) {
+	byteValue, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return "", err
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(byteValue, &result)
+	if err != nil {
+		return "", err
+	}
+	executable := result[key]
+	name, ok := executable.(string)
+	if !ok || name == "" {
+		return "", fmt.Errorf("plugin.json is missing: %s", key)
+	}
+	return name, nil
+}
+
+func GetExecutableFromPluginJSON(dir string) (string, error) {
+	exe, err := GetStringValueFromJSON(path.Join(dir, "plugin.json"), "executable")
+	if err != nil {
+		// In app plugins, the exe may be nested
+		exe, err2 := GetStringValueFromJSON(path.Join(dir, "datasource", "plugin.json"), "executable")
+		if err2 == nil {
+			if !strings.HasPrefix(exe, "../") {
+				return "", fmt.Errorf("datasouce should reference executable in root folder")
+			}
+			return exe[3:], nil
+		}
+	}
+	return exe, err
+}


### PR DESCRIPTION
The current build scripts expect the executable to be in the root, but with app plugins the executable will be in a sub-folder.  This PR checks for an additional "src/datasource/plugin.json" when finding the executable name.

This also move the executable check to an internal utility function so the standalone mode and build can both use it