### PR TITLE
Experimental: Add JSON golden response check

### DIFF
--- a/experimental/golden_response_checker_test.go
+++ b/experimental/golden_response_checker_test.go
@@ -35,10 +35,8 @@ func TestGoldenResponseChecker(t *testing.T) {
 	}
 
 	t.Run("create data frames with no meta", func(t *testing.T) {
-		goldenFile := filepath.Join("testdata", "frame-no-meta.golden.txt")
-		err := CheckGoldenDataResponse(goldenFile, dr, *update)
-
-		require.NoError(t, err)
+		goldenFile := "frame-no-meta.golden"
+		checkGoldenFiles(t, goldenFile, dr)
 	})
 
 	t.Run("create data frames with some non-custom meta", func(t *testing.T) {
@@ -49,10 +47,8 @@ func TestGoldenResponseChecker(t *testing.T) {
 			},
 		}
 
-		goldenFile := filepath.Join("testdata", "frame-non-custom-meta.golden.txt")
-		err := CheckGoldenDataResponse(goldenFile, dr, *update)
-
-		require.NoError(t, err)
+		goldenFile := "frame-non-custom-meta.golden"
+		checkGoldenFiles(t, goldenFile, dr)
 	})
 
 	t.Run("create data frames with some empty custom meta", func(t *testing.T) {
@@ -60,10 +56,8 @@ func TestGoldenResponseChecker(t *testing.T) {
 			Custom: SomeCustomMeta{},
 		}
 
-		goldenFile := filepath.Join("testdata", "frame-empty-custom-meta.golden.txt")
-		err := CheckGoldenDataResponse(goldenFile, dr, true)
-
-		require.NoError(t, err)
+		goldenFile := "frame-empty-custom-meta.golden"
+		checkGoldenFiles(t, goldenFile, dr)
 	})
 
 	t.Run("create data frames with some custom meta", func(t *testing.T) {
@@ -73,10 +67,8 @@ func TestGoldenResponseChecker(t *testing.T) {
 			},
 		}
 
-		goldenFile := filepath.Join("testdata", "frame-custom-meta.golden.txt")
-		err := CheckGoldenDataResponse(goldenFile, dr, true)
-
-		require.NoError(t, err)
+		goldenFile := "frame-custom-meta.golden"
+		checkGoldenFiles(t, goldenFile, dr)
 	})
 
 	t.Run("should render string for JSON fields", func(t *testing.T) {
@@ -91,9 +83,8 @@ func TestGoldenResponseChecker(t *testing.T) {
 					data.NewField("*json.RawMessage", nil, []*json.RawMessage{&r}),
 				),
 			}}
-		goldenFile := filepath.Join("testdata", "frame-json.txt")
-		err = CheckGoldenDataResponse(goldenFile, res, true)
-		require.NoError(t, err)
+		goldenFile := "frame-json"
+		checkGoldenFiles(t, goldenFile, res)
 	})
 }
 
@@ -104,4 +95,13 @@ func TestReadGoldenFile(t *testing.T) {
 		require.NotEmpty(t, dr)
 		require.NoError(t, err)
 	})
+}
+
+func checkGoldenFiles(t *testing.T, name string, dr *backend.DataResponse) {
+	t.Helper()
+	goldenFile := filepath.Join("testdata", name)
+	err := CheckGoldenDataResponse(goldenFile+".txt", dr, *update)
+	require.NoError(t, err)
+
+	CheckGoldenJSONResponse(t, "testdata", name, dr, *update)
 }

--- a/experimental/golden_response_checker_test.go
+++ b/experimental/golden_response_checker_test.go
@@ -16,7 +16,7 @@ type SomeCustomMeta struct {
 	SomeValue string `json:"someValue,omitempty"`
 }
 
-var update = flag.Bool("update", false, "update.golden.data files")
+var update = flag.Bool("update", true, "update.golden.data files")
 
 func TestGoldenResponseChecker(t *testing.T) {
 	dr := &backend.DataResponse{}
@@ -88,6 +88,19 @@ func TestGoldenResponseChecker(t *testing.T) {
 	})
 }
 
