### PR TITLE
sqlutil - Dynamic frame

### DIFF
--- a/data/converters/converters.go
+++ b/data/converters/converters.go
@@ -292,7 +292,7 @@ var JSONValueToNullableInt64 = data.FieldConverter{
 	},
 }
 
-// Uint8ToNullableString parses a string value from a []uint8.
+// Uint8ArrayToNullableString parses a string value from a []uint8.
 var Uint8ArrayToNullableString = data.FieldConverter{
 	OutputFieldType: data.FieldTypeNullableString,
 	Converter: func(v interface{}) (interface{}, error) {

--- a/data/converters/converters.go
+++ b/data/converters/converters.go
@@ -291,3 +291,21 @@ var JSONValueToNullableInt64 = data.FieldConverter{
 		return ptr, err
 	},
 }
+
+// Uint8ToNullableString parses a string value from a []uint8.
+var Uint8ArrayToNullableString = data.FieldConverter{
+	OutputFieldType: data.FieldTypeNullableString,
+	Converter: func(v interface{}) (interface{}, error) {
+		var ptr *string
+		if v == nil {
+			return ptr, nil
+		}
+		val, ok := v.([]uint8)
+		if !ok {
+			return ptr, toConversionError("string", v)
+		}
+		fV := string(val)
+		ptr = &fV
+		return ptr, nil
+	},
+}

--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -334,7 +334,7 @@ var NullConverters = map[reflect.Type]Converter{
 	reflect.TypeOf(false):       NullBoolConverter,
 }
 
-// IntOrFloatToNullableFloat64 returns an error if the input is not an int,int32.int64 or float.
+// IntOrFloatToNullableFloat64 returns an error if the input is not a variation of int or float.
 var IntOrFloatToNullableFloat64 = data.FieldConverter{
 	OutputFieldType: data.FieldTypeNullableFloat64,
 	Converter: func(v interface{}) (interface{}, error) {
@@ -347,7 +347,8 @@ var IntOrFloatToNullableFloat64 = data.FieldConverter{
 		case float64:
 			return &val, nil
 		case float32:
-			return float64(val), nil
+			fval := float64(val)
+			return fval, nil
 		case int:
 			fval := float64(val)
 			return &fval, nil

--- a/data/sqlutil/dynamic_frame.go
+++ b/data/sqlutil/dynamic_frame.go
@@ -8,6 +8,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data/converters"
 )
 
+const STRING = "string"
+
 func isDynamic(converters []Converter) bool {
 	for _, conv := range converters {
 		if conv.Dynamic {
@@ -59,24 +61,24 @@ func findDataTypes(rows Rows, rowLimit int64, types []*sql.ColumnType) ([]Field,
 				field.name = colType.Name()
 			case string:
 				field.converter = &converters.AnyToNullableString
-				field.kind = "string"
+				field.kind = STRING
 				field.name = colType.Name()
 			case []uint8:
 				field.converter = &converters.Uint8ArrayToNullableString
-				field.kind = "string"
+				field.kind = STRING
 				field.name = colType.Name()
 			case nil:
 				continue
 			default:
 				field.converter = &converters.AnyToNullableString
-				field.kind = "string"
+				field.kind = STRING
 				field.name = colType.Name()
 			}
 
 			fields[colIdx] = field
 		}
 
-		i += 1
+		i++
 	}
 
 	fieldList := []Field{}

--- a/data/sqlutil/dynamic_frame.go
+++ b/data/sqlutil/dynamic_frame.go
@@ -1,0 +1,171 @@
+package sqlutil
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/data/converters"
+)
+
+func isDynamic(converters []Converter) bool {
+	for _, conv := range converters {
+		if conv.Dynamic {
+			return true
+		}
+	}
+	return false
+}
+
+func findDataTypes(rows *sql.Rows, rowLimit int64, types []*sql.ColumnType) ([]Field, [][]interface{}, error) {
+	var i int64
+	fields := make(map[int]Field)
+
+	var returnData [][]interface{}
+
+	for rows.Next() {
+		if i == rowLimit {
+			break
+		}
+
+		row := make([]interface{}, len(types))
+		for i := range row {
+			row[i] = new(interface{})
+		}
+		err := rows.Scan(row[:]...)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		returnData = append(returnData, row)
+
+		if len(fields) == len(types) {
+			// found all data types.  keep looping to load all the return data
+			continue
+		}
+
+		for colIdx, col := range row {
+			val := *col.(*interface{})
+			var field Field
+			colType := types[colIdx]
+			switch val.(type) {
+			case time.Time, *time.Time:
+				field.converter = &TimeToNullableTime
+				field.kind = "time"
+				field.name = colType.Name()
+			case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+				field.converter = &IntOrFloatToNullableFloat64
+				field.kind = "float64"
+				field.name = colType.Name()
+			case string:
+				field.converter = &converters.AnyToNullableString
+				field.kind = "string"
+				field.name = colType.Name()
+			case []uint8:
+				field.converter = &converters.Uint8ArrayToNullableString
+				field.kind = "string"
+				field.name = colType.Name()
+			case nil:
+				continue
+			default:
+				field.converter = &converters.AnyToNullableString
+				field.kind = "string"
+				field.name = colType.Name()
+			}
+
+			fields[colIdx] = field
+		}
+
+		i += 1
+	}
+
+	fieldList := []Field{}
+	for colIdx, col := range types {
+		field, ok := fields[colIdx]
+		field.name = col.Name()
+		if ok {
+			fieldList = append(fieldList, field)
+		}
+		field = Field{
+			converter: &converters.AnyToNullableString,
+			kind:      "string",
+			name:      col.Name(),
+		}
+	}
+
+	return fieldList, returnData, nil
+}
+
+func frameDynamic(rows *sql.Rows, rowLimit int64, types []*sql.ColumnType, converters []Converter) (*data.Frame, error) {
+	// find data type(s) from the data
+	fields, rawRows, err := findDataTypes(rows, rowLimit, types)
+	if err != nil {
+		return nil, err
+	}
+
+	// if a converter is defined by column name, override data type that was found
+	fields = overrideConverter(fields, converters)
+
+	frameFields := make(data.Fields, len(fields))
+	for i, f := range fields {
+		frameFields[i] = data.NewFieldFromFieldType(f.converter.OutputFieldType, 0)
+		frameFields[i].Name = f.name
+	}
+
+	frame := data.NewFrame("", frameFields...)
+
+	for _, row := range rawRows {
+		var rowData []interface{}
+
+		for colIdx, col := range row {
+			field := fields[colIdx]
+
+			val := col
+			ptr, ok := col.(*interface{})
+			if ok {
+				val = *ptr
+			}
+
+			val, err := field.converter.Converter(val)
+			if err != nil {
+				return nil, err
+			}
+
+			rowData = append(rowData, val)
+		}
+		frame.AppendRow(rowData...)
+	}
+
+	return frame, nil
+}
+
+// if a converter is defined by column name, override data type that was found
+func overrideConverter(fields []Field, converters []Converter) []Field {
+	var overrides []Field
+	for _, field := range fields {
+		converter := field.converter
+		for _, c := range converters {
+			if c.InputColumnName == field.name {
+				var conv = data.FieldConverter{
+					OutputFieldType: c.FrameConverter.FieldType,
+					Converter:       c.FrameConverter.ConverterFunc,
+				}
+				converter = &conv
+				break
+			}
+		}
+		override := Field{
+			name:      field.name,
+			converter: converter,
+			kind:      field.kind,
+		}
+		overrides = append(overrides, override)
+	}
+	return overrides
+}
+
+type Field struct {
+	name      string
+	converter *data.FieldConverter
+	kind      string
+}

--- a/data/sqlutil/dynamic_frame.go
+++ b/data/sqlutil/dynamic_frame.go
@@ -34,7 +34,7 @@ func findDataTypes(rows Rows, rowLimit int64, types []*sql.ColumnType) ([]Field,
 		for i := range row {
 			row[i] = new(interface{})
 		}
-		err := rows.Scan(row...)
+		err := rows.Scan(row)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -85,14 +85,14 @@ func findDataTypes(rows Rows, rowLimit int64, types []*sql.ColumnType) ([]Field,
 	for colIdx, col := range types {
 		field, ok := fields[colIdx]
 		field.name = col.Name()
-		if ok {
-			fieldList = append(fieldList, field)
+		if !ok {
+			field = Field{
+				converter: &converters.AnyToNullableString,
+				kind:      "string",
+				name:      col.Name(),
+			}
 		}
-		field = Field{
-			converter: &converters.AnyToNullableString,
-			kind:      "string",
-			name:      col.Name(),
-		}
+		fieldList = append(fieldList, field)
 	}
 
 	return fieldList, returnData, nil
@@ -185,6 +185,6 @@ func (rs Rows) Next() bool {
 	return rs.itr.Next()
 }
 
-func (rs Rows) Scan(dest ...interface{}) error {
-	return rs.itr.Scan(dest)
+func (rs Rows) Scan(dest []interface{}) error {
+	return rs.itr.Scan(dest...)
 }

--- a/data/sqlutil/dynamic_frame.go
+++ b/data/sqlutil/dynamic_frame.go
@@ -17,7 +17,7 @@ func isDynamic(converters []Converter) bool {
 	return false
 }
 
-func findDataTypes(rows *sql.Rows, rowLimit int64, types []*sql.ColumnType) ([]Field, [][]interface{}, error) {
+func findDataTypes(rows Rows, rowLimit int64, types []*sql.ColumnType) ([]Field, [][]interface{}, error) {
 	var i int64
 	fields := make(map[int]Field)
 
@@ -96,7 +96,7 @@ func findDataTypes(rows *sql.Rows, rowLimit int64, types []*sql.ColumnType) ([]F
 	return fieldList, returnData, nil
 }
 
-func frameDynamic(rows *sql.Rows, rowLimit int64, types []*sql.ColumnType, converters []Converter) (*data.Frame, error) {
+func frameDynamic(rows Rows, rowLimit int64, types []*sql.ColumnType, converters []Converter) (*data.Frame, error) {
 	// find data type(s) from the data
 	fields, rawRows, err := findDataTypes(rows, rowLimit, types)
 	if err != nil {
@@ -168,4 +168,21 @@ type Field struct {
 	name      string
 	converter *data.FieldConverter
 	kind      string
+}
+
+type RowIterator interface {
+	Next() bool
+	Scan(dest ...interface{}) error
+}
+
+type Rows struct {
+	itr RowIterator
+}
+
+func (rs Rows) Next() bool {
+	return rs.itr.Next()
+}
+
+func (rs Rows) Scan(dest ...interface{}) error {
+	return rs.itr.Scan(dest)
 }

--- a/data/sqlutil/dynamic_frame.go
+++ b/data/sqlutil/dynamic_frame.go
@@ -34,7 +34,7 @@ func findDataTypes(rows Rows, rowLimit int64, types []*sql.ColumnType) ([]Field,
 		for i := range row {
 			row[i] = new(interface{})
 		}
-		err := rows.Scan(row[:]...)
+		err := rows.Scan(row...)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/data/sqlutil/dynamic_frame_test.go
+++ b/data/sqlutil/dynamic_frame_test.go
@@ -54,15 +54,13 @@ func (rs *MockRows) Next() bool {
 
 func (rs *MockRows) Scan(dest ...interface{}) error {
 	data := rs.data[rs.index]
-	for _, d := range dest {
-		cols := d.([]interface{})
-		for j, v := range cols {
-			val := reflect.ValueOf(v)
-			if val.Kind() != reflect.Ptr {
-				panic("val must be a pointer")
-			}
-			val.Elem().Set(reflect.ValueOf(data[j]))
+	for i, d := range dest {
+		foo := d.(*interface{})
+		val := reflect.ValueOf(foo)
+		if val.Kind() != reflect.Ptr {
+			panic("val must be a pointer")
 		}
+		val.Elem().Set(reflect.ValueOf(data[i]))
 	}
 	return nil
 }

--- a/data/sqlutil/dynamic_frame_test.go
+++ b/data/sqlutil/dynamic_frame_test.go
@@ -1,0 +1,71 @@
+package sqlutil
+
+import (
+	"database/sql"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDynamicFrame(t *testing.T) {
+	kind := &sql.ColumnType{}
+	types := []*sql.ColumnType{}
+	types = append(types, kind)
+	converters := []Converter{}
+	data := [][]interface{}{}
+	mockRow := []interface{}{}
+	val := string("foo")
+	mockRow = append(mockRow, val)
+	mockRow2 := []interface{}{}
+	mockRow2 = append(mockRow2, "bar")
+	data = append(data, mockRow)
+	data = append(data, mockRow2)
+	mock := &MockRows{
+		data:  data,
+		index: -1,
+	}
+	rows := Rows{
+		itr: mock,
+	}
+
+	frame, err := frameDynamic(rows, 100, types, converters)
+	assert.Nil(t, err)
+	assert.NotNil(t, frame)
+
+	assert.Equal(t, 2, frame.Rows())
+
+	actual := frame.Fields[0].At(0).(*string)
+	assert.Equal(t, val, *actual)
+
+	actual = frame.Fields[0].At(1).(*string)
+	assert.Equal(t, "bar", *actual)
+}
+
+type MockRows struct {
+	data  [][]interface{}
+	index int
+}
+
+func (rs *MockRows) Next() bool {
+	rs.index += 1
+	if rs.index >= len(rs.data) {
+		return false
+	}
+	return true
+}
+
+func (rs *MockRows) Scan(dest ...interface{}) error {
+	data := rs.data[rs.index]
+	for _, d := range dest {
+		cols := d.([]interface{})
+		for j, v := range cols {
+			val := reflect.ValueOf(v)
+			if val.Kind() != reflect.Ptr {
+				panic("val must be a pointer")
+			}
+			val.Elem().Set(reflect.ValueOf(data[j]))
+		}
+	}
+	return nil
+}

--- a/data/sqlutil/dynamic_frame_test.go
+++ b/data/sqlutil/dynamic_frame_test.go
@@ -48,11 +48,8 @@ type MockRows struct {
 }
 
 func (rs *MockRows) Next() bool {
-	rs.index += 1
-	if rs.index >= len(rs.data) {
-		return false
-	}
-	return true
+	rs.index++
+	return rs.index < len(rs.data)
 }
 
 func (rs *MockRows) Scan(dest ...interface{}) error {

--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -87,6 +87,12 @@ func MakeScanRow(colTypes []*sql.ColumnType, colNames []string, converters ...Co
 				}
 			}
 
+			if v.InputColumnName == colName {
+				scanType = v.InputScanType
+				converter = &converters[i]
+				break
+			}
+
 			// If there's an applicable converter for this column, scan using the InputScanType.
 			if v.InputTypeName == colType.DatabaseTypeName() {
 				scanType = v.InputScanType

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -26,6 +26,7 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 	}
 
 	if isDynamic(converters) {
+		rows := Rows{itr: rows}
 		return frameDynamic(rows, rowLimit, types, converters)
 	}
 

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -25,6 +25,10 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 		return nil, err
 	}
 
+	if isDynamic(converters) {
+		return frameDynamic(rows, rowLimit, types, converters)
+	}
+
 	names, err := rows.Columns()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Infers data types dynamically by reading through the data when sql drivers don't provide data types. 

Also allows overriding the inferred type with a converter.  For example if you have a "time" field and you want to force the data type to time, but the value is a string, you can override it with a converter that matches the column name.

Needed when using drivers that don't provide data types.


