### PR TITLE
Streaming: allow raw byte[] for initial data

### DIFF
--- a/backend/stream.go
+++ b/backend/stream.go
@@ -75,6 +75,13 @@ func NewInitialFrame(frame *data.Frame, include data.FrameInclude) (*InitialData
 	}, nil
 }
 
+// NewInitialData allows sending bytes on subscription
+func NewInitialData(data []byte) (*InitialData, error) {
+	return &InitialData{
+		data: data,
+	}, nil
+}
+
 // PublishStreamRequest is EXPERIMENTAL and is a subject to change till Grafana 8.
 type PublishStreamRequest struct {
 	PluginContext PluginContext

--- a/backend/stream.go
+++ b/backend/stream.go
@@ -75,8 +75,11 @@ func NewInitialFrame(frame *data.Frame, include data.FrameInclude) (*InitialData
 	}, nil
 }
 
-// NewInitialData allows sending bytes on subscription
+// NewInitialData allows sending JSON on subscription
 func NewInitialData(data []byte) (*InitialData, error) {
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("invalid JSON data")
+	}
 	return &InitialData{
 		data: data,
 	}, nil

--- a/backend/stream.go
+++ b/backend/stream.go
@@ -76,7 +76,7 @@ func NewInitialFrame(frame *data.Frame, include data.FrameInclude) (*InitialData
 }
 
 // NewInitialData allows sending JSON on subscription
-func NewInitialData(data []byte) (*InitialData, error) {
+func NewInitialData(data json.RawMessage) (*InitialData, error) {
 	if !json.Valid(data) {
 		return nil, fmt.Errorf("invalid JSON data")
 	}


### PR DESCRIPTION
When subscribing to a channel we may want to send an initial packet that is not a DataFrame