### PR TITLE
HTTPLogger: Support read/write to the same file from multiple instances

### DIFF
--- a/experimental/e2e/fixture/fixture.go
+++ b/experimental/e2e/fixture/fixture.go
@@ -30,11 +30,11 @@ func NewFixture(store storage.Storage) *Fixture {
 }
 
 // Add processes the http.Request and http.Response with the Fixture's RequestProcessor and ResponseProcessor and adds them to the Fixure's Storage.
-func (f *Fixture) Add(originalReq *http.Request, originalRes *http.Response) {
+func (f *Fixture) Add(originalReq *http.Request, originalRes *http.Response) error {
 	req := f.processRequest(originalReq)
 	res := f.processResponse(originalRes)
 	defer res.Body.Close()
-	f.store.Add(req, res)
+	return f.store.Add(req, res)
 }
 
 // Delete deletes the entry with the given ID from the Fixture's Storage.

--- a/experimental/e2e/fixture/fixture.go
+++ b/experimental/e2e/fixture/fixture.go
@@ -47,11 +47,6 @@ func (f *Fixture) Entries() []*storage.Entry {
 	return f.store.Entries()
 }
 
-// Save saves the current state of the Fixture's Storage.
-func (f *Fixture) Save() error {
-	return f.store.Save()
-}
-
 // WithRequestProcessor sets the RequestProcessor for the Fixture.
 func (f *Fixture) WithRequestProcessor(processRequest RequestProcessor) {
 	f.processRequest = processRequest

--- a/experimental/e2e/fixture/fixture_test.go
+++ b/experimental/e2e/fixture/fixture_test.go
@@ -72,7 +72,6 @@ func TestFixtureAdd(t *testing.T) {
 		require.Equal(t, 0, len(f.Entries()))
 		err := f.Add(req, res)
 		require.NoError(t, err)
-		require.NoError(t, err)
 		require.Equal(t, 1, len(f.Entries()))
 		require.Equal(t, 201, f.Entries()[0].Response.StatusCode)
 	})

--- a/experimental/e2e/fixture/fixture_test.go
+++ b/experimental/e2e/fixture/fixture_test.go
@@ -20,7 +20,8 @@ func TestFixtureAdd(t *testing.T) {
 		store := newFakeStorage()
 		f := fixture.NewFixture(store)
 		require.Equal(t, 0, len(f.Entries()))
-		f.Add(req, res)
+		err := f.Add(req, res)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(f.Entries()))
 		require.Equal(t, "http://example.com", f.Entries()[0].Request.URL.String())
 		require.Equal(t, 200, f.Entries()[0].Response.StatusCode)
@@ -36,7 +37,8 @@ func TestFixtureAdd(t *testing.T) {
 			return req
 		})
 		require.Equal(t, 0, len(f.Entries()))
-		f.Add(req, res)
+		err := f.Add(req, res)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(f.Entries()))
 		require.Equal(t, "http://example.com/example", f.Entries()[0].Request.URL.String())
 	})
@@ -51,7 +53,8 @@ func TestFixtureAdd(t *testing.T) {
 			return res
 		})
 		require.Equal(t, 0, len(f.Entries()))
-		f.Add(req, res)
+		err := f.Add(req, res)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(f.Entries()))
 		require.Equal(t, 201, f.Entries()[0].Response.StatusCode)
 	})
@@ -67,7 +70,9 @@ func TestFixtureAdd(t *testing.T) {
 			return res
 		})
 		require.Equal(t, 0, len(f.Entries()))
-		f.Add(req, res)
+		err := f.Add(req, res)
+		require.NoError(t, err)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(f.Entries()))
 		require.Equal(t, 201, f.Entries()[0].Response.StatusCode)
 	})
@@ -205,10 +210,10 @@ func newFakeStorage() *fakeStorage {
 	}
 }
 
