### PR TITLE
FrameType: add frame type indication

### DIFF
--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -10,6 +10,9 @@ import (
 // NOTE -- in javascript this can accept any `[key: string]: any;` however
 // this interface only exposes the values we want to be exposed
 type FrameMeta struct {
+	// Type asserts that he frame matches a known type structure
+	Type FrameType `json:"type,omitempty"`
+
 	// Path is a browsable path on the datasource.
 	Path string `json:"path,omitempty"`
 

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -10,7 +10,7 @@ import (
 // NOTE -- in javascript this can accept any `[key: string]: any;` however
 // this interface only exposes the values we want to be exposed
 type FrameMeta struct {
-	// Type asserts that he frame matches a known type structure
+	// Type asserts that the frame matches a known type structure
 	Type FrameType `json:"type,omitempty"`
 
 	// Path is a browsable path on the datasource.

--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -1,0 +1,51 @@
+package data
+
+// FrameType indicates the frame structure
+type FrameType string
+
+const (
+	// FrameTypeUnknown indicates that we do not know the field type
+	FrameTypeUnknown FrameType = ""
+
+	// FrameTypeTimeSeriesWide ...
+	FrameTypeTimeSeriesWide = "timeseries-wide"
+
+	// FrameTypeTimeSeriesLong ...
+	FrameTypeTimeSeriesLong = "timeseries-long"
+
+	// FrameTypeTimeSeriesMany ...
+	FrameTypeTimeSeriesMany = "timeseries-many"
+
+	// // FrameTypeOHLC ... (known fields for open/high/low/close/ volume)
+	// FrameTypeOHLC = "timeseries-wide-ohlc"
+
+	// // FrameTypeHistogram ...
+	// FrameTypeHistogram = "histogram"
+
+	// // FrameTypeDirectoryListing ...
+	// FrameTypeDirectoryListing = "directory-listing"
+
+	// // Trace ...
+	// Trace = "trace"
+)
+
+// IsKnownType checks if the value is a known structure
+func (p FrameType) IsKnownType() bool {
+	switch p {
+	case
+		FrameTypeTimeSeriesWide,
+		FrameTypeTimeSeriesLong,
+		FrameTypeTimeSeriesMany:
+		return true
+	}
+	return false
+}
+
+// FrameTypes returns a slice of all known frame types
+func FrameTypes() []FrameType {
+	return []FrameType{
+		FrameTypeTimeSeriesWide,
+		FrameTypeTimeSeriesLong,
+		FrameTypeTimeSeriesMany,
+	}
+}

--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -1,6 +1,7 @@
 package data
 
-// FrameType, when set, asserts that the frame has a structure that is valid to for corresponding FrameType.
+// A FrameType string, when present in a frame's metadata, asserts that the
+// frame's structure conforms to the FrameType's specification.
 // This property is currently optional, so FrameType may be FrameTypeUnknown even if the properties of
 // the Frame correspond to a defined FrameType.
 type FrameType string

--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -1,6 +1,8 @@
 package data
 
-// FrameType, when set, asserts that the frame has a structure that is valid to for corresponding FrameType. This property is currently optional, so FrameType may be FrameTypeUnknown even if the properties of the Frame correspond to a defined FrameType.
+// FrameType, when set, asserts that the frame has a structure that is valid to for corresponding FrameType.
+// This property is currently optional, so FrameType may be FrameTypeUnknown even if the properties of
+// the Frame correspond to a defined FrameType.
 type FrameType string
 
 const (
@@ -66,4 +68,16 @@ func FrameTypes() []FrameType {
 		FrameTypeTimeSeriesLong,
 		FrameTypeTimeSeriesMany,
 	}
+}
+
+// IsTimeSeries checks if the type represents a timeseries
+func (p FrameType) IsTimeSeries() bool {
+	switch p {
+	case
+		FrameTypeTimeSeriesWide,
+		FrameTypeTimeSeriesLong,
+		FrameTypeTimeSeriesMany:
+		return true
+	}
+	return false
 }

--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -16,17 +16,13 @@ const (
 	// FrameTypeTimeSeriesMany ...
 	FrameTypeTimeSeriesMany = "timeseries-many"
 
-	// // FrameTypeOHLC ... (known fields for open/high/low/close/ volume)
-	// FrameTypeOHLC = "timeseries-wide-ohlc"
-
-	// // FrameTypeHistogram ...
-	// FrameTypeHistogram = "histogram"
-
-	// // FrameTypeDirectoryListing ...
-	// FrameTypeDirectoryListing = "directory-listing"
-
-	// // Trace ...
-	// Trace = "trace"
+	// Soon?
+	// "timeseries-wide-ohlc" -- known fields for open/high/low/close
+	// "histogram" -- BucketMin, BucketMax, values...
+	// "directory-listing" -- known fields for name, size, mime-type, modified, etc
+	// "trace" -- ??
+	// "node-graph-nodes"
+	// "node-graph-edges"
 )
 
 // IsKnownType checks if the value is a known structure

--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -14,18 +14,21 @@ const (
 	// field[1..n]:
 	//  * distinct labels may be attached to each field
 	//  * numeric & boolean fields can be drawn as lines on a graph
+	// See https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/#wide-format
 	FrameTypeTimeSeriesWide = "timeseries-wide"
 
-	// FrameTypeTimeSeriesLong has at least two fields:
+	// FrameTypeTimeSeriesLong uses string fields to define dimensions.  I has at least two fields:
 	// field[0]:
 	//  * type time
 	//  * ascending values
-	//  * duplicate times used for different dimensions
+	//  * duplicate times exist for multiple dimensions
 	// field[1..n]:
-	//  * string fields convert to labels
+	//  * string fields define series dimensions
+	//  * non-string fields define the series progression
+	// See https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/#long-format
 	FrameTypeTimeSeriesLong = "timeseries-long"
 
-	// FrameTypeTimeSeriesMany has exacty two fields
+	// FrameTypeTimeSeriesMany is the same as "Wide" with exactly one numeric value field
 	// field[0]:
 	//  * type time
 	//  * ascending values

--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -1,6 +1,6 @@
 package data
 
-// FrameType indicates the frame structure
+// FrameType, when set, asserts that the frame has a structure that is valid to for corresponding FrameType. This property is currently optional, so FrameType may be FrameTypeUnknown even if the properties of the Frame correspond to a defined FrameType.
 type FrameType string
 
 const (

--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -7,13 +7,32 @@ const (
 	// FrameTypeUnknown indicates that we do not know the field type
 	FrameTypeUnknown FrameType = ""
 
-	// FrameTypeTimeSeriesWide ...
+	// FrameTypeTimeSeriesWide has at least two fields:
+	// field[0]:
+	//  * type time
+	//  * unique ascending values
+	// field[1..n]:
+	//  * distinct labels may be attached to each field
+	//  * numeric & boolean fields can be drawn as lines on a graph
 	FrameTypeTimeSeriesWide = "timeseries-wide"
 
-	// FrameTypeTimeSeriesLong ...
+	// FrameTypeTimeSeriesLong has at least two fields:
+	// field[0]:
+	//  * type time
+	//  * ascending values
+	//  * duplicate times used for different dimensions
+	// field[1..n]:
+	//  * string fields convert to labels
 	FrameTypeTimeSeriesLong = "timeseries-long"
 
-	// FrameTypeTimeSeriesMany ...
+	// FrameTypeTimeSeriesMany has exacty two fields
+	// field[0]:
+	//  * type time
+	//  * ascending values
+	// field[1]:
+	//  * number field
+	//  * labels represent the series dimensions
+	// This structure is typically part of a list of frames with the same structure
 	FrameTypeTimeSeriesMany = "timeseries-many"
 
 	// Soon?

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -9,6 +9,8 @@ import (
 )
 
 // TimeSeriesType represents the type of time series the schema can be treated as (if any).
+//
+// Deprecated: this type will be replaced with FrameType and FrameType#IsTimeSeries()
 type TimeSeriesType int
 
 // TODO: Create and link to Grafana documentation on Long vs Wide
@@ -60,6 +62,7 @@ func (t TimeSeriesType) String() string {
 
 // TimeSeriesSchema returns the TimeSeriesSchema of the frame. The TimeSeriesSchema's Type
 // value will be TimeSeriesNot if it is not a time series.
+// Deprecated
 func (f *Frame) TimeSeriesSchema() (tsSchema TimeSeriesSchema) {
 	tsSchema.Type = TimeSeriesTypeNot
 	if f.Fields == nil || len(f.Fields) == 0 {

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -255,6 +255,10 @@ func LongToWide(longFrame *Frame, fillMissing *FillMissing) (*Frame, error) {
 		return nil, err
 	}
 
+	if wideFrame.Meta == nil {
+		wideFrame.Meta = &FrameMeta{}
+	}
+	wideFrame.Meta.Type = FrameTypeTimeSeriesWide
 	return wideFrame, nil
 }
 
@@ -498,6 +502,11 @@ func WideToLong(wideFrame *Frame) (*Frame, error) {
 			longFrameCounter++
 		}
 	}
+
+	if longFrame.Meta == nil {
+		longFrame.SetMeta(&FrameMeta{})
+	}
+	longFrame.Meta.Type = FrameTypeTimeSeriesLong
 	return longFrame, nil
 }
 

--- a/data/time_series_test.go
+++ b/data/time_series_test.go
@@ -119,7 +119,9 @@ func TestLongToWide(t *testing.T) {
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth"}, []float64{
 					2.0,
 					4.0,
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -164,7 +166,9 @@ func TestLongToWide(t *testing.T) {
 					data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []float64{
 						2.0,
 						4.0,
-					})),
+					})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -215,7 +219,9 @@ func TestLongToWide(t *testing.T) {
 				data.NewField(`Values Int64`, data.Labels{"Animal Factor": "sloth"}, []int64{
 					2,
 					4,
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -272,7 +278,9 @@ func TestLongToWide(t *testing.T) {
 				data.NewField(`Values Int64`, data.Labels{"Animal Factor": "sloth", "Location": "Central & South America"}, []int64{
 					2,
 					4,
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -309,7 +317,9 @@ func TestLongToWide(t *testing.T) {
 				data.NewField(`Values Floats`, data.Labels{"Animal Factor": "sloth"}, []*float64{
 					float64Ptr(2.0),
 					float64Ptr(4.0),
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -373,7 +383,9 @@ func TestLongToWide(t *testing.T) {
 					4.0,
 					0.0,
 					6.0,
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 
 			Err: require.NoError,
 		},
@@ -438,7 +450,9 @@ func TestLongToWide(t *testing.T) {
 					float64Ptr(4.0),
 					nil,
 					float64Ptr(6.0),
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -532,7 +546,9 @@ func TestLongToWide(t *testing.T) {
 					-1,
 					6,
 				}),
-			),
+			).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -626,7 +642,9 @@ func TestLongToWide(t *testing.T) {
 					int64Ptr(4),
 					int64Ptr(6),
 				}),
-			),
+			).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -720,7 +738,9 @@ func TestLongToWide(t *testing.T) {
 					nil,
 					int64Ptr(6),
 				}),
-			),
+			).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -814,7 +834,9 @@ func TestLongToWide(t *testing.T) {
 					int64Ptr(-1),
 					int64Ptr(6),
 				}),
-			),
+			).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -907,7 +929,9 @@ func TestLongToWide(t *testing.T) {
 					int64Ptr(4),
 					int64Ptr(6),
 				}),
-			),
+			).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -1000,7 +1024,9 @@ func TestLongToWide(t *testing.T) {
 					nil,
 					int64Ptr(6.0),
 				}),
