### PR TITLE
Chore: Add global code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# these will be requested for review when someone opens a pull request.
+* @grafana/plugins-platform-backend


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds global code owners of the repository. Adding more codeowners rules after this global one takes precedence. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
