### PR TITLE
Field benchmarks

### DIFF
--- a/data/field_bench_test.go
+++ b/data/field_bench_test.go
@@ -1,0 +1,179 @@
+package data_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+const LENGTH = 100_000
+
+func BenchmarkNewFieldNullableFloat(b *testing.B) {
+	b.ReportAllocs()
+	b.Run("NewField *float64 make() known length", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			vals := make([]*float64, LENGTH)
+			for i := float64(0); i < LENGTH; i++ {
+				vals[int(i)] = &i
+			}
+			_ = data.NewField("Test", data.Labels{}, vals)
+		}
+	})
+
+	b.Run("NewField *float64 pre-fill array", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			vals := []*float64{}
+			for i := float64(0); i < LENGTH; i++ {
+				vals = append(vals, &i)
+			}
+			_ = data.NewField("Test", data.Labels{}, vals)
+		}
+	})
+
+	b.Run("NewField *float64 Append", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			f := data.NewField("Test", data.Labels{}, make([]*float64, 0))
+			for i := float64(0); i < LENGTH; i++ {
+				f.Append(&i)
+			}
+		}
+	})
+}
+
+func BenchmarkNewFieldFromTypeNullableFloat(b *testing.B) {
+	b.Run("NewFieldFromFieldType *float64 Append", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			f := data.NewFieldFromFieldType(data.FieldTypeNullableFloat64, 0)
+			for i := float64(0); i < LENGTH; i++ {
+				f.Append(&i)
+			}
+		}
+	})
+
+	b.Run("NewFieldFromFieldType *float64 Set", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			f := data.NewFieldFromFieldType(data.FieldTypeNullableFloat64, LENGTH)
+			for i := float64(0); i < LENGTH; i++ {
+				f.Set(int(i), &i)
+			}
+		}
+	})
+}
+
+func BenchmarkNewFieldFloat(b *testing.B) {
+	b.Run("NewField float64 make() known length", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			vals := make([]float64, LENGTH)
+			for i := float64(0); i < LENGTH; i++ {
+				vals[int(i)] = i
+			}
+			_ = data.NewField("Test", data.Labels{}, vals)
+		}
+	})
+
+	b.Run("NewField float64 pre-fill array", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			vals := []float64{}
+			for i := float64(0); i < LENGTH; i++ {
+				vals = append(vals, i)
+			}
+			_ = data.NewField("Test", data.Labels{}, vals)
+		}
+	})
+
+	b.Run("NewField float64 Append", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			f := data.NewField("Test", data.Labels{}, make([]float64, 0))
+			for i := float64(0); i < LENGTH; i++ {
+				f.Append(i)
+			}
+		}
+	})
+}
+
+func BenchmarkNewFieldFromeTypeFloat(b *testing.B) {
+	b.Run("NewFieldFromFieldType float64 Append", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			f := data.NewFieldFromFieldType(data.FieldTypeFloat64, 0)
+			for i := float64(0); i < LENGTH; i++ {
+				f.Append(i)
+			}
+		}
+	})
+
+	b.Run("NewFieldFromFieldType float64 Set", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			f := data.NewFieldFromFieldType(data.FieldTypeFloat64, LENGTH)
+			for i := float64(0); i < LENGTH; i++ {
+				f.Set(int(i), i)
+			}
+		}
+	})
+}
+
+func BenchmarkNewFieldTime(b *testing.B) {
+	b.Run("NewField time.Time make() known length", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			vals := make([]time.Time, LENGTH)
+			for i := float64(0); i < LENGTH; i++ {
+				vals[int(i)] = time.Now()
+			}
+			_ = data.NewField("Test", data.Labels{}, vals)
+		}
+	})
+
+	b.Run("NewField time.Time pre-fill array", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			vals := []time.Time{}
+			for i := float64(0); i < LENGTH; i++ {
+				vals = append(vals, time.Now())
+			}
+			_ = data.NewField("Test", data.Labels{}, vals)
+		}
+	})
+
+	b.Run("NewField time.Time Append", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			f := data.NewField("Test", data.Labels{}, make([]time.Time, 0))
+			for i := float64(0); i < LENGTH; i++ {
+				f.Append(time.Now())
+			}
+		}
+	})
+}
+
+func BenchmarkNewFieldFromeTypeTime(b *testing.B) {
+	b.Run("NewFieldFromFieldType time.Time Append", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			f := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+			for i := float64(0); i < LENGTH; i++ {
+				f.Append(time.Now())
+			}
+		}
+	})
+
+	b.Run("NewFieldFromFieldType time.Time Set", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			f := data.NewFieldFromFieldType(data.FieldTypeTime, LENGTH)
+			for i := float64(0); i < LENGTH; i++ {
+				f.Set(int(i), time.Now())
+			}
+		}
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
Added benchmarks to test theory in https://github.com/grafana/grafana/pull/44520
```
BenchmarkNewFieldNullableFloat/NewField_*float64_make()_known_length-32                      656           2407223 ns/op         1605797 B/op          7 allocs/op
BenchmarkNewFieldNullableFloat/NewField_*float64_pre-fill_array-32                           255           4547511 ns/op         5457360 B/op         36 allocs/op
BenchmarkNewFieldNullableFloat/NewField_*float64_Append-32                                   303           3810055 ns/op         4654497 B/op         35 allocs/op
BenchmarkNewFieldFromTypeNullableFloat/NewFieldFromFieldType_*float64_Append-32              297           3528601 ns/op         4654418 B/op         33 allocs/op
BenchmarkNewFieldFromTypeNullableFloat/NewFieldFromFieldType_*float64_Set-32                 732           1458889 ns/op          802896 B/op          4 allocs/op
BenchmarkNewFieldFloat/NewField_float64_make()_known_length-32                              3657            354358 ns/op         1605778 B/op          6 allocs/op
BenchmarkNewFieldFloat/NewField_float64_pre-fill_array-32                                   1864            723249 ns/op         5457314 B/op         35 allocs/op
BenchmarkNewFieldFloat/NewField_float64_Append-32                                            424           2685568 ns/op         5454521 B/op     100033 allocs/op
BenchmarkNewFieldFromeTypeFloat/NewFieldFromFieldType_float64_Append-32                      583           2623808 ns/op         5454445 B/op     100031 allocs/op
BenchmarkNewFieldFromeTypeFloat/NewFieldFromFieldType_float64_Set-32                         579           1775448 ns/op         1602893 B/op     100002 allocs/op
BenchmarkNewFieldTime/NewField_time.Time_make()_known_length-32                              124           8986156 ns/op         4800656 B/op          6 allocs/op
BenchmarkNewFieldTime/NewField_time.Time_pre-fill_array-32                                    75          15044672 ns/op        16998530 B/op         36 allocs/op
BenchmarkNewFieldTime/NewField_time.Time_Append-32                                            82          15641945 ns/op        16998268 B/op     100035 allocs/op
BenchmarkNewFieldFromeTypeTime/NewFieldFromFieldType_time.Time_Append-32                      63          16749603 ns/op        16998200 B/op     100033 allocs/op
BenchmarkNewFieldFromeTypeTime/NewFieldFromFieldType_time.Time_Set-32                        100          11790655 ns/op         4800328 B/op     100003 allocs/op
PASS
```

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
