### PR TITLE
httpclient: adds support for contextual middlewares

### DIFF
--- a/backend/httpclient/contextual_middleware.go
+++ b/backend/httpclient/contextual_middleware.go
@@ -1,0 +1,57 @@
+package httpclient
+
+import (
+	"context"
+	"net/http"
+)
+
+// ContextualMiddlewareName is the middleware name used by ContextualMiddleware.
+const ContextualMiddlewareName = "contextual-middleware"
+
+// ContextualMiddleware is a middleware that allows the outgoing request to be
+// modified with contextual middlewares.
+// Use WithContextualMiddleware to provide contextual middlewares.
+func ContextualMiddleware() Middleware {
+	return NamedMiddlewareFunc(ContextualMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
+		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			ctxMiddlewares := ContextualMiddlewareFromContext(req.Context())
+			if len(ctxMiddlewares) == 0 {
+				return next.RoundTrip(req)
+			}
+
+			return roundTripperFromMiddlewares(opts, ctxMiddlewares, next).RoundTrip(req)
+		})
+	})
+}
+
+type contextualMiddlewareValue struct {
+	middlewares []Middleware
+}
+
+type contextualMiddlewareKey struct{}
+
+// WithContextualMiddleware returns a copy of parent in which the provided
+// middlewares is associated.
+func WithContextualMiddleware(parent context.Context, middlewares ...Middleware) context.Context {
+	if len(middlewares) == 0 {
+		middlewares = []Middleware{}
+	}
+
+	return context.WithValue(parent, contextualMiddlewareKey{}, contextualMiddlewareValue{
+		middlewares: middlewares,
+	})
+}
+
+// ContextualMiddlewareFromContext returns middlewares from context, if any.
+func ContextualMiddlewareFromContext(ctx context.Context) []Middleware {
+	v := ctx.Value(contextualMiddlewareKey{})
+	if v == nil {
+		return []Middleware{}
+	}
+
+	if opts, ok := v.(contextualMiddlewareValue); ok {
+		return opts.middlewares
+	}
+
+	return []Middleware{}
+}

--- a/backend/httpclient/contextual_middleware.go
+++ b/backend/httpclient/contextual_middleware.go
@@ -32,9 +32,15 @@ type contextualMiddlewareKey struct{}
 
 // WithContextualMiddleware returns a copy of parent in which the provided
 // middlewares is associated.
+// If contextual middleware already exists, new middleware will be appended.
 func WithContextualMiddleware(parent context.Context, middlewares ...Middleware) context.Context {
 	if len(middlewares) == 0 {
 		middlewares = []Middleware{}
+	}
+
+	existingMiddlewares := ContextualMiddlewareFromContext(parent)
+	if len(existingMiddlewares) > 0 {
+		middlewares = append(existingMiddlewares, middlewares...)
 	}
 
 	return context.WithValue(parent, contextualMiddlewareKey{}, contextualMiddlewareValue{

--- a/backend/httpclient/contextual_middleware_example_test.go
+++ b/backend/httpclient/contextual_middleware_example_test.go
@@ -1,0 +1,42 @@
+package httpclient_test
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+)
+
+func ExampleWithContextualMiddleware() {
+	provider := httpclient.NewProvider()
+	client, err := provider.New()
+	if err != nil {
+		log.Fatalf("failed to create HTTP client. error: %s", err)
+	}
+
+	parent := context.Background()
+	ctx := httpclient.WithContextualMiddleware(parent,
+		httpclient.MiddlewareFunc(func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+			return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				req.Header.Set("X-Custom-Header", "val")
+
+				return next.RoundTrip(req)
+			})
+		}))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://www.google.com", nil)
+	if err != nil {
+		log.Fatalf("failed to create request. error: %s", err)
+	}
+
+	rsp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("failed to GET. error: %s", err)
+	}
+	if err := rsp.Body.Close(); err != nil {
+		log.Printf("failed to close response body. error: %s", err)
+	}
+
+	log.Printf("Got response: %v", rsp.StatusCode)
+}

--- a/backend/httpclient/contextual_middleware_test.go
+++ b/backend/httpclient/contextual_middleware_test.go
@@ -1,0 +1,83 @@
+package httpclient
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextualMiddleware(t *testing.T) {
+	t.Run("Without contextual middlewares should return next http.RoundTripper", func(t *testing.T) {
+		ctx := &testContext{}
+		finalRoundTripper := ctx.createRoundTripper("final")
+		ctxMiddleware := ContextualMiddleware()
+		rt := ctxMiddleware.CreateMiddleware(Options{}, finalRoundTripper)
+		require.NotNil(t, rt)
+		middlewareName, ok := ctxMiddleware.(MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, ContextualMiddlewareName, middlewareName.MiddlewareName())
+
+		req, err := http.NewRequest(http.MethodGet, "http://", nil)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		if res.Body != nil {
+			require.NoError(t, res.Body.Close())
+		}
+		require.Len(t, ctx.callChain, 1)
+		require.ElementsMatch(t, []string{"final"}, ctx.callChain)
+	})
+
+	t.Run("With contextual middleware should apply additional middlewares to the request", func(t *testing.T) {
+		tCtx := &testContext{}
+		finalRoundTripper := tCtx.createRoundTripper("final")
+		ctxMiddleware := ContextualMiddleware()
+
+		middlewares := []Middleware{
+			tCtx.createMiddleware("mw1"),
+			tCtx.createMiddleware("mw2"),
+			tCtx.createMiddleware("mw3"),
+			ctxMiddleware,
+		}
+		rt := roundTripperFromMiddlewares(Options{}, middlewares, finalRoundTripper)
+		require.NotNil(t, rt)
+		middlewareName, ok := ctxMiddleware.(MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, ContextualMiddlewareName, middlewareName.MiddlewareName())
+
+		ctx := context.Background()
+		contextualMiddlewares := []Middleware{
+			tCtx.createMiddleware("ctxmw1"),
+			tCtx.createMiddleware("ctxmw2"),
+			tCtx.createMiddleware("ctxmw3"),
+		}
+		ctx = WithContextualMiddleware(ctx, contextualMiddlewares...)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://", nil)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		if res.Body != nil {
+			require.NoError(t, res.Body.Close())
+		}
+		require.Len(t, tCtx.callChain, 13)
+		require.ElementsMatch(t, []string{
+			"before mw1",
+			"before mw2",
+			"before mw3",
+			"before ctxmw1",
+			"before ctxmw2",
+			"before ctxmw3",
+			"final",
+			"after ctxmw3",
+			"after ctxmw2",
+			"after ctxmw1",
+			"after mw3",
+			"after mw2",
+			"after mw1",
+		}, tCtx.callChain)
+	})
+}

--- a/backend/httpclient/contextual_middleware_test.go
+++ b/backend/httpclient/contextual_middleware_test.go
@@ -49,12 +49,9 @@ func TestContextualMiddleware(t *testing.T) {
 		require.Equal(t, ContextualMiddlewareName, middlewareName.MiddlewareName())
 
 		ctx := context.Background()
-		contextualMiddlewares := []Middleware{
-			tCtx.createMiddleware("ctxmw1"),
-			tCtx.createMiddleware("ctxmw2"),
-			tCtx.createMiddleware("ctxmw3"),
-		}
-		ctx = WithContextualMiddleware(ctx, contextualMiddlewares...)
+		ctx = WithContextualMiddleware(ctx, tCtx.createMiddleware("ctxmw1"))
+		ctx = WithContextualMiddleware(ctx, tCtx.createMiddleware("ctxmw2"))
+		ctx = WithContextualMiddleware(ctx, tCtx.createMiddleware("ctxmw3"))
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://", nil)
 		require.NoError(t, err)
 		res, err := rt.RoundTrip(req)

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -199,21 +199,30 @@ func DefaultMiddlewares() []Middleware {
 	return []Middleware{
 		BasicAuthenticationMiddleware(),
 		CustomHeadersMiddleware(),
+		ContextualMiddleware(),
 	}
 }
 
 func roundTripperFromMiddlewares(opts Options, middlewares []Middleware, finalRoundTripper http.RoundTripper) http.RoundTripper {
-	for i, j := 0, len(middlewares)-1; i < j; i, j = i+1, j-1 {
-		middlewares[i], middlewares[j] = middlewares[j], middlewares[i]
-	}
-
+	reversed := reverseMiddlewares(middlewares)
 	next := finalRoundTripper
 
-	for _, m := range middlewares {
+	for _, m := range reversed {
 		next = m.CreateMiddleware(opts, next)
 	}
 
 	return next
+}
+
+func reverseMiddlewares(middlewares []Middleware) []Middleware {
+	reversed := make([]Middleware, len(middlewares))
+	copy(reversed, middlewares)
+
+	for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+		reversed[i], reversed[j] = reversed[j], reversed[i]
+	}
+
+	return reversed
 }
 
 type namedMiddleware struct {

--- a/backend/httpclient/provider_test.go
+++ b/backend/httpclient/provider_test.go
@@ -23,9 +23,10 @@ func TestProvider(t *testing.T) {
 			client, err := ctx.provider.New()
 			require.NoError(t, err)
 			require.NotNil(t, client)
-			require.Len(t, ctx.usedMiddlewares, 2)
+			require.Len(t, ctx.usedMiddlewares, 3)
 			require.Equal(t, BasicAuthenticationMiddlewareName, ctx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 			require.Equal(t, CustomHeadersMiddlewareName, ctx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ContextualMiddlewareName, ctx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 		})
 
 		t.Run("Transport should use default middlewares", func(t *testing.T) {
@@ -33,9 +34,10 @@ func TestProvider(t *testing.T) {
 			transport, err := ctx.provider.GetTransport()
 			require.NoError(t, err)
 			require.NotNil(t, transport)
-			require.Len(t, ctx.usedMiddlewares, 2)
+			require.Len(t, ctx.usedMiddlewares, 3)
 			require.Equal(t, BasicAuthenticationMiddlewareName, ctx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 			require.Equal(t, CustomHeadersMiddlewareName, ctx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ContextualMiddlewareName, ctx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 		})
 
 		t.Run("New() with options and no middleware should return expected http client and transport", func(t *testing.T) {
@@ -57,14 +59,12 @@ func TestProvider(t *testing.T) {
 			require.NotNil(t, client)
 			require.Equal(t, time.Second, client.Timeout)
 
-			transport, ok := client.Transport.(*http.Transport)
-			require.True(t, ok)
-			require.NotNil(t, transport)
-			require.Equal(t, 3*time.Second, transport.TLSHandshakeTimeout)
-			require.Equal(t, 4*time.Second, transport.ExpectContinueTimeout)
-			require.Equal(t, 5, transport.MaxIdleConns)
-			require.Equal(t, 7, transport.MaxIdleConnsPerHost)
-			require.Equal(t, 6*time.Second, transport.IdleConnTimeout)
+			require.NotNil(t, ctx.transport)
+			require.Equal(t, 3*time.Second, ctx.transport.TLSHandshakeTimeout)
+			require.Equal(t, 4*time.Second, ctx.transport.ExpectContinueTimeout)
+			require.Equal(t, 5, ctx.transport.MaxIdleConns)
+			require.Equal(t, 7, ctx.transport.MaxIdleConnsPerHost)
+			require.Equal(t, 6*time.Second, ctx.transport.IdleConnTimeout)
 		})
 
 		t.Run("New() with options middleware should return expected http.Client", func(t *testing.T) {
@@ -78,12 +78,13 @@ func TestProvider(t *testing.T) {
 			require.Equal(t, DefaultTimeoutOptions.Timeout, client.Timeout)
 
 			t.Run("Should use configured middlewares and implement MiddlewareName", func(t *testing.T) {
-				require.Len(t, pCtx.usedMiddlewares, 5)
+				require.Len(t, pCtx.usedMiddlewares, 6)
 				require.Equal(t, "mw1", pCtx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 				require.Equal(t, "mw2", pCtx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 				require.Equal(t, "mw3", pCtx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 				require.Equal(t, BasicAuthenticationMiddlewareName, pCtx.usedMiddlewares[3].(MiddlewareName).MiddlewareName())
 				require.Equal(t, CustomHeadersMiddlewareName, pCtx.usedMiddlewares[4].(MiddlewareName).MiddlewareName())
+				require.Equal(t, ContextualMiddlewareName, pCtx.usedMiddlewares[5].(MiddlewareName).MiddlewareName())
 			})
 
 			t.Run("When roundtrip should call expected middlewares", func(t *testing.T) {

--- a/build/common_unix.go
+++ b/build/common_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package build


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for contextual middlewares that allows additional middlewares to be added to chain on a contextual basis, e.g. per user/request specific logic like forwarded OAuth token or cookies as example.

**Which issue(s) this PR fixes**:
Ref https://github.com/grafana/grafana/pull/50344

**Special notes for your reviewer**:
