### PR TITLE
Fix data races due to concurrent jsoniter Stream buffer usage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ steps:
 - name: test
   image: grafana/grafana-plugin-ci:1.2.1-alpine
   commands:
-  - mage -v test
+  - mage -v testRace
 ---
 kind: pipeline
 type: docker
@@ -56,10 +56,10 @@ steps:
 - name: test
   image: grafana/grafana-plugin-ci:1.2.1-alpine
   commands:
-  - mage -v test
+  - mage -v testRace
 
 ---
 kind: signature
-hmac: 1e5f0fa823644b18b2fffc3c454f263996010fde0b2b907293dc6657b53470e0
+hmac: 6bc4908a836313924b1b3e8bdc0758a2c1bb65dc3843c7c55ff7f020695dbc57
 
 ...

--- a/backend/data.go
+++ b/backend/data.go
@@ -118,7 +118,7 @@ func (r DataResponse) MarshalJSON() ([]byte, error) {
 	defer cfg.ReturnStream(stream)
 
 	writeDataResponseJSON(&r, stream)
-	return append([]byte(nil), stream.Buffer()...), stream.Error // Copy this with care, for concurency, you may need to copy the buffer
+	return append([]byte(nil), stream.Buffer()...), stream.Error
 }
 
 // TimeRange represents a time range for a query and is a property of DataQuery.

--- a/backend/data.go
+++ b/backend/data.go
@@ -78,7 +78,7 @@ func (r QueryDataResponse) MarshalJSON() ([]byte, error) {
 	defer cfg.ReturnStream(stream)
 
 	writeQueryDataResponseJSON(&r, stream)
-	return stream.Buffer(), stream.Error
+	return append([]byte(nil), stream.Buffer()...), stream.Error
 }
 
 // UnmarshalJSON will read JSON into a QueryDataResponse
@@ -118,7 +118,7 @@ func (r DataResponse) MarshalJSON() ([]byte, error) {
 	defer cfg.ReturnStream(stream)
 
 	writeDataResponseJSON(&r, stream)
-	return stream.Buffer(), stream.Error // Copy this with care, for concurency, you may need to copy the buffer
+	return append([]byte(nil), stream.Buffer()...), stream.Error // Copy this with care, for concurency, you may need to copy the buffer
 }
 
 // TimeRange represents a time range for a query and is a property of DataQuery.


### PR DESCRIPTION
**What this PR does / why we need it**:

#299 introduced fixes for possible concurrent buffer usage of jsoniter.Stream byte buffer. It also introduced some tests to catch possible bugs in the future. Looks like race detector can't catch those bugs on every run – so we missed a couple of places where a copy of buffer also required. 

This may fix occasionally broken JSON when marshalling responses.

**Which issue(s) this PR fixes**:

Fixes #424 