### PR TITLE
Missing dataTopic prop to frame meta

### DIFF
--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -66,9 +66,12 @@ const (
 type VisType string
 
 const (
+	// DataTopicAnnotations is used to specify that the frame should be used as annotation of the actual data frame response.
+	// Example: When DataTopic is set to DataTopicAnnotations, the frame will be used as exemplar data in timeseries panel
 	DataTopicAnnotations DataTopic = "annotations"
 )
 
+// DataTopic is used to identify which topic the frame should be assigned to.
 type DataTopic string
 
 // FrameMetaFromJSON creates a QueryResultMeta from a json string

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -41,7 +41,7 @@ type FrameMeta struct {
 
 	// Optionally identify which topic the frame should be assigned to.
 	// A value specified in the response will override what the request asked for.
-	DataTopic string `json:"dataTopic,omitempty"`
+	DataTopic DataTopic `json:"dataTopic,omitempty"`
 }
 
 // Should be kept in sync with grafana/packages/grafana-data/src/types/data.ts#PreferredVisualisationType
@@ -64,6 +64,12 @@ const (
 
 // VisType is used to indicate how the data should be visualized in explore.
 type VisType string
+
+const (
+	DataTopicAnnotations = "annotations"
+)
+
+type DataTopic string
 
 // FrameMetaFromJSON creates a QueryResultMeta from a json string
 func FrameMetaFromJSON(jsonStr string) (*FrameMeta, error) {

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -38,6 +38,10 @@ type FrameMeta struct {
 	// ExecutedQueryString is the raw query sent to the underlying system. All macros and templating
 	// have been applied.  When metadata contains this value, it will be shown in the query inspector.
 	ExecutedQueryString string `json:"executedQueryString,omitempty"`
+
+	// Optionally identify which topic the frame should be assigned to.
+	// A value specified in the response will override what the request asked for.
+	DataTopic string `json:"dataTopic,omitempty"`
 }
 
 // Should be kept in sync with grafana/packages/grafana-data/src/types/data.ts#PreferredVisualisationType

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -66,7 +66,7 @@ const (
 type VisType string
 
 const (
-	DataTopicAnnotations = "annotations"
+	DataTopicAnnotations DataTopic = "annotations"
 )
 
 type DataTopic string

--- a/data/frame_meta_test.go
+++ b/data/frame_meta_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,6 +34,39 @@ func TestJSONNotice(t *testing.T) {
 			err = json.Unmarshal([]byte(tt.json), &n)
 			require.NoError(t, err)
 			require.Equal(t, tt.notice, n)
+		})
+	}
+}
+
+func TestFrameMetaFromJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		jsonStr string
+		want    *FrameMeta
+		wantErr error
+	}{
+		{
+			name:    "empty json should not throw any error",
+			jsonStr: `{}`,
+			want:    &FrameMeta{},
+		},
+		{
+			name:    "valid dataTopic should parse correctly",
+			jsonStr: `{ "dataTopic" : "annotations" }`,
+			want:    &FrameMeta{DataTopic: DataTopicAnnotations},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FrameMetaFromJSON(tt.jsonStr)
+			if tt.wantErr != nil {
+				require.NotNil(t, err)
+				assert.Equal(t, tt.wantErr, err)
+				return
+			}
+			require.Nil(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Added missing `dataTopic` prop to frame meta. This prop is currently used to distinguish between regular data with exemplars data in response. 

Corresponding frontend: https://github.com/grafana/grafana/blob/d8d1ca8151831a10ee80ea775e126d16b9dd2c62/packages/grafana-data/src/types/data.ts#L54