### PR TITLE
get log level

### DIFF
--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -67,17 +67,17 @@ func (l *hclogWrapper) Level() Level {
 	if l.logger.IsDebug() {
 		return Debug
 	}
-	if l.logger.IsError() {
-		return Error
+	if l.logger.IsTrace() {
+		return Trace
 	}
 	if l.logger.IsInfo() {
 		return Info
 	}
-	if l.logger.IsTrace() {
-		return Trace
-	}
 	if l.logger.IsWarn() {
 		return Warn
+	}
+	if l.logger.IsError() {
+		return Error
 	}
 	return NoLevel
 }

--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -27,11 +27,11 @@ type Logger interface {
 
 // New creates a new logger.
 func New() Logger {
-	return NewLogger(Debug)
+	return NewWithLevel(Debug)
 }
 
-// NewLogger creates a new logger at the Level defined.
-func NewLogger(level Level) Logger {
+// NewWithLevel creates a new logger at the Level defined.
+func NewWithLevel(level Level) Logger {
 	return &hclogWrapper{
 		logger: hclog.New(&hclog.LoggerOptions{
 			// Use debug as level since anything less severe is suppressed.

--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -27,10 +27,14 @@ type Logger interface {
 
 // New creates a new logger.
 func New() Logger {
+	return NewLogger(Debug)
+}
+
+func NewLogger(level Level) Logger {
 	return &hclogWrapper{
 		logger: hclog.New(&hclog.LoggerOptions{
 			// Use debug as level since anything less severe is suppressed.
-			Level: hclog.Debug,
+			Level: hclog.Level(level),
 			// Use JSON format to make the output in Grafana format and work
 			// when using multiple arguments such as Debug("message", "key", "value").
 			JSONFormat: true,

--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -30,6 +30,7 @@ func New() Logger {
 	return NewLogger(Debug)
 }
 
+// NewLogger creates a new logger at the Level defined.
 func NewLogger(level Level) Logger {
 	return &hclogWrapper{
 		logger: hclog.New(&hclog.LoggerOptions{

--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -60,21 +60,21 @@ func (l *hclogWrapper) Error(msg string, args ...interface{}) {
 
 func (l *hclogWrapper) Level() Level {
 	if l.logger.IsDebug() {
-		return Level(hclog.Debug)
+		return Debug
 	}
 	if l.logger.IsError() {
-		return Level(hclog.Error)
+		return Error
 	}
 	if l.logger.IsInfo() {
-		return Level(hclog.Info)
+		return Info
 	}
 	if l.logger.IsTrace() {
-		return Level(hclog.Trace)
+		return Trace
 	}
 	if l.logger.IsWarn() {
-		return Level(hclog.Warn)
+		return Warn
 	}
-	return Level(hclog.NoLevel)
+	return NoLevel
 }
 
 // DefaultLogger is the default logger.

--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -5,12 +5,15 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 )
 
+type Level hclog.Level
+
 // Logger is the main Logger interface.
 type Logger interface {
 	Debug(msg string, args ...interface{})
 	Info(msg string, args ...interface{})
 	Warn(msg string, args ...interface{})
 	Error(msg string, args ...interface{})
+	Level() Level
 }
 
 // New creates a new logger.
@@ -44,6 +47,25 @@ func (l *hclogWrapper) Warn(msg string, args ...interface{}) {
 
 func (l *hclogWrapper) Error(msg string, args ...interface{}) {
 	l.logger.Error(msg, args...)
+}
+
+func (l *hclogWrapper) Level() Level {
+	if l.logger.IsDebug() {
+		return Level(hclog.Debug)
+	}
+	if l.logger.IsError() {
+		return Level(hclog.Error)
+	}
+	if l.logger.IsInfo() {
+		return Level(hclog.Info)
+	}
+	if l.logger.IsTrace() {
+		return Level(hclog.Trace)
+	}
+	if l.logger.IsWarn() {
+		return Level(hclog.Warn)
+	}
+	return Level(hclog.NoLevel)
 }
 
 // DefaultLogger is the default logger.

--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -5,7 +5,16 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 )
 
-type Level hclog.Level
+type Level int32
+
+const (
+	NoLevel Level = iota
+	Trace
+	Debug
+	Info
+	Warn
+	Error
+)
 
 // Logger is the main Logger interface.
 type Logger interface {

--- a/backend/log/log_test.go
+++ b/backend/log/log_test.go
@@ -14,7 +14,7 @@ func TestLogLevel(t *testing.T) {
 }
 
 func TestLogLevelWarn(t *testing.T) {
-	logger := log.NewLogger(log.Warn)
+	logger := log.NewWithLevel(log.Warn)
 	level := logger.Level()
 	assert.Equal(t, level, log.Warn)
 }

--- a/backend/log/log_test.go
+++ b/backend/log/log_test.go
@@ -12,3 +12,9 @@ func TestLogLevel(t *testing.T) {
 	level := logger.Level()
 	assert.Equal(t, level, log.Debug)
 }
+
+func TestLogLevelWarn(t *testing.T) {
+	logger := log.NewLogger(log.Warn)
+	level := logger.Level()
+	assert.Equal(t, level, log.Warn)
+}

--- a/backend/log/log_test.go
+++ b/backend/log/log_test.go
@@ -1,0 +1,14 @@
+package log_test
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogLevel(t *testing.T) {
+	logger := log.New()
+	level := logger.Level()
+	assert.Equal(t, level, log.Level(log.Debug))
+}

--- a/backend/log/log_test.go
+++ b/backend/log/log_test.go
@@ -10,5 +10,5 @@ import (
 func TestLogLevel(t *testing.T) {
 	logger := log.New()
 	level := logger.Level()
-	assert.Equal(t, level, log.Level(log.Debug))
+	assert.Equal(t, level, log.Debug)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Return the log level.  For cases where we may want to do something expensive, like convert a large struct to string (if Level is Debug) so we can log it.
