### PR TITLE
Allow TLS skip verify to be used on its own

### DIFF
--- a/backend/http_settings.go
+++ b/backend/http_settings.go
@@ -76,7 +76,7 @@ func (s *HTTPSettings) HTTPClientOptions() httpclient.Options {
 		}
 	}
 
-	if s.TLSClientAuth || s.TLSAuthWithCACert {
+	if s.TLSClientAuth || s.TLSAuthWithCACert || s.TLSSkipVerify {
 		opts.TLS = &httpclient.TLSOptions{
 			CACertificate:      s.TLSCACert,
 			ClientCertificate:  s.TLSClientCert,
@@ -217,11 +217,11 @@ func parseHTTPSettings(jsonData json.RawMessage, secureJSONData map[string]strin
 	if v, exists := dat["tlsAuthWithCACert"]; exists {
 		s.TLSAuthWithCACert = v.(bool)
 	}
+	if v, exists := dat["tlsSkipVerify"]; exists {
+		s.TLSSkipVerify = v.(bool)
+	}
 
 	if s.TLSClientAuth || s.TLSAuthWithCACert {
-		if v, exists := dat["tlsSkipVerify"]; exists {
-			s.TLSSkipVerify = v.(bool)
-		}
 		if v, exists := dat["serverName"]; exists {
 			s.TLSServerName = v.(string)
 		}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
`TLSSkipVerify` should be treated independently of the other TLS options - currently it will only be set and used when either `TLSClientAuth` or `TLSAuthWithCACert` fields are set

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes 
https://github.com/grafana/grafana/issues/37177
https://github.com/grafana/grafana/issues/37683
