### PR TITLE
Fix stable sort order of query response when encoded to JSON

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 
@@ -28,6 +29,11 @@ func Protobuf() error {
 // Test runs the test suite.
 func Test() error {
 	return sh.RunV("go", "test", "./...")
+}
+
+// TestRace runs the test suite with the data race detector enabled.
+func TestRace() error {
+	return sh.RunV("go", "test", "-race", "./...")
 }
 
 func Lint() error {

--- a/backend/json.go
+++ b/backend/json.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"fmt"
+	"sort"
 	"unsafe"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -84,12 +85,20 @@ func writeQueryDataResponseJSON(qdr *QueryDataResponse, stream *jsoniter.Stream)
 	stream.WriteObjectStart()
 	started := false
 
+	refIDs := []string{}
+	for refID := range qdr.Responses {
+		refIDs = append(refIDs, refID)
+	}
+	sort.Strings(refIDs)
+
 	// Make sure all keys in the result are written
-	for id, res := range qdr.Responses {
+	for _, refID := range refIDs {
+		res := qdr.Responses[refID]
+
 		if started {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField(id)
+		stream.WriteObjectField(refID)
 		obj := res // avoid implicit memory
 		writeDataResponseJSON(&obj, stream)
 		started = true


### PR DESCRIPTION
**What this PR does / why we need it**:
Not sure this solves the initial request of #366, but this will make sure that the order of query responses (refIDs) are always  stable (increasing order, e.g. A, B, C even if query requests has the order C, A, B.

**Which issue(s) this PR fixes**:
Fixes #366 

**Special notes for your reviewer**:
- Before my changes adding the test and running `mage testRace` would catch the problem with unstable ordering of JSON encoding