### PR TITLE
Add support for managed app plugins

### DIFF
--- a/backend/app/doc.go
+++ b/backend/app/doc.go
@@ -1,0 +1,2 @@
+// Package app provides utilities for creating and serving a app plugin over gRPC.
+package app

--- a/backend/app/instance_provider.go
+++ b/backend/app/instance_provider.go
@@ -10,7 +10,7 @@ import (
 // InstanceFactoryFunc factory method for creating app instances.
 type InstanceFactoryFunc func(settings backend.AppInstanceSettings) (instancemgmt.Instance, error)
 
-// NewInstanceManager creates a new data source instance manager,
+// NewInstanceManager creates a new app instance manager,
 //
 // This is a helper method for calling NewInstanceProvider and creating a new instancemgmt.InstanceProvider,
 // and providing that to instancemgmt.New.

--- a/backend/app/instance_provider.go
+++ b/backend/app/instance_provider.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 )
 
-// InstanceFactoryFunc factory method for creating data source instances.
+// InstanceFactoryFunc factory method for creating app instances.
 type InstanceFactoryFunc func(settings backend.AppInstanceSettings) (instancemgmt.Instance, error)
 
 // NewInstanceManager creates a new data source instance manager,

--- a/backend/app/instance_provider.go
+++ b/backend/app/instance_provider.go
@@ -1,4 +1,4 @@
-package datasource
+package app
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 )
 
 // InstanceFactoryFunc factory method for creating data source instances.
-type InstanceFactoryFunc func(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error)
+type InstanceFactoryFunc func(settings backend.AppInstanceSettings) (instancemgmt.Instance, error)
 
 // NewInstanceManager creates a new data source instance manager,
 //
@@ -41,13 +41,8 @@ type instanceProvider struct {
 }
 
 func (ip *instanceProvider) GetKey(pluginContext backend.PluginContext) (interface{}, error) {
-	if pluginContext.DataSourceInstanceSettings == nil && pluginContext.AppInstanceSettings == nil {
-		return nil, fmt.Errorf("data source and app instance settings cannot be nil")
-	}
-
-	// Must be a datasource plugin
-	if pluginContext.DataSourceInstanceSettings != nil {
-		return pluginContext.DataSourceInstanceSettings.ID, nil
+	if pluginContext.AppInstanceSettings == nil {
+		return nil, fmt.Errorf("app instance settings cannot be nil")
 	}
 
 	// Since app plugins have just one instance, use pluginID as instance cache key
@@ -55,11 +50,11 @@ func (ip *instanceProvider) GetKey(pluginContext backend.PluginContext) (interfa
 }
 
 func (ip *instanceProvider) NeedsUpdate(pluginContext backend.PluginContext, cachedInstance instancemgmt.CachedInstance) bool {
-	curSettings := pluginContext.DataSourceInstanceSettings
-	cachedSettings := cachedInstance.PluginContext.DataSourceInstanceSettings
+	curSettings := pluginContext.AppInstanceSettings
+	cachedSettings := cachedInstance.PluginContext.AppInstanceSettings
 	return !curSettings.Updated.Equal(cachedSettings.Updated)
 }
 
 func (ip *instanceProvider) NewInstance(pluginContext backend.PluginContext) (instancemgmt.Instance, error) {
-	return ip.factory(*pluginContext.DataSourceInstanceSettings)
+	return ip.factory(*pluginContext.AppInstanceSettings)
 }

--- a/backend/app/instance_provider.go
+++ b/backend/app/instance_provider.go
@@ -42,6 +42,7 @@ type instanceProvider struct {
 
 func (ip *instanceProvider) GetKey(pluginContext backend.PluginContext) (interface{}, error) {
 	if pluginContext.AppInstanceSettings == nil {
+		// fail fast if there is no app settings
 		return nil, fmt.Errorf("app instance settings cannot be nil")
 	}
 

--- a/backend/app/instance_provider.go
+++ b/backend/app/instance_provider.go
@@ -19,12 +19,12 @@ func NewInstanceManager(fn InstanceFactoryFunc) instancemgmt.InstanceManager {
 	return instancemgmt.New(ip)
 }
 
-// NewInstanceProvider create a new data source instance provuder,
+// NewInstanceProvider create a new app instance provider,
 //
-// The instance provider is responsible for providing cache keys for data source instances,
+// The instance provider is responsible for providing cache keys for application instances,
 // creating new instances when needed and invalidating cached instances when they have been
 // updated in Grafana.
-// Cache key is based on the numerical data source identifier.
+// Cache key is based on the app plugin identifier, and the numeric Grafana organization ID.
 // If fn is nil, NewInstanceProvider panics.
 func NewInstanceProvider(fn InstanceFactoryFunc) instancemgmt.InstanceProvider {
 	if fn == nil {
@@ -45,8 +45,9 @@ func (ip *instanceProvider) GetKey(pluginContext backend.PluginContext) (interfa
 		return nil, fmt.Errorf("app instance settings cannot be nil")
 	}
 
-	// Since app plugins have just one instance, use pluginID as instance cache key
-	return pluginContext.PluginID, nil
+	// The instance key generated for app plugins should include both plugin ID, and the OrgID, since for a single
+	// Grafana instance there might be different orgs using the same plugin.
+	return fmt.Sprintf("%s#%v", pluginContext.PluginID, pluginContext.OrgID), nil
 }
 
 func (ip *instanceProvider) NeedsUpdate(pluginContext backend.PluginContext, cachedInstance instancemgmt.CachedInstance) bool {

--- a/backend/app/instance_provider_test.go
+++ b/backend/app/instance_provider_test.go
@@ -1,0 +1,84 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testAppPluginID = "super-app-plugin"
+	testOrgID       = 42
+)
+
+func TestInstanceProvider(t *testing.T) {
+	type testInstance struct {
+		value string
+	}
+	ip := NewInstanceProvider(func(settings backend.AppInstanceSettings) (instancemgmt.Instance, error) {
+		return testInstance{value: "what an app"}, nil
+	})
+
+	t.Run("When data source instance settings not provided should return error", func(t *testing.T) {
+		_, err := ip.GetKey(backend.PluginContext{})
+		require.Error(t, err)
+	})
+
+	t.Run("When app instance settings provided should return expected key", func(t *testing.T) {
+		key, err := ip.GetKey(backend.PluginContext{
+			PluginID:            testAppPluginID,
+			OrgID:               testOrgID,
+			AppInstanceSettings: &backend.AppInstanceSettings{},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "super-app-plugin#42", key)
+	})
+
+	t.Run("When current app instance settings compared to cached instance haven't been updated should return false", func(t *testing.T) {
+		curSettings := backend.PluginContext{
+			AppInstanceSettings: &backend.AppInstanceSettings{
+				Updated: time.Now(),
+			},
+		}
+		cachedInstance := instancemgmt.CachedInstance{
+			PluginContext: backend.PluginContext{
+				AppInstanceSettings: &backend.AppInstanceSettings{
+					Updated: curSettings.AppInstanceSettings.Updated,
+				},
+			},
+		}
+		needsUpdate := ip.NeedsUpdate(curSettings, cachedInstance)
+		require.False(t, needsUpdate)
+	})
+
+	t.Run("When current app instance settings compared to cached instance have been updated should return true", func(t *testing.T) {
+		curSettings := backend.PluginContext{
+			AppInstanceSettings: &backend.AppInstanceSettings{
+				Updated: time.Now(),
+			},
+		}
+		cachedInstance := instancemgmt.CachedInstance{
+			PluginContext: backend.PluginContext{
+				AppInstanceSettings: &backend.AppInstanceSettings{
+					Updated: curSettings.AppInstanceSettings.Updated.Add(time.Second),
+				},
+			},
+		}
+		needsUpdate := ip.NeedsUpdate(curSettings, cachedInstance)
+		require.True(t, needsUpdate)
+	})
+
+	t.Run("When creating a new instance should return expected instance", func(t *testing.T) {
+		i, err := ip.NewInstance(backend.PluginContext{
+			PluginID:            testAppPluginID,
+			OrgID:               testOrgID,
+			AppInstanceSettings: &backend.AppInstanceSettings{},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, i)
+		require.Equal(t, "what an app", i.(testInstance).value)
+	})
+}

--- a/backend/app/manage.go
+++ b/backend/app/manage.go
@@ -1,0 +1,44 @@
+package app
+
+import (
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/internal/automanagement"
+	"github.com/grafana/grafana-plugin-sdk-go/internal/standalone"
+)
+
+// ManageOpts can modify Manage behaviour.
+type ManageOpts struct {
+	// GRPCSettings settings for gPRC.
+	GRPCSettings backend.GRPCSettings
+}
+
+// Manage starts serving the data source over gPRC with automatic instance management.
+// pluginID should match the one from plugin.json.
+func Manage(pluginID string, instanceFactory InstanceFactoryFunc, opts ManageOpts) error {
+	backend.SetupPluginEnvironment(pluginID) // Enable profiler.
+
+	handler := automanagement.NewManager(NewInstanceManager(instanceFactory))
+
+	serveOpts := backend.ServeOpts{
+		CheckHealthHandler:  handler,
+		CallResourceHandler: handler,
+		QueryDataHandler:    handler,
+		StreamHandler:       handler,
+		GRPCSettings:        opts.GRPCSettings,
+	}
+
+	info, err := standalone.GetInfo(pluginID)
+	if err != nil {
+		return err
+	}
+
+	if info.Standalone {
+		return backend.StandaloneServe(serveOpts, info.Address)
+	} else if info.Address != "" {
+		standalone.RunDummyPluginLocator(info.Address)
+		return nil
+	}
+
+	// The default/normal hashicorp path.
+	return backend.Serve(serveOpts)
+}

--- a/backend/app/manage.go
+++ b/backend/app/manage.go
@@ -12,7 +12,7 @@ type ManageOpts struct {
 	GRPCSettings backend.GRPCSettings
 }
 
-// Manage starts serving the data source over gPRC with automatic instance management.
+// Manage starts serving the app over gPRC with automatic instance management.
 // pluginID should match the one from plugin.json.
 func Manage(pluginID string, instanceFactory InstanceFactoryFunc, opts ManageOpts) error {
 	backend.SetupPluginEnvironment(pluginID) // Enable profiler.

--- a/backend/datasource/instance_provider.go
+++ b/backend/datasource/instance_provider.go
@@ -41,17 +41,11 @@ type instanceProvider struct {
 }
 
 func (ip *instanceProvider) GetKey(pluginContext backend.PluginContext) (interface{}, error) {
-	if pluginContext.DataSourceInstanceSettings == nil && pluginContext.AppInstanceSettings == nil {
-		return nil, fmt.Errorf("data source and app instance settings cannot be nil")
+	if pluginContext.DataSourceInstanceSettings == nil {
+		return nil, fmt.Errorf("data source instance settings cannot be nil")
 	}
 
-	// Must be a datasource plugin
-	if pluginContext.DataSourceInstanceSettings != nil {
-		return pluginContext.DataSourceInstanceSettings.ID, nil
-	}
-
-	// Since app plugins have just one instance, use pluginID as instance cache key
-	return pluginContext.PluginID, nil
+	return pluginContext.DataSourceInstanceSettings.ID, nil
 }
 
 func (ip *instanceProvider) NeedsUpdate(pluginContext backend.PluginContext, cachedInstance instancemgmt.CachedInstance) bool {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
The SDK introduces to plugin development a way to initialize the backend plugin instances with configurations contained in the plugin's `jsonData` or `securedJsonData`. This is achieved by having _managed_ backend plugin instances.

Currently, just datasource plugins are supported for this managed approach.

This PR is based on the datasource work, and does the same for app plugins, which should have just one plugin instance alive at each moment.

**Which issue(s) this PR fixes**:
Fixes #534

**Special notes for your reviewer**:
- ~~Tests haven't been added yet. Would be happy to add if the implemented approach is accepted.~~
