### PR TITLE
cascade healthcheck error

### DIFF
--- a/internal/automanagement/manager.go
+++ b/internal/automanagement/manager.go
@@ -38,7 +38,10 @@ func (m *Manager) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 func (m *Manager) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	h, err := m.Get(req.PluginContext)
 	if err != nil {
-		return nil, err
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusError,
+			Message: err.Error(),
+		}, nil
 	}
 	if ds, ok := h.(backend.CheckHealthHandler); ok {
 		return ds.CheckHealth(ctx, req)


### PR DESCRIPTION
**What this PR does / why we need it**:

When using managed data source instance, plugin health neck failed to cascade actual error.  Instead of showing actual error, health check showing generic error "plugin health check failed"

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/sqlds/issues/44

**Special notes for your reviewer**:
