### PR TITLE
Add CollectMetricsResult.ToUsageStats

### DIFF
--- a/backend/diagnostics.go
+++ b/backend/diagnostics.go
@@ -1,8 +1,15 @@
 package backend
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
+
+	prom "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
 )
 
 // CheckHealthHandler enables users to send health check
@@ -82,4 +89,97 @@ func (fn CollectMetricsHandlerFunc) CollectMetrics(ctx context.Context) (*Collec
 // CollectMetricsResult collect metrics result.
 type CollectMetricsResult struct {
 	PrometheusMetrics []byte
+}
+
+// ToUsageStats filters a CollectMetricsResult and returns usage stats
+func (res *CollectMetricsResult) ToUsageStats(pluginID string) map[string]interface{} {
+	var (
+		parser expfmt.TextParser
+		r      = regexp.MustCompile(`usage_stats[_]?`)
+		stats  = map[string]interface{}{}
+		reader = bytes.NewReader(res.PrometheusMetrics)
+	)
+
+	mfs, err := parser.TextToMetricFamilies(reader)
+	if err != nil {
+		Logger.Error("unable to parse usage stats from metric", "plugin", pluginID, "err", err)
+	}
+	for _, mf := range mfs {
+		if !strings.HasPrefix(mf.GetName(), "usage_stats") {
+			continue
+		}
+		name := r.ReplaceAllString(mf.GetName(), "")
+		for _, m := range mf.Metric {
+			labels := []string{pluginID, name}
+			for _, l := range m.Label {
+				labels = append(labels, l.GetName(), l.GetValue())
+			}
+			converted := map[string]interface{}{}
+			switch mf.GetType() {
+			case prom.MetricType_COUNTER:
+				converted = convertCounter(labels, m)
+			case prom.MetricType_GAUGE:
+				converted = convertGauge(labels, m)
+			case prom.MetricType_SUMMARY:
+				converted = convertSummary(labels, m)
+			case prom.MetricType_HISTOGRAM:
+				converted = convertHistogram(labels, m)
+			}
+			for k, v := range converted {
+				stats[k] = v
+			}
+		}
+	}
+
+	return stats
+}
+
+func convertCounter(labels []string, m *prom.Metric) map[string]interface{} {
+	stats := map[string]interface{}{}
+	key := toUsageStatKey(labels...)
+	stats[key] = m.GetCounter().GetValue()
+	return stats
+}
+
+func convertGauge(labels []string, m *prom.Metric) map[string]interface{} {
+	stats := map[string]interface{}{}
+	key := toUsageStatKey(labels...)
+	stats[key] = m.GetGauge().GetValue()
+	return stats
+}
+
+func convertSummary(labels []string, m *prom.Metric) map[string]interface{} {
+	stats := map[string]interface{}{}
+	summary := m.GetSummary()
+	key := toUsageStatKey(append(labels, "sum")...)
+	stats[key] = summary.GetSampleSum()
+	key = toUsageStatKey(append(labels, "count")...)
+	stats[key] = float64(summary.GetSampleCount())
+	for _, q := range summary.Quantile {
+		key = toUsageStatKey(append(labels, "quantile", fmt.Sprintf("%.2f", q.GetQuantile()))...)
+		stats[key] = q.GetValue()
+	}
+	return stats
+}
+
+func convertHistogram(labels []string, m *prom.Metric) map[string]interface{} {
+	h := m.GetHistogram()
+	stats := map[string]interface{}{}
+	key := toUsageStatKey(append(labels, "sum")...)
+	stats[key] = h.GetSampleSum()
+	key = toUsageStatKey(append(labels, "count")...)
+	stats[key] = float64(h.GetSampleCount())
+	for _, b := range h.Bucket {
+		key = toUsageStatKey(append(labels, "bucket", fmt.Sprintf("%.0f", b.GetUpperBound()))...)
+		stats[key] = float64(b.GetCumulativeCount())
+	}
+	return stats
+}
+
+func toUsageStatKey(s ...string) string {
+	cleaned := make([]string, len(s))
+	for i, v := range s {
+		cleaned[i] = strings.ToLower(strings.ReplaceAll(v, ".", "_"))
+	}
+	return "stats.plugin." + strings.Join(cleaned, ".")
 }

--- a/backend/diagnostics_test.go
+++ b/backend/diagnostics_test.go
@@ -1,0 +1,113 @@
+package backend_test
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToUsageStats(t *testing.T) {
+	t.Run("should ignore metrics without the usage_stats prefix", func(t *testing.T) {
+		metrics := `
+# TYPE go_goroutines gauge
+go_goroutines 10.0
+`
+		res := &backend.CollectMetricsResult{PrometheusMetrics: []byte(metrics)}
+		stats := res.ToUsageStats("grafana-fake-datasource")
+		require.Equal(t, map[string]interface{}{}, stats)
+	})
+
+	t.Run("should parse counter", func(t *testing.T) {
+		metrics := `
+# HELP usage_stats_instance_total Number of instances
+# TYPE usage_stats_instance_total counter
+usage_stats_instance_total 10.0
+`
+		res := &backend.CollectMetricsResult{PrometheusMetrics: []byte(metrics)}
+		stats := res.ToUsageStats("grafana-fake-datasource")
+		require.Equal(t, map[string]interface{}{"stats.plugin.grafana-fake-datasource.instance_total": 10.0}, stats)
+	})
+
+	t.Run("should parse gauge", func(t *testing.T) {
+		metrics := `
+# HELP usage_stats_response_size_bytes Response size in bytes
+# TYPE usage_stats_response_size_bytes gauge
+usage_stats_response_size_bytes 100.0
+`
+		res := &backend.CollectMetricsResult{PrometheusMetrics: []byte(metrics)}
+		stats := res.ToUsageStats("example")
+		require.Equal(t, map[string]interface{}{"stats.plugin.example.response_size_bytes": float64(100)}, stats)
+	})
+
+	t.Run("should parse summary", func(t *testing.T) {
+		metrics := `
+# HELP usage_stats_response_size_bytes Response size in bytes
+# TYPE usage_stats_response_size_bytes summary
+usage_stats_response_size_bytes{quantile="0.5"} 1.0
+usage_stats_response_size_bytes{quantile="0.9"} 1.0
+usage_stats_response_size_bytes{quantile="0.99"} 1.0
+usage_stats_response_size_bytes_sum 4
+usage_stats_response_size_bytes_count 6
+`
+		res := &backend.CollectMetricsResult{PrometheusMetrics: []byte(metrics)}
+		stats := res.ToUsageStats("example")
+		require.Equal(t, map[string]interface{}{
+			"stats.plugin.example.response_size_bytes.count":         6.0,
+			"stats.plugin.example.response_size_bytes.quantile.0_50": 1.0,
+			"stats.plugin.example.response_size_bytes.quantile.0_90": 1.0,
+			"stats.plugin.example.response_size_bytes.quantile.0_99": 1.0,
+			"stats.plugin.example.response_size_bytes.sum":           4.0,
+		}, stats)
+	})
+
+	t.Run("should parse histogram", func(t *testing.T) {
+		metrics := `
+# HELP usage_stats_response_size_bytes Histogram for response size in bytes
+# TYPE usage_stats_response_size_bytes histogram
+usage_stats_response_size_bytes_bucket{le="8.999999999999998"} 58475
+usage_stats_response_size_bytes_bucket{le="24.999999999999996"} 858715
+usage_stats_response_size_bytes_bucket{le="64.99999999999999"} 1.606968e+06
+usage_stats_response_size_bytes_bucket{le="144.99999999999997"} 1.963916e+06
+usage_stats_response_size_bytes_bucket{le="320.99999999999994"} 2.013705e+06
+usage_stats_response_size_bytes_bucket{le="704.9999999999999"} 2.026067e+06
+usage_stats_response_size_bytes_bucket{le="1536.9999999999998"} 2.035428e+06
+usage_stats_response_size_bytes_bucket{le="3200.9999999999995"} 2.038281e+06
+usage_stats_response_size_bytes_bucket{le="6528.999999999999"} 2.041383e+06
+usage_stats_response_size_bytes_bucket{le="13568.999999999998"} 2.042418e+06
+usage_stats_response_size_bytes_bucket{le="27264.999999999996"} 2.043538e+06
+usage_stats_response_size_bytes_bucket{le="+Inf"} 2.043966e+06
+usage_stats_response_size_bytes_sum 1.88505312e+08
+usage_stats_response_size_bytes_count 2.043966e+06
+`
+		res := &backend.CollectMetricsResult{PrometheusMetrics: []byte(metrics)}
+		stats := res.ToUsageStats("example")
+		require.Equal(t, map[string]interface{}{
+			"stats.plugin.example.response_size_bytes.bucket.+inf":  2.043966e+06,
+			"stats.plugin.example.response_size_bytes.bucket.13569": 2.042418e+06,
+			"stats.plugin.example.response_size_bytes.bucket.145":   1.963916e+06,
+			"stats.plugin.example.response_size_bytes.bucket.1537":  2.035428e+06,
+			"stats.plugin.example.response_size_bytes.bucket.25":    858715.0,
+			"stats.plugin.example.response_size_bytes.bucket.27265": 2.043538e+06,
+			"stats.plugin.example.response_size_bytes.bucket.3201":  2.038281e+06,
+			"stats.plugin.example.response_size_bytes.bucket.321":   2.013705e+06,
+			"stats.plugin.example.response_size_bytes.bucket.65":    1.606968e+06,
+			"stats.plugin.example.response_size_bytes.bucket.6529":  2.041383e+06,
+			"stats.plugin.example.response_size_bytes.bucket.705":   2.026067e+06,
+			"stats.plugin.example.response_size_bytes.bucket.9":     58475.0,
+			"stats.plugin.example.response_size_bytes.count":        2.043966e+06,
+			"stats.plugin.example.response_size_bytes.sum":          1.88505312e+08,
+		}, stats)
+	})
+
+	t.Run("should parse and clean labels", func(t *testing.T) {
+		metrics := `
+# HELP usage_stats_queries count of queries
+# TYPE usage_stats_queries counter
+usage_stats_queries{feature="Analytics",Version="1.2.1"} 5.0
+`
+		res := &backend.CollectMetricsResult{PrometheusMetrics: []byte(metrics)}
+		stats := res.ToUsageStats("example")
+		require.Equal(t, map[string]interface{}{"stats.plugin.example.queries.feature.analytics.version.1_2_1": 5.0}, stats)
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

This will parse out any metrics from `CollectMetricsResponse` that have a `usage_stats` prefix and convert them to the `map[string]interface{}` that usage stats service expects. This is a result of a suggestion from @ryantxu in #443. 

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #444

**Special notes for your reviewer**:
