### PR TITLE
Fix: MakeScanRow not to add converter for empty string column

### DIFF
--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -87,7 +87,7 @@ func MakeScanRow(colTypes []*sql.ColumnType, colNames []string, converters ...Co
 				}
 			}
 
-			if v.InputColumnName == colName {
+			if v.InputColumnName == colName && v.InputColumnName != "" {
 				scanType = v.InputScanType
 				converter = &converters[i]
 				break


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes https://github.com/grafana/support-escalations/issues/2877
