### PR TITLE
Fix | Add support for default converters based on database type #492

### DIFF
--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -147,7 +147,12 @@ func DefaultConverterFunc(t reflect.Type) func(in interface{}) (interface{}, err
 }
 
 // NewDefaultConverter creates a Converter that assumes that the value is scannable into a String, and placed into the dataframe as a nullable string.
-func NewDefaultConverter(name string, nullable bool, t reflect.Type) Converter {
+func NewDefaultConverter(name string, nullable bool, t reflect.Type, databaseType string) Converter {
+	for _, c := range NullConverters {
+		if c.InputTypeName == databaseType {
+			return c
+		}
+	}
 	slice := reflect.MakeSlice(reflect.SliceOf(t), 0, 0).Interface()
 	if !data.ValidFieldType(slice) {
 		return Converter{

--- a/data/sqlutil/converter_test.go
+++ b/data/sqlutil/converter_test.go
@@ -14,17 +14,19 @@ import (
 
 func TestDefaultConverter(t *testing.T) {
 	type Suite struct {
-		Name     string
-		Type     reflect.Type
-		Nullable bool
-		Expected sqlutil.Converter
+		Name             string
+		Type             reflect.Type
+		DatabaseTypeName string
+		Nullable         bool
+		Expected         sqlutil.Converter
 	}
 
 	suite := []Suite{
 		{
-			Name:     "non-nullable type",
-			Type:     reflect.TypeOf(int64(0)),
-			Nullable: false,
+			Name:             "non-nullable type",
+			Type:             reflect.TypeOf(int64(0)),
+			Nullable:         false,
+			DatabaseTypeName: "",
 			Expected: sqlutil.Converter{
 				InputScanType: reflect.TypeOf(int64(0)),
 				FrameConverter: sqlutil.FrameConverter{
@@ -33,9 +35,10 @@ func TestDefaultConverter(t *testing.T) {
 			},
 		},
 		{
-			Name:     "nullable int64",
-			Type:     reflect.TypeOf(int64(0)),
-			Nullable: true,
+			Name:             "nullable int64",
+			Type:             reflect.TypeOf(int64(0)),
+			Nullable:         true,
+			DatabaseTypeName: "",
 			Expected: sqlutil.Converter{
 				InputScanType: reflect.TypeOf(sql.NullInt64{}),
 				FrameConverter: sqlutil.FrameConverter{
@@ -44,9 +47,10 @@ func TestDefaultConverter(t *testing.T) {
 			},
 		},
 		{
-			Name:     "string",
-			Type:     reflect.TypeOf(""),
-			Nullable: false,
+			Name:             "string",
+			Type:             reflect.TypeOf(""),
+			Nullable:         false,
+			DatabaseTypeName: "",
 			Expected: sqlutil.Converter{
 				InputScanType: reflect.TypeOf(""),
 				FrameConverter: sqlutil.FrameConverter{
@@ -55,9 +59,10 @@ func TestDefaultConverter(t *testing.T) {
 			},
 		},
 		{
-			Name:     "nullable string",
-			Type:     reflect.TypeOf(""),
-			Nullable: true,
+			Name:             "nullable string",
+			Type:             reflect.TypeOf(""),
+			Nullable:         true,
+			DatabaseTypeName: "",
 			Expected: sqlutil.Converter{
 				InputScanType: reflect.TypeOf(sql.NullString{}),
 				FrameConverter: sqlutil.FrameConverter{
@@ -66,9 +71,10 @@ func TestDefaultConverter(t *testing.T) {
 			},
 		},
 		{
-			Name:     "string",
-			Type:     reflect.TypeOf(time.Time{}),
-			Nullable: false,
+			Name:             "string",
+			Type:             reflect.TypeOf(time.Time{}),
+			Nullable:         false,
+			DatabaseTypeName: "",
 			Expected: sqlutil.Converter{
 				InputScanType: reflect.TypeOf(time.Time{}),
 				FrameConverter: sqlutil.FrameConverter{
@@ -77,9 +83,10 @@ func TestDefaultConverter(t *testing.T) {
 			},
 		},
 		{
-			Name:     "nullable time",
-			Type:     reflect.TypeOf(time.Time{}),
-			Nullable: true,
+			Name:             "nullable time",
+			Type:             reflect.TypeOf(time.Time{}),
+			Nullable:         true,
+			DatabaseTypeName: "",
 			Expected: sqlutil.Converter{
 				InputScanType: reflect.TypeOf(sql.NullTime{}),
 				FrameConverter: sqlutil.FrameConverter{
@@ -88,9 +95,22 @@ func TestDefaultConverter(t *testing.T) {
 			},
 		},
 		{
-			Name:     "nullable bool",
-			Type:     reflect.TypeOf(false),
-			Nullable: true,
+			Name:             "nullable bool",
+			Type:             reflect.TypeOf(false),
+			Nullable:         true,
+			DatabaseTypeName: "",
+			Expected: sqlutil.Converter{
+				InputScanType: reflect.TypeOf(sql.NullBool{}),
+				FrameConverter: sqlutil.FrameConverter{
+					FieldType: data.FieldTypeBool.NullableType(),
+				},
+			},
+		},
+		{
+			Name:             "nullable bool with database type",
+			Type:             reflect.TypeOf(false),
+			Nullable:         true,
+			DatabaseTypeName: "BOOLEAN",
 			Expected: sqlutil.Converter{
 				InputScanType: reflect.TypeOf(sql.NullBool{}),
 				FrameConverter: sqlutil.FrameConverter{
@@ -102,7 +122,7 @@ func TestDefaultConverter(t *testing.T) {
 
 	for i, v := range suite {
 		t.Run(fmt.Sprintf("[%d/%d] %s", i+1, len(suite), v.Name), func(t *testing.T) {
-			c := sqlutil.NewDefaultConverter(v.Name, v.Nullable, v.Type)
+			c := sqlutil.NewDefaultConverter(v.Name, v.Nullable, v.Type, v.DatabaseTypeName)
 			assert.Equal(t, c.FrameConverter.FieldType, v.Expected.FrameConverter.FieldType)
 			assert.Equal(t, c.InputScanType.String(), v.Expected.InputScanType.String())
 

--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -96,7 +96,7 @@ func MakeScanRow(colTypes []*sql.ColumnType, colNames []string, converters ...Co
 		}
 
 		if converter == nil {
-			v := NewDefaultConverter(colType.Name(), nullable, scanType)
+			v := NewDefaultConverter(colType.Name(), nullable, scanType, colType.DatabaseTypeName())
 			converter = &v
 			scanType = v.InputScanType
 		}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
This PR enables support for default nullable converters when ScanType is not supported by driver and no converters provided

**Which issue(s) this PR fixes**:
#492

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #492

**Special notes for your reviewer**:
