### PR TITLE
FrameTypes: remove table footer

### DIFF
--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -59,11 +59,6 @@ const (
 
 	// FrameTypeTable represents an arbitrary table structure with no constraints
 	FrameTypeTable = "table"
-
-	// FrameTypeTableFooter may exist next to FrameTypeTable and represent data that
-	// should show up in the footer section.  It must have the same width, but not
-	// necessarily same field types as the sibling table data
-	FrameTypeTableFooter = "table-footer"
 )
 
 // IsKnownType checks if the value is a known structure


### PR DESCRIPTION
We added this while trying to sync table data with data that could get displayed as a footer -- that work never got merged, and likely will not.

Lets remove it for now to avoid any confusion.