-			),
+			).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 	}
@@ -1058,7 +1084,9 @@ func TestLongToWideBool(t *testing.T) {
 				data.NewField(`Values Floats`, data.Labels{"Enabled Factor": "true"}, []float64{
 					1.0,
 					3.0,
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesWide,
+			}),
 			Err: require.NoError,
 		},
 	}
@@ -1115,7 +1143,9 @@ func TestWideToLong(t *testing.T) {
 					"sloth",
 					"cat",
 					"sloth",
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesLong,
+			}),
 			Err: require.NoError,
 		},
 
@@ -1162,7 +1192,9 @@ func TestWideToLong(t *testing.T) {
 					"Central & South America",
 					"Florida",
 					"Central & South America",
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesLong,
+			}),
 		},
 		{
 			name: "two values, one factor",
@@ -1212,7 +1244,9 @@ func TestWideToLong(t *testing.T) {
 					"sloth",
 					"cat",
 					"sloth",
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesLong,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -1269,7 +1303,9 @@ func TestWideToLong(t *testing.T) {
 					"Central & South America",
 					"Florida",
 					"Central & South America",
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesLong,
+			}),
 			Err: require.NoError,
 		},
 		{
@@ -1307,7 +1343,9 @@ func TestWideToLong(t *testing.T) {
 					"sloth",
 					"cat",
 					"sloth",
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesLong,
+			}),
 		},
 		{
 			name: "sparse: one value, two factor",
@@ -1394,7 +1432,9 @@ func TestWideToLong(t *testing.T) {
 					"Florida",
 					"",
 					"Central & South America",
-				})),
+				})).SetMeta(&data.FrameMeta{
+				Type: data.FrameTypeTimeSeriesLong,
+			}),
 
 			Err: require.NoError,
 		},


### PR DESCRIPTION
Alternative approach started in #375 -- rather than a flag "isWideTimeSeries" this adds a type field to meta so we could define other types also.

This is a baby step that just adds a type property in meta, we will still need to:
1. define the types formally and externally
2. be able to validate types

Initial discussion of types exists in:
https://docs.google.com/document/d/17m6TSSJnxuQMyzk6OKk6umzGqw4Bz33uyRf5Vqf2c04/edit#
