### PR TITLE
Chore: Add go-swagger annotations to models

### DIFF
--- a/backend/data.go
+++ b/backend/data.go
@@ -98,11 +98,13 @@ func NewQueryDataResponse() *QueryDataResponse {
 // Responses is a map of RefIDs (Unique Query ID) to DataResponses.
 // The QueryData method the QueryDataHandler method will set the RefId
 // property on the DataResponses' frames based on these RefIDs.
+//swagger:model
 type Responses map[string]DataResponse
 
 // DataResponse contains the results from a DataQuery.
 // A map of RefIDs (unique query identifiers) to this type makes up the Responses property of a QueryDataResponse.
 // The Error property is used to allow for partial success responses from the containing QueryDataResponse.
+//swagger:model
 type DataResponse struct {
 	// The data returned from the Query. Each Frame repeats the RefID.
 	Frames data.Frames

--- a/data/field.go
+++ b/data/field.go
@@ -14,6 +14,7 @@ import (
 // See NewField() for supported types.
 //
 // The slice data in the Field is a not exported, so methods on the Field are used to to manipulate its data.
+//swagger:model
 type Field struct {
 	// Name is default identifier of the field. The name does not have to be unique, but the combination
 	// of name and Labels should be unique for proper behavior in all situations.

--- a/data/frame.go
+++ b/data/frame.go
@@ -30,6 +30,7 @@ import (
 //
 // A Frame is a general data container for Grafana. A Frame can be table data
 // or time series data depending on its content and field types.
+//swagger:model
 type Frame struct {
 	// Name is used in some Grafana visualizations.
 	Name string
@@ -67,6 +68,7 @@ func (f *Frame) MarshalJSON() ([]byte, error) {
 
 // Frames is a slice of Frame pointers.
 // It is the main data container within a backend.DataResponse.
+//swagger:model
 type Frames []*Frame
 
 // AppendRow adds a new row to the Frame by appending to each element of vals to

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -9,6 +9,7 @@ import (
 // https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/types/data.ts#L11
 // NOTE -- in javascript this can accept any `[key: string]: any;` however
 // this interface only exposes the values we want to be exposed
+//swagger:model
 type FrameMeta struct {
 	// Type asserts that the frame matches a known type structure
 	Type FrameType `json:"type,omitempty"`

--- a/data/labels.go
+++ b/data/labels.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Labels are used to add metadata to an object.  The JSON will always be sorted keys
+//swagger:model FrameLabels
 type Labels map[string]string
 
 func init() { //nolint:gochecknoinits


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->
**Updated**
After generating the Grafana Swagger specification, we merge it with the stable Alerting one. However, some model names conflict.
The mixin algorithm that go swagger uses, if the model name is reserved, [prints a warning and keeps the model in the primary mixin](https://github.com/go-openapi/analysis/blob/1bb0b3375104313f41a4e30ff915025261b20ed3/mixin.go#L169).
Our [merging script](https://github.com/grafana/grafana/blob/main/pkg/api/docs/merge/merge_specs.go) [compares the models](https://github.com/grafana/grafana/blob/42f69a5e63c1f259a88f4f11d3aefd8f069c0e38/pkg/api/docs/merge/merge_specs.go#L35) and warns the users if they actually differ and overrides that model.
Both solutions are unsatisfactory because we need both models to co-exist and referenced correctly from the respective operations in the the final Swagger specification so that it is correct/complete.

Therefore, we either need to:

1. modify our script to rename the model in case of conflicts or
2. use swagger annotations to indicate that we want to use an alternative name for the conflicting model.

The present fix is required if we follow the 2nd approach. I think that's preferable because in that case and after we have merged this we can get rid of our script and use the go swagger command for merging the specs.

**What this PR does / why we need it**:
- It specifies a model name for [Labels](https://github.com/grafana/grafana-plugin-sdk-go/blob/84169ce75b21305e0b43c06aada5ee90497154aa/data/labels.go#L14) (`FrameLabels`) to differentiate it from [the Prometheus Labels](https://pkg.go.dev/github.com/prometheus/prometheus@v0.36.2/model/labels#Labels)
- It adds go-swagger annotations to the models referenced by the Grafana swagger specification.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
