### PR TITLE
Out of the box support for enabling profiling via Grafana

### DIFF
--- a/backend/setup.go
+++ b/backend/setup.go
@@ -7,12 +7,12 @@ import (
 	"os"
 )
 
-const (
-	// PluginProfilerEnv is a constant for the GF_PLUGINS_PROFILER environment variable used to enable pprof.
-	PluginProfilerEnv = "GF_PLUGINS_PROFILER"
+var (
+	// PluginProfilerEnvs is a list of valid environment variables used to enable pprof.
+	PluginProfilerEnvs = []string{"GF_PLUGINS_PROFILER", "GF_PLUGIN_PROFILER"}
 
-	// PluginProfilerPortEnv is a constant for the GF_PLUGINS_PROFILER_PORT environment variable use to specify a pprof port (default 6060).
-	PluginProfilerPortEnv = "GF_PLUGINS_PROFILER_PORT"
+	// PluginProfilerPortEnvs is a list of valid environment variable used to specify a pprof port (default 6060).
+	PluginProfilerPortEnvs = []string{"GF_PLUGINS_PROFILER_PORT", "GF_PLUGIN_PROFILER_PORT"}
 )
 
 // SetupPluginEnvironment will read the environment variables and apply the
@@ -24,17 +24,23 @@ const (
 func SetupPluginEnvironment(pluginID string) {
 	// Enable profiler
 	profilerEnabled := false
-	if value, ok := os.LookupEnv(PluginProfilerEnv); ok {
-		// compare value to plugin name
-		if value == pluginID {
-			profilerEnabled = true
+	for _, env := range PluginProfilerEnvs {
+		if value, ok := os.LookupEnv(env); ok {
+			// compare value to plugin name
+			if value == pluginID {
+				profilerEnabled = true
+			}
+			break
 		}
 	}
 	Logger.Info("Profiler", "enabled", profilerEnabled)
 	if profilerEnabled {
 		profilerPort := "6060"
-		if value, ok := os.LookupEnv(PluginProfilerPortEnv); ok {
-			profilerPort = value
+		for _, env := range PluginProfilerPortEnvs {
+			if value, ok := os.LookupEnv(env); ok {
+				profilerPort = value
+				break
+			}
 		}
 
 		Logger.Info("Profiler", "port", profilerPort)

--- a/backend/setup.go
+++ b/backend/setup.go
@@ -12,6 +12,7 @@ var (
 	PluginProfilerEnvDeprecated = "GF_PLUGINS_PROFILER"
 	// PluginProfilerEnv is a constant for the GF_PLUGIN_PROFILER environment variable used to enable pprof.
 	PluginProfilerEnv = "GF_PLUGIN_PROFILER"
+
 	// PluginProfilerPortEnvDeprecated is a constant for the GF_PLUGINS_PROFILER_PORT environment variable use to specify a pprof port (default 6060).
 	PluginProfilerPortEnvDeprecated = "GF_PLUGINS_PROFILER_PORT"
 	// PluginProfilerPortEnv is a constant for the GF_PLUGIN_PROFILER_PORT environment variable use to specify a pprof port (default 6060).
@@ -47,7 +48,6 @@ func SetupPluginEnvironment(pluginID string) {
 				break
 			}
 		}
-
 		Logger.Info("Profiler", "port", profilerPort)
 		portConfig := fmt.Sprintf(":%s", profilerPort)
 

--- a/backend/setup.go
+++ b/backend/setup.go
@@ -10,13 +10,13 @@ import (
 var (
 	// PluginProfilerEnvDeprecated is a deprecated constant for the GF_PLUGINS_PROFILER environment variable used to enable pprof.
 	PluginProfilerEnvDeprecated = "GF_PLUGINS_PROFILER"
-	// PluginProfilerEnv is a constant for the GF_PLUGIN_PROFILER environment variable used to enable pprof.
-	PluginProfilerEnv = "GF_PLUGIN_PROFILER"
+	// PluginProfilingEnabledEnv is a constant for the GF_PLUGIN_PROFILING_ENABLED environment variable used to enable pprof.
+	PluginProfilingEnabledEnv = "GF_PLUGIN_PROFILING_ENABLED"
 
 	// PluginProfilerPortEnvDeprecated is a constant for the GF_PLUGINS_PROFILER_PORT environment variable use to specify a pprof port (default 6060).
 	PluginProfilerPortEnvDeprecated = "GF_PLUGINS_PROFILER_PORT"
-	// PluginProfilerPortEnv is a constant for the GF_PLUGIN_PROFILER_PORT environment variable use to specify a pprof port (default 6060).
-	PluginProfilerPortEnv = "GF_PLUGIN_PROFILER_PORT"
+	// PluginProfilingPortEnv is a constant for the GF_PLUGIN_PROFILING_PORT environment variable use to specify a pprof port (default 6060).
+	PluginProfilingPortEnv = "GF_PLUGIN_PROFILING_PORT"
 )
 
 // SetupPluginEnvironment will read the environment variables and apply the
@@ -33,7 +33,7 @@ func SetupPluginEnvironment(pluginID string) {
 		if value == pluginID {
 			profilerEnabled = true
 		}
-	} else if value, ok = os.LookupEnv(PluginProfilerEnv); ok {
+	} else if value, ok = os.LookupEnv(PluginProfilingEnabledEnv); ok {
 		if value == "true" {
 			profilerEnabled = true
 		}
@@ -42,7 +42,7 @@ func SetupPluginEnvironment(pluginID string) {
 	Logger.Info("Profiler", "enabled", profilerEnabled)
 	if profilerEnabled {
 		profilerPort := "6060"
-		for _, env := range []string{PluginProfilerPortEnvDeprecated, PluginProfilerPortEnv} {
+		for _, env := range []string{PluginProfilerPortEnvDeprecated, PluginProfilingPortEnv} {
 			if value, ok := os.LookupEnv(env); ok {
 				profilerPort = value
 				break

--- a/backend/setup.go
+++ b/backend/setup.go
@@ -8,11 +8,14 @@ import (
 )
 
 var (
-	// PluginProfilerEnvs is a list of valid environment variables used to enable pprof.
-	PluginProfilerEnvs = []string{"GF_PLUGINS_PROFILER", "GF_PLUGIN_PROFILER"}
-
-	// PluginProfilerPortEnvs is a list of valid environment variable used to specify a pprof port (default 6060).
-	PluginProfilerPortEnvs = []string{"GF_PLUGINS_PROFILER_PORT", "GF_PLUGIN_PROFILER_PORT"}
+	// PluginProfilerEnvDeprecated is a deprecated constant for the GF_PLUGINS_PROFILER environment variable used to enable pprof.
+	PluginProfilerEnvDeprecated = "GF_PLUGINS_PROFILER"
+	// PluginProfilerEnv is a constant for the GF_PLUGIN_PROFILER environment variable used to enable pprof.
+	PluginProfilerEnv = "GF_PLUGIN_PROFILER"
+	// PluginProfilerPortEnvDeprecated is a constant for the GF_PLUGINS_PROFILER_PORT environment variable use to specify a pprof port (default 6060).
+	PluginProfilerPortEnvDeprecated = "GF_PLUGINS_PROFILER_PORT"
+	// PluginProfilerPortEnv is a constant for the GF_PLUGIN_PROFILER_PORT environment variable use to specify a pprof port (default 6060).
+	PluginProfilerPortEnv = "GF_PLUGIN_PROFILER_PORT"
 )
 
 // SetupPluginEnvironment will read the environment variables and apply the
@@ -24,19 +27,21 @@ var (
 func SetupPluginEnvironment(pluginID string) {
 	// Enable profiler
 	profilerEnabled := false
-	for _, env := range PluginProfilerEnvs {
-		if value, ok := os.LookupEnv(env); ok {
-			// compare value to plugin name
-			if value == pluginID {
-				profilerEnabled = true
-			}
-			break
+	if value, ok := os.LookupEnv(PluginProfilerEnvDeprecated); ok {
+		// compare value to plugin name
+		if value == pluginID {
+			profilerEnabled = true
+		}
+	} else if value, ok = os.LookupEnv(PluginProfilerEnv); ok {
+		if value == "true" {
+			profilerEnabled = true
 		}
 	}
+
 	Logger.Info("Profiler", "enabled", profilerEnabled)
 	if profilerEnabled {
 		profilerPort := "6060"
-		for _, env := range PluginProfilerPortEnvs {
+		for _, env := range []string{PluginProfilerPortEnvDeprecated, PluginProfilerPortEnv} {
 			if value, ok := os.LookupEnv(env); ok {
 				profilerPort = value
 				break


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
If we want to enable profiling for a plugin, with this change it's as simple as:

```ini

[plugin.grafana-github-datasource]
profiling_enabled = true
profiling_port    = 6060
```

Sometimes it's not possible/a lot of work to configure the existing (now deprecated) env variables
**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #459

**Special notes for your reviewer**:
(see issue for full details)