### PR TITLE
add convert with column function

### DIFF
--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -19,6 +19,9 @@ type FrameConverter struct {
 	// `in` is always supplied as a pointer, as it is scanned as a pointer, even if `InputScanType` is not a pointer.
 	// For example, if `InputScanType` is `string`, then `in` is `*string`
 	ConverterFunc func(in interface{}) (interface{}, error)
+	// ConvertWithColumn is the same as ConverterFunc, but allows passing the column type
+	// useful when column attributes are needed during conversion
+	ConvertWithColumn func(in interface{}, col sql.ColumnType) (interface{}, error)
 }
 
 // StringConverter can be used to store types not supported by
@@ -124,6 +127,9 @@ type Converter struct {
 
 	// FrameConverter defines how to convert the scanned value into a value that can be put into a dataframe
 	FrameConverter FrameConverter
+
+	// colType is the underlying sql column type, set during scan
+	colType sql.ColumnType
 }
 
 // DefaultConverterFunc assumes that the scanned value, in, is already a type that can be put into a dataframe.

--- a/data/sqlutil/frame.go
+++ b/data/sqlutil/frame.go
@@ -26,6 +26,14 @@ func Append(frame *data.Frame, row []interface{}, converters ...Converter) error
 
 	d := make([]interface{}, len(row))
 	for i, v := range row {
+		if converters[i].FrameConverter.ConvertWithColumn != nil {
+			value, err := converters[i].FrameConverter.ConvertWithColumn(v, converters[i].colType)
+			if err != nil {
+				return err
+			}
+			d[i] = value
+			continue
+		}
 		value, err := converters[i].FrameConverter.ConverterFunc(v)
 		if err != nil {
 			return err

--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -100,6 +100,7 @@ func MakeScanRow(colTypes []*sql.ColumnType, colNames []string, converters ...Co
 			converter = &v
 			scanType = v.InputScanType
 		}
+		converter.colType = *colType
 
 		r.Append(colName, scanType)
 		c = append(c, *converter)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a function to the converter that allows passing the column type.  We need to know the precision/scale for decimal conversion in clickhouse.