-func (s *fakeStorage) Add(req *http.Request, res *http.Response) {
+func (s *fakeStorage) Add(req *http.Request, res *http.Response) error {
 	resBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	res.Body = io.NopCloser(bytes.NewBuffer(resBody))
 	resCopy := *res
@@ -217,6 +222,7 @@ func (s *fakeStorage) Add(req *http.Request, res *http.Response) {
 		Request:  req,
 		Response: &resCopy,
 	})
+	return nil
 }
 
 func (s *fakeStorage) Delete(req *http.Request) bool {

--- a/experimental/e2e/proxy.go
+++ b/experimental/e2e/proxy.go
@@ -124,7 +124,11 @@ func (p *Proxy) append(res *http.Response, ctx *goproxy.ProxyCtx) *http.Response
 	if matched := f.Match(res.Request); matched != nil {
 		return matched
 	}
-	f.Add(res.Request, res)
+	err := f.Add(res.Request, res)
+	if err != nil {
+		fmt.Println("Failed to append response", "url:", res.Request.URL.String(), "status:", res.StatusCode, "error:", err)
+		return res
+	}
 	fmt.Println("Append", "url:", res.Request.URL.String(), "status:", res.StatusCode)
 	return res
 }
@@ -138,7 +142,11 @@ func (p *Proxy) overwrite(res *http.Response, ctx *goproxy.ProxyCtx) *http.Respo
 	if f.Delete(res.Request) {
 		fmt.Println("Removed existing match", "url:", res.Request.URL.String(), "status:", res.StatusCode)
 	}
-	f.Add(res.Request, res)
+	err := f.Add(res.Request, res)
+	if err != nil {
+		fmt.Println("Failed to overwrite response", "url:", res.Request.URL.String(), "status:", res.StatusCode, "error:", err)
+		return res
+	}
 	fmt.Println("Overwrite", "url:", res.Request.URL.String(), "status:", res.StatusCode)
 	return res
 }

--- a/experimental/e2e/proxy.go
+++ b/experimental/e2e/proxy.go
@@ -125,10 +125,6 @@ func (p *Proxy) append(res *http.Response, ctx *goproxy.ProxyCtx) *http.Response
 		return matched
 	}
 	f.Add(res.Request, res)
-	err := f.Save()
-	if err != nil {
-		panic(err)
-	}
 	fmt.Println("Append", "url:", res.Request.URL.String(), "status:", res.StatusCode)
 	return res
 }
@@ -143,10 +139,6 @@ func (p *Proxy) overwrite(res *http.Response, ctx *goproxy.ProxyCtx) *http.Respo
 		fmt.Println("Removed existing match", "url:", res.Request.URL.String(), "status:", res.StatusCode)
 	}
 	f.Add(res.Request, res)
-	err := f.Save()
-	if err != nil {
-		panic(err)
-	}
 	fmt.Println("Overwrite", "url:", res.Request.URL.String(), "status:", res.StatusCode)
 	return res
 }

--- a/experimental/e2e/proxy_test.go
+++ b/experimental/e2e/proxy_test.go
@@ -65,7 +65,8 @@ func TestProxy(t *testing.T) {
 				Request:    req,
 			}
 			require.Len(t, proxy.Fixtures[0].Entries(), 0)
-			proxy.Fixtures[0].Add(req, res)
+			err = proxy.Fixtures[0].Add(req, res)
+			require.NoError(t, err)
 			require.Len(t, proxy.Fixtures[0].Entries(), 1)
 			req, err = http.NewRequest(http.MethodPost, srv.URL+"/foo", bytes.NewBuffer([]byte("bar")))
 			require.NoError(t, err)
@@ -127,7 +128,8 @@ func TestProxy(t *testing.T) {
 				Body:       ioutil.NopCloser(bytes.NewBufferString("bar")),
 				Request:    req,
 			}
-			proxy.Fixtures[0].Add(req, res)
+			err = proxy.Fixtures[0].Add(req, res)
+			require.NoError(t, err)
 			resp, err := client.Do(req)
 			require.NoError(t, err)
 			defer resp.Body.Close()
@@ -212,10 +214,10 @@ func newFakeStorage() *fakeStorage {
 	}
 }
 
