### PR TITLE
Build: Complile both arm+amd when running on darwin

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -4,7 +4,9 @@
 package main
 
 import (
+	"fmt"
 	"github.com/magefile/mage/sh"
+	"runtime"
 )
 
 // Build builds the binaries.
@@ -24,6 +26,13 @@ func Protobuf() error {
 	}
 
 	return sh.RunV("./proto/generate.sh")
+}
+
+// Info writes system info
+func Info() error {
+	fmt.Printf("runtime.GOOS: %s\n", runtime.GOOS)
+	fmt.Printf("runtime.GOARCH: %s\n", runtime.GOARCH)
+	return nil
 }
 
 // Test runs the test suite.

--- a/Magefile.go
+++ b/Magefile.go
@@ -4,9 +4,7 @@
 package main
 
 import (
-	"fmt"
 	"github.com/magefile/mage/sh"
-	"runtime"
 )
 
 // Build builds the binaries.
@@ -26,13 +24,6 @@ func Protobuf() error {
 	}
 
 	return sh.RunV("./proto/generate.sh")
-}
-
-// Info writes system info
-func Info() error {
-	fmt.Printf("runtime.GOOS: %s\n", runtime.GOOS)
-	fmt.Printf("runtime.GOARCH: %s\n", runtime.GOARCH)
-	return nil
 }
 
 // Test runs the test suite.

--- a/build/common.go
+++ b/build/common.go
@@ -174,6 +174,14 @@ func (Build) Debug() error {
 
 // Backend build a production build for the current platform
 func (Build) Backend() error {
+	// The M1 platform detection is kinda flakey, so we will just build both
+	if runtime.GOOS == "darwin" {
+		err := buildBackend(newBuildConfig("darwin", "arm64"))
+		if err != nil {
+			return err
+		}
+		buildBackend(newBuildConfig("darwin", "amd64"))
+	}
 	cfg := newBuildConfig(runtime.GOOS, runtime.GOARCH)
 	return buildBackend(cfg)
 }

--- a/build/common.go
+++ b/build/common.go
@@ -180,7 +180,7 @@ func (Build) Backend() error {
 		if err != nil {
 			return err
 		}
-		buildBackend(newBuildConfig("darwin", "amd64"))
+		return buildBackend(newBuildConfig("darwin", "amd64"))
 	}
 	cfg := newBuildConfig(runtime.GOOS, runtime.GOARCH)
 	return buildBackend(cfg)


### PR DESCRIPTION
Fixes: #538, but kinda hacky

With an M1, it appears that `mage build:backend` will build amd rather than arm -- I don't understand how grafana detects the OS different, but when it goes to run the arm version it is missing so we get stuck.

This PR just builds both amd+arm when the platform is darwin

Trying to be smarter looks like will be much worse!
https://www.yellowduck.be/posts/detecting-apple-silicon-via-go/