### PR TITLE
Arrow: convert from an Arrow Record to a data Frame

### DIFF
--- a/data/arrow.go
+++ b/data/arrow.go
@@ -666,8 +666,7 @@ func FromArrowRecord(record array.Record) (*Frame, error) {
 		return nil, err
 	}
 
-	err = populateFrameFieldsFromRecord(record, nullable, frame)
-	if err != nil {
+	if err = populateFrameFieldsFromRecord(record, nullable, frame); err != nil {
 		return nil, err
 	}
 	return frame, nil
@@ -693,10 +692,10 @@ func UnmarshalArrowFrame(b []byte) (*Frame, error) {
 		return nil, err
 	}
 
-	err = populateFrameFields(fR, nullable, frame)
-	if err != nil {
+	if err = populateFrameFields(fR, nullable, frame); err != nil {
 		return nil, err
 	}
+
 	return frame, nil
 }
 


### PR DESCRIPTION
This PR adds a new method `FromArrowRecord`, which converts an Arrow Record into a `data.Frame`. 

### Rationale

Whilst the current data frame API has methods for converting serialised bytes representing an Arrow table into a `data.Frame` there is currently nothing that lets one easily convert a materialised `arrow.Record` into a `data.Frame`.

My use-case is as follows: our project ([InfluxDB IOx](https://github.com/influxdata/influxdb_iox)) exposes an API to its SQL front-end via Arrow Flight. I'm prototyping a [Grafana backend data-source](https://github.com/e-dard/grafana-plugin-sdk-go) for IOx that uses Arrow flight as the protocol between plugin and IOx. Using the Go Flight client means that I have easy access to `array.Record` results from IOx but I couldn't finagle an easy way to get them into `data.Frames`.

### Implementation

You use `FromArrowRecord` something like this:

```go 
r, err := flight.NewRecordReader(some_flight_data_stream_response)
if err != nil {
	panic(err)
}

var frames data.Frames
for r.Next() {
	rb := r.Record()
	defer rb.Release()

	frame, err := data.FromArrowRecord(rb) // new method
	if err != nil {
		panic(err)
	}
	
	frames = append(frames, frame)
}
```

Finally, I took the opportunity to DRY up some methods in `arrow.go`. The net new changes are quite small.