-func (s *fakeStorage) Add(req *http.Request, res *http.Response) {
+func (s *fakeStorage) Add(req *http.Request, res *http.Response) error {
 	resBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	res.Body = io.NopCloser(bytes.NewBuffer(resBody))
 	resCopy := *res
@@ -224,6 +226,7 @@ func (s *fakeStorage) Add(req *http.Request, res *http.Response) {
 		Request:  req,
 		Response: &resCopy,
 	})
+	return nil
 }
 
 func (s *fakeStorage) Delete(req *http.Request) bool {

--- a/experimental/e2e/storage/har.go
+++ b/experimental/e2e/storage/har.go
@@ -220,12 +220,17 @@ func (s *HAR) Entries() []*Entry {
 // Delete removes the HAR entry matching the given Request.
 func (s *HAR) Delete(req *http.Request) bool {
 	_ = s.Load()
-	if i, entry := s.findEntry(req); entry != nil {
-		s.har.Log.Entries = append(s.har.Log.Entries[:i], s.har.Log.Entries[i+1:]...)
-		err := s.Save()
-		return err == nil
+	i, entry := s.findEntry(req)
+	if entry == nil {
+		return false
 	}
-	return false
+	s.har.Log.Entries = append(s.har.Log.Entries[:i], s.har.Log.Entries[i+1:]...)
+	err := s.Save()
+	if err != nil {
+		fmt.Printf("Failed to delete entry: %s\n", err.Error())
+		return false
+	}
+	return true
 }
 
 // Save writes the HAR to disk.

--- a/experimental/e2e/storage/har_test.go
+++ b/experimental/e2e/storage/har_test.go
@@ -133,9 +133,9 @@ func TestHARStorage(t *testing.T) {
 }
 
 func exampleRequest() (*http.Request, *http.Response) {
-	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
 	res := &http.Response{
-		StatusCode: 404,
+		StatusCode: http.StatusNotFound,
 		Body:       ioutil.NopCloser(strings.NewReader("")),
 	}
 	return req, res

--- a/experimental/e2e/storage/har_test.go
+++ b/experimental/e2e/storage/har_test.go
@@ -2,6 +2,7 @@ package storage_test
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -16,26 +17,46 @@ import (
 func TestHARStorage(t *testing.T) {
 	t.Run("Add", func(t *testing.T) {
 		t.Run("should add a new entry to the storage", func(t *testing.T) {
-			s := storage.NewHARStorage("testdata/example_add.har")
-			s.Init()
-			req, err := http.NewRequest("GET", "http://example.com/", nil)
+			f, err := os.CreateTemp("", "example_*.har")
 			require.NoError(t, err)
-			res := &http.Response{
-				StatusCode: 404,
-				Body:       ioutil.NopCloser(strings.NewReader("")),
-			}
+			s := storage.NewHARStorage(f.Name())
+			req, res := exampleRequest()
 			s.Add(req, res)
 			require.Len(t, s.Entries(), 1)
 			require.Equal(t, req.URL.String(), s.Entries()[0].Request.URL.String())
 			require.Equal(t, res.Status, s.Entries()[0].Response.Status)
+			err = os.Remove(f.Name())
+			require.NoError(t, err)
+		})
+
+		t.Run("should support multiple instances concurrently adding to the same file", func(t *testing.T) {
+			f, err := os.CreateTemp("", "example_*.har")
+			require.NoError(t, err)
+			c := make(chan bool)
+			one := storage.NewHARStorage(f.Name())
+			two := storage.NewHARStorage(f.Name())
+			go func() {
+				req, res := exampleRequest()
+				req.URL.Path = "/one"
+				one.Add(req, res)
+				c <- true
+			}()
+			req, res := exampleRequest()
+			req.URL.Path = "/two"
+			two.Add(req, res)
+			<-c
+			require.Len(t, one.Entries(), 2)
+			require.Len(t, two.Entries(), 2)
+			require.Equal(t, one.Entries()[0].Request.URL.String(), two.Entries()[0].Request.URL.String())
+			require.Equal(t, one.Entries()[1].Request.URL.String(), two.Entries()[1].Request.URL.String())
+			err = os.Remove(f.Name())
+			require.NoError(t, err)
 		})
 	})
 
 	t.Run("Load", func(t *testing.T) {
 		t.Run("should load the HAR from disk", func(t *testing.T) {
 			s := storage.NewHARStorage("testdata/example.har")
-			err := s.Load()
-			require.NoError(t, err)
 			req := s.Entries()[0].Request
 			res := s.Entries()[0].Response
 			require.Equal(t, "https://grafana.com/api/plugins", req.URL.String())
@@ -58,9 +79,13 @@ func TestHARStorage(t *testing.T) {
 
 	t.Run("Delete", func(t *testing.T) {
 		t.Run("should delete second entry", func(t *testing.T) {
-			s := storage.NewHARStorage("testdata/example.har")
-			err := s.Load()
+			source, err := os.Open("testdata/example.har")
 			require.NoError(t, err)
+			f, err := os.CreateTemp("", "example_*.har")
+			require.NoError(t, err)
+			_, err = io.Copy(f, source)
+			require.NoError(t, err)
+			s := storage.NewHARStorage(f.Name())
 			require.Equal(t, 2, len(s.Entries()))
 			ok := s.Delete(s.Entries()[1].Request)
 			require.True(t, ok)
@@ -72,8 +97,6 @@ func TestHARStorage(t *testing.T) {
 	t.Run("Save", func(t *testing.T) {
 		t.Run("should save", func(t *testing.T) {
 			source := storage.NewHARStorage("testdata/example.har")
-			err := source.Load()
-			require.NoError(t, err)
 			f, err := os.CreateTemp("", "example_*.har")
 			require.NoError(t, err)
 			dest := storage.NewHARStorage(f.Name())
@@ -89,7 +112,6 @@ func TestHARStorage(t *testing.T) {
 			for _, entry := range source.Entries() {
 				dest.Add(entry.Request, entry.Response)
 			}
-			err = dest.Save()
 			require.NoError(t, err)
 			sourceData, err := os.ReadFile("testdata/example.har")
 			require.NoError(t, err)
@@ -101,4 +123,13 @@ func TestHARStorage(t *testing.T) {
 			require.NoError(t, err)
 		})
 	})
+}
+
+func exampleRequest() (*http.Request, *http.Response) {
+	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	res := &http.Response{
+		StatusCode: 404,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}
+	return req, res
 }

--- a/experimental/e2e/storage/openapi.go
+++ b/experimental/e2e/storage/openapi.go
@@ -33,7 +33,9 @@ func NewOpenAPIStorage(path string) *OpenAPI {
 }
 
 // Add is a no-op for OpenAPI storage.
-func (o *OpenAPI) Add(*http.Request, *http.Response) {}
+func (o *OpenAPI) Add(*http.Request, *http.Response) error {
+	return nil
+}
 
 // Delete is a no-op for OpenAPI storage.
 func (o *OpenAPI) Delete(*http.Request) bool {

--- a/experimental/e2e/storage/types.go
+++ b/experimental/e2e/storage/types.go
@@ -52,7 +52,7 @@ func (e *Entry) Match(incoming *http.Request) *http.Response {
 
 // Storage is an interface for storing Entry objects.
 type Storage interface {
-	Add(*http.Request, *http.Response)
+	Add(*http.Request, *http.Response) error
 	Delete(*http.Request) bool
 	Load() error
 	Save() error

--- a/experimental/http_logger/http_logger.go
+++ b/experimental/http_logger/http_logger.go
@@ -82,7 +82,6 @@ func (hl *HTTPLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	hl.fixture.Add(req, res)
-	err = hl.fixture.Save()
 
 	return res, err
 }

--- a/experimental/http_logger/http_logger.go
+++ b/experimental/http_logger/http_logger.go
@@ -81,8 +81,7 @@ func (hl *HTTPLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 		return res, err
 	}
 
-	hl.fixture.Add(req, res)
-
+	err = hl.fixture.Add(req, res)
 	return res, err
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Prometheus uses the proxy client for resource calls, and the backend client for queries. Two instances of the HTTP logger will be created in this scenario, and they will both be pointed at the same HAR file. This is an issue with the current implementation because concurrent requests will overwrite logged requests from the other instance since the mutex is stored on the HTTPLogger instance.

This PR moves the read/write mutex to a location that can be shared between instances of the HTTP logger.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
