### PR TITLE
Extends HTTP client options mapping with labels and custom options

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -7,6 +7,9 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 )
 
+const dataCustomOptionsKey = "grafanaData"
+const secureDataCustomOptionsKey = "grafanaSecureData"
+
 // User represents a Grafana user.
 type User struct {
 	Login string
@@ -145,9 +148,6 @@ type PluginContext struct {
 	// Will only be set if request targeting a data source instance.
 	DataSourceInstanceSettings *DataSourceInstanceSettings
 }
-
-const dataCustomOptionsKey = "grafanaData"
-const secureDataCustomOptionsKey = "grafanaSecureData"
 
 func setCustomOptionsFromHTTPSettings(opts *httpclient.Options, httpSettings *HTTPSettings) {
 	opts.CustomOptions = map[string]interface{}{}

--- a/backend/common.go
+++ b/backend/common.go
@@ -39,7 +39,10 @@ func (s *AppInstanceSettings) HTTPClientOptions() (httpclient.Options, error) {
 		return httpclient.Options{}, err
 	}
 
-	return httpSettings.HTTPClientOptions(), nil
+	opts := httpSettings.HTTPClientOptions()
+	setCustomOptionsFromHTTPSettings(&opts, httpSettings)
+
+	return opts, nil
 }
 
 // DataSourceInstanceSettings represents settings for a data source instance.
@@ -101,7 +104,13 @@ func (s *DataSourceInstanceSettings) HTTPClientOptions() (httpclient.Options, er
 		httpSettings.BasicAuthPassword = s.DecryptedSecureJSONData["password"]
 	}
 
-	return httpSettings.HTTPClientOptions(), nil
+	opts := httpSettings.HTTPClientOptions()
+	opts.Labels["datasource_name"] = s.Name
+	opts.Labels["datasource_uid"] = s.UID
+
+	setCustomOptionsFromHTTPSettings(&opts, httpSettings)
+
+	return opts, nil
 }
 
 // PluginContext holds contextual information about a plugin request, such as
@@ -135,4 +144,57 @@ type PluginContext struct {
 	//
 	// Will only be set if request targeting a data source instance.
 	DataSourceInstanceSettings *DataSourceInstanceSettings
+}
+
+const dataCustomOptionsKey = "grafanaData"
+const secureDataCustomOptionsKey = "grafanaSecureData"
+
+func setCustomOptionsFromHTTPSettings(opts *httpclient.Options, httpSettings *HTTPSettings) {
+	opts.CustomOptions = map[string]interface{}{}
+
+	if httpSettings.JSONData != nil {
+		opts.CustomOptions[dataCustomOptionsKey] = httpSettings.JSONData
+	}
+
+	if httpSettings.SecureJSONData != nil {
+		opts.CustomOptions[secureDataCustomOptionsKey] = httpSettings.SecureJSONData
+	}
+}
+
+// JSONDataFromHTTPClientOptions extracts JSON data from CustomOptions of httpclient.Options.
+func JSONDataFromHTTPClientOptions(opts httpclient.Options) (res map[string]interface{}) {
+	if opts.CustomOptions == nil {
+		return
+	}
+
+	val, exists := opts.CustomOptions[dataCustomOptionsKey]
+	if !exists {
+		return
+	}
+
+	jsonData, ok := val.(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	return jsonData
+}
+
+// SecureJSONDataFromHTTPClientOptions extracts secure JSON data from CustomOptions of httpclient.Options.
+func SecureJSONDataFromHTTPClientOptions(opts httpclient.Options) (res map[string]string) {
+	if opts.CustomOptions == nil {
+		return
+	}
+
+	val, exists := opts.CustomOptions[secureDataCustomOptionsKey]
+	if !exists {
+		return
+	}
+
+	secureJSONData, ok := val.(map[string]string)
+	if !ok {
+		return
+	}
+
+	return secureJSONData
 }

--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -5,10 +5,72 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+func TestAppInstanceSettings(t *testing.T) {
+	t.Run("HTTPClientOptions() should translate settings as expected", func(t *testing.T) {
+		tcs := []struct {
+			instanceSettings      *AppInstanceSettings
+			expectedClientOptions httpclient.Options
+		}{
+			{
+				instanceSettings:      &AppInstanceSettings{},
+				expectedClientOptions: httpclient.Options{},
+			},
+			{
+				instanceSettings: &AppInstanceSettings{
+					JSONData: []byte("{ \"key\": \"value\" }"),
+					DecryptedSecureJSONData: map[string]string{
+						"sKey": "sValue",
+					},
+				},
+				expectedClientOptions: httpclient.Options{
+					CustomOptions: map[string]interface{}{
+						dataCustomOptionsKey: map[string]interface{}{
+							"key": "value",
+						},
+						secureDataCustomOptionsKey: map[string]string{
+							"sKey": "sValue",
+						},
+					},
+				},
+			},
+		}
+
+		for _, tc := range tcs {
+			opts, err := tc.instanceSettings.HTTPClientOptions()
+			assert.NoError(t, err)
+			if tc.expectedClientOptions.BasicAuth != nil {
+				assert.Equal(t, tc.expectedClientOptions.BasicAuth, opts.BasicAuth)
+			} else {
+				assert.Nil(t, opts.BasicAuth)
+			}
+
+			if tc.expectedClientOptions.Labels != nil {
+				assert.Equal(t, tc.expectedClientOptions.Labels, opts.Labels)
+			}
+
+			jsonData := JSONDataFromHTTPClientOptions(opts)
+			expectedJSONData := JSONDataFromHTTPClientOptions(tc.expectedClientOptions)
+			secureJSONData := SecureJSONDataFromHTTPClientOptions(opts)
+			expectedSecureJSONData := SecureJSONDataFromHTTPClientOptions(tc.expectedClientOptions)
+
+			if len(tc.expectedClientOptions.CustomOptions) > 0 {
+				assert.Equal(t, tc.expectedClientOptions.CustomOptions, opts.CustomOptions)
+				assert.Equal(t, expectedJSONData, jsonData)
+				assert.Equal(t, expectedSecureJSONData, secureJSONData)
+			} else {
+				assert.Empty(t, opts.CustomOptions)
+				assert.Empty(t, jsonData)
+				assert.Empty(t, secureJSONData)
+			}
+		}
+	})
+}
+
 func TestDataSourceInstanceSettings(t *testing.T) {
-	t.Run("HTTPClientOptions() should translate basic auth settings as expected", func(t *testing.T) {
+	t.Run("HTTPClientOptions() should translate settings as expected", func(t *testing.T) {
 		tcs := []struct {
 			instanceSettings      *DataSourceInstanceSettings
 			expectedClientOptions httpclient.Options
@@ -19,6 +81,8 @@ func TestDataSourceInstanceSettings(t *testing.T) {
 			},
 			{
 				instanceSettings: &DataSourceInstanceSettings{
+					Name:             "ds1",
+					UID:              "uid1",
 					User:             "user",
 					JSONData:         []byte("{}"),
 					BasicAuthEnabled: true,
@@ -33,10 +97,23 @@ func TestDataSourceInstanceSettings(t *testing.T) {
 						User:     "buser",
 						Password: "bpwd",
 					},
+					Labels: map[string]string{
+						"datasource_name": "ds1",
+						"datasource_uid":  "uid1",
+					},
+					CustomOptions: map[string]interface{}{
+						dataCustomOptionsKey: map[string]interface{}{},
+						secureDataCustomOptionsKey: map[string]string{
+							"basicAuthPassword": "bpwd",
+							"password":          "pwd",
+						},
+					},
 				},
 			},
 			{
 				instanceSettings: &DataSourceInstanceSettings{
+					Name:             "ds2",
+					UID:              "uid2",
 					User:             "user",
 					JSONData:         []byte("{}"),
 					BasicAuthEnabled: false,
@@ -51,6 +128,35 @@ func TestDataSourceInstanceSettings(t *testing.T) {
 						User:     "user",
 						Password: "pwd",
 					},
+					Labels: map[string]string{
+						"datasource_name": "ds2",
+						"datasource_uid":  "uid2",
+					},
+					CustomOptions: map[string]interface{}{
+						dataCustomOptionsKey: map[string]interface{}{},
+						secureDataCustomOptionsKey: map[string]string{
+							"basicAuthPassword": "bpwd",
+							"password":          "pwd",
+						},
+					},
+				},
+			},
+			{
+				instanceSettings: &DataSourceInstanceSettings{
+					JSONData: []byte("{ \"key\": \"value\" }"),
+					DecryptedSecureJSONData: map[string]string{
+						"sKey": "sValue",
+					},
+				},
+				expectedClientOptions: httpclient.Options{
+					CustomOptions: map[string]interface{}{
+						dataCustomOptionsKey: map[string]interface{}{
+							"key": "value",
+						},
+						secureDataCustomOptionsKey: map[string]string{
+							"sKey": "sValue",
+						},
+					},
 				},
 			},
 		}
@@ -58,7 +164,50 @@ func TestDataSourceInstanceSettings(t *testing.T) {
 		for _, tc := range tcs {
 			opts, err := tc.instanceSettings.HTTPClientOptions()
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedClientOptions.BasicAuth, opts.BasicAuth)
+			if tc.expectedClientOptions.BasicAuth != nil {
+				assert.Equal(t, tc.expectedClientOptions.BasicAuth, opts.BasicAuth)
+			} else {
+				assert.Nil(t, opts.BasicAuth)
+			}
+
+			if tc.expectedClientOptions.Labels != nil {
+				assert.Equal(t, tc.expectedClientOptions.Labels, opts.Labels)
+			}
+
+			jsonData := JSONDataFromHTTPClientOptions(opts)
+			expectedJSONData := JSONDataFromHTTPClientOptions(tc.expectedClientOptions)
+			secureJSONData := SecureJSONDataFromHTTPClientOptions(opts)
+			expectedSecureJSONData := SecureJSONDataFromHTTPClientOptions(tc.expectedClientOptions)
+
+			if len(tc.expectedClientOptions.CustomOptions) > 0 {
+				assert.Equal(t, tc.expectedClientOptions.CustomOptions, opts.CustomOptions)
+				assert.Equal(t, expectedJSONData, jsonData)
+				assert.Equal(t, expectedSecureJSONData, secureJSONData)
+			} else {
+				assert.Empty(t, opts.CustomOptions)
+				assert.Empty(t, jsonData)
+				assert.Empty(t, secureJSONData)
+			}
 		}
 	})
+}
+
+func TestCustomOptions(t *testing.T) {
+	opts := &httpclient.Options{}
+	expectedJSONData := map[string]interface{}{
+		"key": "value",
+	}
+	expectedSecureJSONData := map[string]string{
+		"sKey": "sValue",
+	}
+	setCustomOptionsFromHTTPSettings(opts, &HTTPSettings{
+		JSONData:       expectedJSONData,
+		SecureJSONData: expectedSecureJSONData,
+	})
+
+	jsonData := JSONDataFromHTTPClientOptions(*opts)
+	secureJSONData := SecureJSONDataFromHTTPClientOptions(*opts)
+
+	require.Equal(t, expectedJSONData, jsonData)
+	require.Equal(t, expectedSecureJSONData, secureJSONData)
 }

--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -193,21 +193,43 @@ func TestDataSourceInstanceSettings(t *testing.T) {
 }
 
 func TestCustomOptions(t *testing.T) {
-	opts := &httpclient.Options{}
-	expectedJSONData := map[string]interface{}{
-		"key": "value",
-	}
-	expectedSecureJSONData := map[string]string{
-		"sKey": "sValue",
-	}
-	setCustomOptionsFromHTTPSettings(opts, &HTTPSettings{
-		JSONData:       expectedJSONData,
-		SecureJSONData: expectedSecureJSONData,
+	t.Run("Should be able to extract JSONData and SecureJSONData from custom options", func(t *testing.T) {
+		opts := &httpclient.Options{}
+		expectedJSONData := map[string]interface{}{
+			"key": "value",
+		}
+		expectedSecureJSONData := map[string]string{
+			"sKey": "sValue",
+		}
+		setCustomOptionsFromHTTPSettings(opts, &HTTPSettings{
+			JSONData:       expectedJSONData,
+			SecureJSONData: expectedSecureJSONData,
+		})
+
+		jsonData := JSONDataFromHTTPClientOptions(*opts)
+		secureJSONData := SecureJSONDataFromHTTPClientOptions(*opts)
+
+		require.Equal(t, expectedJSONData, jsonData)
+		require.Equal(t, expectedSecureJSONData, secureJSONData)
 	})
 
-	jsonData := JSONDataFromHTTPClientOptions(*opts)
-	secureJSONData := SecureJSONDataFromHTTPClientOptions(*opts)
+	t.Run("Should be able to extract JSONData and SecureJSONData from custom options", func(t *testing.T) {
+		opts := &httpclient.Options{
+			CustomOptions: map[string]interface{}{},
+		}
+		incorrectJSONData := map[string]string{
+			"key": "value",
+		}
+		incorrectSecureJSONData := map[string]interface{}{
+			"sKey": "sValue",
+		}
+		opts.CustomOptions[dataCustomOptionsKey] = incorrectJSONData
+		opts.CustomOptions[secureDataCustomOptionsKey] = incorrectSecureJSONData
 
-	require.Equal(t, expectedJSONData, jsonData)
-	require.Equal(t, expectedSecureJSONData, secureJSONData)
+		jsonData := JSONDataFromHTTPClientOptions(*opts)
+		secureJSONData := SecureJSONDataFromHTTPClientOptions(*opts)
+
+		require.Empty(t, jsonData)
+		require.Empty(t, secureJSONData)
+	})
 }

--- a/backend/http_settings.go
+++ b/backend/http_settings.go
@@ -44,12 +44,17 @@ type HTTPSettings struct {
 	SigV4Profile       string
 	SigV4AccessKey     string
 	SigV4SecretKey     string
+
+	JSONData       map[string]interface{}
+	SecureJSONData map[string]string
 }
 
 // HTTPClientOptions creates and returns httpclient.Options.
 func (s *HTTPSettings) HTTPClientOptions() httpclient.Options {
 	opts := httpclient.Options{
-		Headers: s.Headers,
+		Headers:       s.Headers,
+		Labels:        map[string]string{},
+		CustomOptions: map[string]interface{}{},
 	}
 
 	opts.Timeouts = &httpclient.TimeoutOptions{
@@ -276,6 +281,9 @@ func parseHTTPSettings(jsonData json.RawMessage, secureJSONData map[string]strin
 		}
 		index++
 	}
+
+	s.JSONData = dat
+	s.SecureJSONData = secureJSONData
 
 	return s, nil
 }

--- a/backend/http_settings_test.go
+++ b/backend/http_settings_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -55,6 +56,9 @@ func TestParseHTTPSettings(t *testing.T) {
 			"httpHeaderValue1":  "SecretOne",
 			"httpHeaderValue2":  "SecretTwo",
 		}
+		var jsonMap map[string]interface{}
+		err := json.Unmarshal([]byte(jsonStr), &jsonMap)
+		require.NoError(t, err)
 		s, err := parseHTTPSettings([]byte(jsonStr), secureData)
 		require.NoError(t, err)
 		require.NotNil(t, s)
@@ -92,12 +96,14 @@ func TestParseHTTPSettings(t *testing.T) {
 			SigV4Profile:          "ghi",
 			SigV4AccessKey:        "sigV4AccessKey4",
 			SigV4SecretKey:        "sigV4SecretKey5",
+			JSONData:              jsonMap,
+			SecureJSONData:        secureData,
 		}, s)
 
 		t.Run("HTTPClientOptions() should convert to expected httpclient.Options", func(t *testing.T) {
 			opts := s.HTTPClientOptions()
 			require.NotNil(t, opts)
-			require.Equal(t, httpclient.Options{
+			expectedOpts := httpclient.Options{
 				BasicAuth: &httpclient.BasicAuthOptions{
 					User:     "user",
 					Password: "pwd",
@@ -133,7 +139,10 @@ func TestParseHTTPSettings(t *testing.T) {
 					AccessKey:     "sigV4AccessKey4",
 					SecretKey:     "sigV4SecretKey5",
 				},
-			}, opts)
+				Labels:        map[string]string{},
+				CustomOptions: map[string]interface{}{},
+			}
+			require.Equal(t, expectedOpts, opts)
 		})
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This should get HTTP client options mapping in the SDK in pair with datasource_cache.go (the old way for core data sources in Grafana).

This change adds data source labels for name and UID as can be seen in [datasource_cache.go](https://github.com/grafana/grafana/blob/bb1dac3c7201e1a8b3bc7def7fdc355c1830623a/pkg/models/datasource_cache.go#L101-L104).

This change adds JSON data to custom options as can be seen in [datasource_cache.go](https://github.com/grafana/grafana/blob/bb1dac3c7201e1a8b3bc7def7fdc355c1830623a/pkg/models/datasource_cache.go#L108-L110). Can be retrieved via `backend.JSONDataFromHTTPClientOptions`.

This change also adds secure JSON data to custom options. Can be retrieved via `backend.SecureJSONDataFromHTTPClientOptions`.

Adding both JSONData and SecureJSONData under their own key in CustomOptions to limit a conflict on keys. Let me know WDYT?

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