+func TestGoldenJSONFrame(t *testing.T) {
+	f := data.NewFrame("Frame One",
+		data.NewField("Single float64", nil, []float64{
+			8.26, 8.7, 14.82, 10.07, 8.52,
+		}).SetConfig(&data.FieldConfig{Unit: "Percent"}),
+	)
+	CheckGoldenJSONFrame(t, "testdata", "single-json-frame.golden", f, *update)
+}
+
+func TestGoldenJSONFramer(t *testing.T) {
+	CheckGoldenJSONFramer(t, "testdata", "single-json-framer.golden", &fakeFramer{}, *update)
+}
+
 func TestReadGoldenFile(t *testing.T) {
 	t.Run("read a large golden file", func(t *testing.T) {
 		goldenFile := filepath.Join("testdata", "large.golden.txt")
@@ -104,4 +117,13 @@ func checkGoldenFiles(t *testing.T, name string, dr *backend.DataResponse) {
 	require.NoError(t, err)
 
 	CheckGoldenJSONResponse(t, "testdata", name, dr, *update)
+}
+
+type fakeFramer struct{}
+
+func (f *fakeFramer) Frames() (data.Frames, error) {
+	return data.Frames{
+		data.NewFrame("Frame One", data.NewField("A", nil, []float64{1, 2, 3})),
+		data.NewFrame("Frame Two", data.NewField("B", nil, []float64{4})),
+	}, nil
 }

--- a/experimental/testdata/frame-custom-meta.golden.jsonc
+++ b/experimental/testdata/frame-custom-meta.golden.jsonc
@@ -1,0 +1,104 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "custom": {
+//          "someValue": "value"
+//      }
+//  }
+//  Name: Frame One
+//  Dimensions: 1 Fields by 5 Rows
+//  +----------------------+
+//  | Name: Single float64 |
+//  | Labels:              |
+//  | Type: []float64      |
+//  +----------------------+
+//  | 8.26                 |
+//  | 8.7                  |
+//  | 14.82                |
+//  | 10.07                |
+//  | 8.52                 |
+//  +----------------------+
+//  
+//  
+//  
+//  Frame[1] 
+//  Name: Frame Two
+//  Dimensions: 1 Fields by 3 Rows
+//  +---------------------+
+//  | Name: single string |
+//  | Labels: a=b         |
+//  | Type: []string      |
+//  +---------------------+
+//  | a                   |
+//  | b                   |
+//  | c                   |
+//  +---------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "frames": [
+    {
+      "schema": {
+        "name": "Frame One",
+        "meta": {
+          "custom": {
+            "someValue": "value"
+          }
+        },
+        "fields": [
+          {
+            "name": "Single float64",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64"
+            },
+            "config": {
+              "unit": "Percent"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            8.26,
+            8.7,
+            14.82,
+            10.07,
+            8.52
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "name": "Frame Two",
+        "fields": [
+          {
+            "name": "single string",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            },
+            "labels": {
+              "a": "b"
+            },
+            "config": {
+              "displayName": "123"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "a",
+            "b",
+            "c"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/experimental/testdata/frame-empty-custom-meta.golden.jsonc
+++ b/experimental/testdata/frame-empty-custom-meta.golden.jsonc
@@ -1,0 +1,100 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "custom": {}
+//  }
+//  Name: Frame One
+//  Dimensions: 1 Fields by 5 Rows
+//  +----------------------+
+//  | Name: Single float64 |
+//  | Labels:              |
+//  | Type: []float64      |
+//  +----------------------+
+//  | 8.26                 |
+//  | 8.7                  |
+//  | 14.82                |
+//  | 10.07                |
+//  | 8.52                 |
+//  +----------------------+
+//  
+//  
+//  
+//  Frame[1] 
+//  Name: Frame Two
+//  Dimensions: 1 Fields by 3 Rows
+//  +---------------------+
+//  | Name: single string |
+//  | Labels: a=b         |
+//  | Type: []string      |
+//  +---------------------+
+//  | a                   |
+//  | b                   |
+//  | c                   |
+//  +---------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "frames": [
+    {
+      "schema": {
+        "name": "Frame One",
+        "meta": {
+          "custom": {}
+        },
+        "fields": [
+          {
+            "name": "Single float64",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64"
+            },
+            "config": {
+              "unit": "Percent"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            8.26,
+            8.7,
+            14.82,
+            10.07,
+            8.52
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "name": "Frame Two",
+        "fields": [
+          {
+            "name": "single string",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            },
+            "labels": {
+              "a": "b"
+            },
+            "config": {
+              "displayName": "123"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "a",
+            "b",
+            "c"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/experimental/testdata/frame-json.jsonc
+++ b/experimental/testdata/frame-json.jsonc
@@ -1,0 +1,57 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] 
+//  Name: JSON frame
+//  Dimensions: 2 Fields by 1 Rows
+//  +-------------------------+--------------------------+
+//  | Name: json.RawMessage   | Name: *json.RawMessage   |
+//  | Labels:                 | Labels:                  |
+//  | Type: []json.RawMessage | Type: []*json.RawMessage |
+//  +-------------------------+--------------------------+
+//  | {"a":1,"b":2}           | {"a":1,"b":2}            |
+//  +-------------------------+--------------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "frames": [
+    {
+      "schema": {
+        "name": "JSON frame",
+        "fields": [
+          {
+            "name": "json.RawMessage",
+            "type": "other",
+            "typeInfo": {
+              "frame": "json.RawMessage"
+            }
+          },
+          {
+            "name": "*json.RawMessage",
+            "type": "other",
+            "typeInfo": {
+              "frame": "json.RawMessage",
+              "nullable": true
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            {
+              "a": 1,
+              "b": 2
+            }
+          ],
+          [
+            {
+              "a": 1,
+              "b": 2
+            }
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/experimental/testdata/frame-no-meta.golden.jsonc
+++ b/experimental/testdata/frame-no-meta.golden.jsonc
@@ -1,0 +1,95 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] 
+//  Name: Frame One
+//  Dimensions: 1 Fields by 5 Rows
+//  +----------------------+
+//  | Name: Single float64 |
+//  | Labels:              |
+//  | Type: []float64      |
+//  +----------------------+
+//  | 8.26                 |
+//  | 8.7                  |
+//  | 14.82                |
+//  | 10.07                |
+//  | 8.52                 |
+//  +----------------------+
+//  
+//  
+//  
+//  Frame[1] 
+//  Name: Frame Two
+//  Dimensions: 1 Fields by 3 Rows
+//  +---------------------+
+//  | Name: single string |
+//  | Labels: a=b         |
+//  | Type: []string      |
+//  +---------------------+
+//  | a                   |
+//  | b                   |
+//  | c                   |
+//  +---------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "frames": [
+    {
+      "schema": {
+        "name": "Frame One",
+        "fields": [
+          {
+            "name": "Single float64",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64"
+            },
+            "config": {
+              "unit": "Percent"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            8.26,
+            8.7,
+            14.82,
+            10.07,
+            8.52
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "name": "Frame Two",
+        "fields": [
+          {
+            "name": "single string",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            },
+            "labels": {
+              "a": "b"
+            },
+            "config": {
+              "displayName": "123"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "a",
+            "b",
+            "c"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/experimental/testdata/frame-non-custom-meta.golden.jsonc
+++ b/experimental/testdata/frame-non-custom-meta.golden.jsonc
@@ -1,0 +1,110 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "notices": [
+//          {
+//              "text": "hello"
+//          }
+//      ],
+//      "executedQueryString": "SELECT * FROM X"
+//  }
+//  Name: Frame One
+//  Dimensions: 1 Fields by 5 Rows
+//  +----------------------+
+//  | Name: Single float64 |
+//  | Labels:              |
+//  | Type: []float64      |
+//  +----------------------+
+//  | 8.26                 |
+//  | 8.7                  |
+//  | 14.82                |
+//  | 10.07                |
+//  | 8.52                 |
+//  +----------------------+
+//  
+//  
+//  
+//  Frame[1] 
+//  Name: Frame Two
+//  Dimensions: 1 Fields by 3 Rows
+//  +---------------------+
+//  | Name: single string |
+//  | Labels: a=b         |
+//  | Type: []string      |
+//  +---------------------+
+//  | a                   |
+//  | b                   |
+//  | c                   |
+//  +---------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "frames": [
+    {
+      "schema": {
+        "name": "Frame One",
+        "meta": {
+          "notices": [
+            {
+              "text": "hello"
+            }
+          ],
+          "executedQueryString": "SELECT * FROM X"
+        },
+        "fields": [
+          {
+            "name": "Single float64",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64"
+            },
+            "config": {
+              "unit": "Percent"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            8.26,
+            8.7,
+            14.82,
+            10.07,
+            8.52
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "name": "Frame Two",
+        "fields": [
+          {
+            "name": "single string",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            },
+            "labels": {
+              "a": "b"
+            },
+            "config": {
+              "displayName": "123"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            "a",
+            "b",
+            "c"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/experimental/testdata/single-json-frame.golden.jsonc
+++ b/experimental/testdata/single-json-frame.golden.jsonc
@@ -1,0 +1,51 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] 
+//  Name: Frame One
+//  Dimensions: 1 Fields by 5 Rows
+//  +----------------------+
+//  | Name: Single float64 |
+//  | Labels:              |
+//  | Type: []float64      |
+//  +----------------------+
+//  | 8.26                 |
+//  | 8.7                  |
+//  | 14.82                |
+//  | 10.07                |
+//  | 8.52                 |
+//  +----------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "frames": [
+    {
+      "schema": {
+        "name": "Frame One",
+        "fields": [
+          {
+            "name": "Single float64",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64"
+            },
+            "config": {
+              "unit": "Percent"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            8.26,
+            8.7,
+            14.82,
+            10.07,
+            8.52
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/experimental/testdata/single-json-framer.golden.jsonc
+++ b/experimental/testdata/single-json-framer.golden.jsonc
@@ -1,0 +1,78 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] 
+//  Name: Frame One
+//  Dimensions: 1 Fields by 3 Rows
+//  +-----------------+
+//  | Name: A         |
+//  | Labels:         |
+//  | Type: []float64 |
+//  +-----------------+
+//  | 1               |
+//  | 2               |
+//  | 3               |
+//  +-----------------+
+//  
+//  
+//  
+//  Frame[1] 
+//  Name: Frame Two
+//  Dimensions: 1 Fields by 1 Rows
+//  +-----------------+
+//  | Name: B         |
+//  | Labels:         |
+//  | Type: []float64 |
+//  +-----------------+
+//  | 4               |
+//  +-----------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "frames": [
+    {
+      "schema": {
+        "name": "Frame One",
+        "fields": [
+          {
+            "name": "A",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1,
+            2,
+            3
+          ]
+        ]
+      }
+    },
+    {
+      "schema": {
+        "name": "Frame Two",
+        "fields": [
+          {
+            "name": "B",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            4
+          ]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

We use something similar in [prometheus parsing tests](https://github.com/grafana/grafana/blob/main/pkg/util/converter/prom_test.go#L56-L78) and this came up when @yesoreyeram and I were debugging something this morning. JSON snapshots would have quickly revealed an issue that was hidden by the current base64 encoded snapshots.

@ryantxu and I were discussing this, and we both agreed that having the table output is also nice as a quick check since it's really easy to read in most instances. The approach I landed on was to use the `.jsonc` (JSON + comments) format so that tables could still be included in the golden files.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
