### PR TITLE
HTTP Logger: Add Path and Enabled overrides

### DIFF
--- a/experimental/http_logger/http_logger.go
+++ b/experimental/http_logger/http_logger.go
@@ -29,17 +29,26 @@ type HTTPLogger struct {
 	fixture  *fixture.Fixture
 }
 
+type Options struct {
+	Path      string
+	EnabledFn func() bool
+}
+
 // NewHTTPLogger creates a new HTTPLogger.
-func NewHTTPLogger(pluginID string, proxied http.RoundTripper) *HTTPLogger {
-	path := defaultPath(pluginID)
-	s := storage.NewHARStorage(path)
+func NewHTTPLogger(pluginID string, proxied http.RoundTripper, opts ...Options) *HTTPLogger {
+	if len(opts) > 1 {
+		panic("too many Options arguments provided")
+	}
+
+	loggerOpts := getOptions(pluginID, opts...)
+	s := storage.NewHARStorage(loggerOpts.Path)
 	f := fixture.NewFixture(s)
 
 	return &HTTPLogger{
 		pluginID: pluginID,
 		proxied:  proxied,
 		fixture:  f,
-		enabled:  defaultEnabledCheck,
+		enabled:  loggerOpts.EnabledFn,
 	}
 }
 
@@ -108,4 +117,23 @@ func defaultEnabledCheck() bool {
 func getTempFilePath(pluginID string) string {
 	filename := fmt.Sprintf("%s_%d.har", pluginID, time.Now().UnixMilli())
 	return path.Join(os.TempDir(), filename)
+}
+
+func getOptions(pluginID string, opts ...Options) Options {
+	o := Options{EnabledFn: defaultEnabledCheck, Path: defaultPath(pluginID)}
+
+	// if there's not one set of options provided, return the defaults
+	if len(opts) != 1 {
+		return o
+	}
+
+	if opts[0].Path != "" {
+		o.Path = opts[0].Path
+	}
+
+	if opts[0].EnabledFn != nil {
+		o.EnabledFn = opts[0].EnabledFn
+	}
+
+	return o
 }

--- a/experimental/http_logger/http_logger.go
+++ b/experimental/http_logger/http_logger.go
@@ -52,19 +52,6 @@ func NewHTTPLogger(pluginID string, proxied http.RoundTripper, opts ...Options) 
 	}
 }
 
-// WithPath sets the path to store HAR file.
-func (hl *HTTPLogger) WithPath(path string) *HTTPLogger {
-	s := storage.NewHARStorage(path)
-	hl.fixture = fixture.NewFixture(s)
-	return hl
-}
-
-// WithEnabledCheck sets the function used to check if HTTP logging is enabled.
-func (hl *HTTPLogger) WithEnabledCheck(fn func() bool) *HTTPLogger {
-	hl.enabled = fn
-	return hl
-}
-
 // RoundTrip implements the http.RoundTripper interface.
 func (hl *HTTPLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 	if !hl.enabled() {

--- a/experimental/http_logger/http_logger.go
+++ b/experimental/http_logger/http_logger.go
@@ -43,6 +43,19 @@ func NewHTTPLogger(pluginID string, proxied http.RoundTripper) *HTTPLogger {
 	}
 }
 
+// WithPath sets the path to store HAR file.
+func (hl *HTTPLogger) WithPath(path string) *HTTPLogger {
+	s := storage.NewHARStorage(path)
+	hl.fixture = fixture.NewFixture(s)
+	return hl
+}
+
+// WithEnabledCheck sets the function used to check if HTTP logging is enabled.
+func (hl *HTTPLogger) WithEnabledCheck(fn func() bool) *HTTPLogger {
+	hl.enabled = fn
+	return hl
+}
+
 // RoundTrip implements the http.RoundTripper interface.
 func (hl *HTTPLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 	if !hl.enabled() {

--- a/experimental/http_logger/http_logger_test.go
+++ b/experimental/http_logger/http_logger_test.go
@@ -57,10 +57,10 @@ func TestHTTPLogger(t *testing.T) {
 		f, err := os.CreateTemp("", "test_*.har")
 		defer os.Remove(f.Name())
 		require.NoError(t, err)
-		h := httplogger.
-			NewHTTPLogger("example-plugin-id", &fakeRoundTripper{}).
-			WithPath(f.Name()).
-			WithEnabledCheck(func() bool { return true })
+		h := httplogger.NewHTTPLogger("example-plugin-id", &fakeRoundTripper{}, httplogger.Options{
+			Path:      f.Name(),
+			EnabledFn: func() bool { return true },
+		})
 		c := &http.Client{
 			Transport: h,
 			Timeout:   time.Second * 30,

--- a/experimental/http_logger/http_logger_test.go
+++ b/experimental/http_logger/http_logger_test.go
@@ -48,6 +48,39 @@ func TestHTTPLogger(t *testing.T) {
 		_, err = os.Stat(f.Name())
 		require.Equal(t, true, errors.Is(err, os.ErrNotExist))
 	})
+
+	t.Run("should set path and enabled overrides", func(t *testing.T) {
+		// ensure env variables are not set
+		os.Setenv(httplogger.PluginHARLogEnabledEnv, "false")
+		os.Setenv(httplogger.PluginHARLogPathEnv, "")
+
+		f, err := os.CreateTemp("", "test_*.har")
+		defer os.Remove(f.Name())
+		require.NoError(t, err)
+		h := httplogger.
+			NewHTTPLogger("example-plugin-id", &fakeRoundTripper{}).
+			WithPath(f.Name()).
+			WithEnabledCheck(func() bool { return true })
+		c := &http.Client{
+			Transport: h,
+			Timeout:   time.Second * 30,
+		}
+		res, err := c.Get("http://example.com")
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		b, err := ioutil.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "OK", string(b))
+		expected := storage.NewHARStorage("testdata/example.har")
+		actual := storage.NewHARStorage(f.Name())
+		require.Equal(t, 1, len(actual.Entries()))
+		require.Equal(t, expected.Entries()[0].Request, actual.Entries()[0].Request)
+		require.Equal(t, expected.Entries()[0].Response, actual.Entries()[0].Response)
+		har, err := ioutil.ReadFile(f.Name())
+		require.NoError(t, err)
+		require.Greater(t, len(har), 0)
+	})
 }
 
 func setup(enabled bool) (*http.Client, *os.File) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

These overrides will be used to add support for the HTTP logger in core plugins. Relying on environment variables is not possible in that context since all core plugins share the same environment.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
https://github.com/grafana/grafana/pull/46578 depends on this change