### PR TITLE
fix minor typo in output

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -34,7 +34,7 @@ func GetExecutableFromPluginJSON(dir string) (string, error) {
 		exe, err2 := GetStringValueFromJSON(path.Join(dir, "datasource", "plugin.json"), "executable")
 		if err2 == nil {
 			if !strings.HasPrefix(exe, "../") {
-				return "", fmt.Errorf("datasouce should reference executable in root folder")
+				return "", fmt.Errorf("datasource should reference executable in root folder")
 			}
 			return exe[3:], nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Output says "datasouce" when it should say "datasource" (running mage on a backend plugin)

```
❯ mage
Error: datasouce should reference executable in root folder
datasouce should reference executable in root folder
datasouce should reference executable in root folder
datasouce should reference executable in root folder
datasouce should reference executable in root folder
datasouce should reference executable in root folder
```

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

noticed this output while using the sdk