### PR TITLE
Fix mapping of basic auth settings for DataSourceInstanceSettings

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -91,6 +91,16 @@ func (s *DataSourceInstanceSettings) HTTPClientOptions() (httpclient.Options, er
 		return httpclient.Options{}, err
 	}
 
+	if s.BasicAuthEnabled {
+		httpSettings.BasicAuthEnabled = s.BasicAuthEnabled
+		httpSettings.BasicAuthUser = s.BasicAuthUser
+		httpSettings.BasicAuthPassword = s.DecryptedSecureJSONData["basicAuthPassword"]
+	} else if s.User != "" {
+		httpSettings.BasicAuthEnabled = true
+		httpSettings.BasicAuthUser = s.User
+		httpSettings.BasicAuthPassword = s.DecryptedSecureJSONData["password"]
+	}
+
 	return httpSettings.HTTPClientOptions(), nil
 }
 

--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -1,0 +1,64 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDataSourceInstanceSettings(t *testing.T) {
+	t.Run("HTTPClientOptions() should translate basic auth settings as expected", func(t *testing.T) {
+		tcs := []struct {
+			instanceSettings      *DataSourceInstanceSettings
+			expectedClientOptions httpclient.Options
+		}{
+			{
+				instanceSettings:      &DataSourceInstanceSettings{},
+				expectedClientOptions: httpclient.Options{},
+			},
+			{
+				instanceSettings: &DataSourceInstanceSettings{
+					User:             "user",
+					JSONData:         []byte("{}"),
+					BasicAuthEnabled: true,
+					BasicAuthUser:    "buser",
+					DecryptedSecureJSONData: map[string]string{
+						"basicAuthPassword": "bpwd",
+						"password":          "pwd",
+					},
+				},
+				expectedClientOptions: httpclient.Options{
+					BasicAuth: &httpclient.BasicAuthOptions{
+						User:     "buser",
+						Password: "bpwd",
+					},
+				},
+			},
+			{
+				instanceSettings: &DataSourceInstanceSettings{
+					User:             "user",
+					JSONData:         []byte("{}"),
+					BasicAuthEnabled: false,
+					BasicAuthUser:    "buser",
+					DecryptedSecureJSONData: map[string]string{
+						"basicAuthPassword": "bpwd",
+						"password":          "pwd",
+					},
+				},
+				expectedClientOptions: httpclient.Options{
+					BasicAuth: &httpclient.BasicAuthOptions{
+						User:     "user",
+						Password: "pwd",
+					},
+				},
+			},
+		}
+
+		for _, tc := range tcs {
+			opts, err := tc.instanceSettings.HTTPClientOptions()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedClientOptions.BasicAuth, opts.BasicAuth)
+		}
+	})
+}

--- a/backend/http_settings.go
+++ b/backend/http_settings.go
@@ -103,8 +103,10 @@ func parseHTTPSettings(jsonData json.RawMessage, secureJSONData map[string]strin
 	}
 
 	var dat map[string]interface{}
-	if err := json.Unmarshal(jsonData, &dat); err != nil {
-		return nil, err
+	if jsonData != nil {
+		if err := json.Unmarshal(jsonData, &dat); err != nil {
+			return nil, err
+		}
 	}
 
 	if v, exists := dat["access"]; exists {


### PR DESCRIPTION
**What this PR does / why we need it**:
The mapping of basic auth settings from DataSourceInstanceSettings to HTTPClientOptions was not done properly since all settings was only read from JSONData where basic auth fields are stored on the DataSourceInstanceSettings itself.

**Which issue(s) this PR fixes**:
Related to https://github.com/grafana/grafana/pull/35798

**Special notes for your reviewer**:
