### PR TITLE
Azure interfances and httpclient.Options

### DIFF
--- a/backend/azcredentials/credentials.go
+++ b/backend/azcredentials/credentials.go
@@ -1,0 +1,5 @@
+package azcredentials
+
+type AzureCredentials interface {
+	AzureAuthType() string
+}

--- a/backend/httpclient/options.go
+++ b/backend/httpclient/options.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"net/http"
 	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/azcredentials"
 )
 
 // ConfigureClientFunc function signature for configuring http.Client.
@@ -29,6 +31,9 @@ type Options struct {
 	// TLS TLS related options.
 	TLS   *TLSOptions
 	SigV4 *SigV4Config
+
+	// Azure authentication options.
+	Azure *AzureOptions
 
 	// Headers custom headers.
 	Headers map[string]string
@@ -116,4 +121,10 @@ type SigV4Config struct {
 	AssumeRoleARN string
 	ExternalID    string
 	Region        string
+}
+
+// AzureOptions Azure authentication options.
+type AzureOptions struct {
+	Credentials azcredentials.AzureCredentials
+	Scopes      []string
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a top level interface `azcredentials.AzureCredentials` for Azure credentials so it could be accessible across Grafana and from external plugins in context of datasource authentication to Azure services.

`httpclient.Options` have strongly typed configuration section `Azure` which allows configuration of Azure authentication for the datasource http client.

**Which issue(s) this PR fixes**:

Related [#33809](https://github.com/grafana/grafana/issues/33809)

**Special notes for your reviewer**:

Actual implementation of different Azure credential types delegated to a dedicated library [grafana/grafana-azure-sdk-go](https://github.com/grafana/grafana-azure-sdk-go).