### PR TITLE
WIP/EntityAPI: add general index structure

### DIFF
--- a/experimental/entity/entity.go
+++ b/experimental/entity/entity.go
@@ -48,7 +48,7 @@ type EntityLocator struct {
 	// UID may contain / to indicate parent folder's
 	UID string `json:"UID,omitempty"`
 
-	// dasboard, datasource, etc
+	// dashboard, datasource, folder, etc
 	Kind string `json:"kind,omitempty"`
 
 	// prometheus etc

--- a/experimental/entity/fields.go
+++ b/experimental/entity/fields.go
@@ -1,0 +1,18 @@
+package entity
+
+import "github.com/grafana/grafana-plugin-sdk-go/data"
+
+type IndexField struct {
+	// Name is the field name
+	Name string `json:"name,omitempty"`
+
+	// IsUnique is a hint that values for this field will be unique across the corpus
+	IsUnique bool `json:"unique,omitempty"`
+
+	// Type maps to the DataFrame field type
+	// currently JSON will be used for anything multi-valued
+	Type data.FieldType `json:"type"`
+
+	// Config is optional display configuration information for Grafana.  This can include units and description
+	Config *data.FieldConfig `json:"config,omitempty"`
+}

--- a/experimental/entity/kind.go
+++ b/experimental/entity/kind.go
@@ -34,42 +34,66 @@ type KindInfo struct {
 type Kind interface {
 	Info() KindInfo
 
-	// Called before saving any object.  The result will be sanitized and safe to write on disk
-	Normalize(ctx context.Context, payload []byte, details bool) (NormalizeResponse, error)
-
-	// Modify the object payload
-	Migrate(ctx context.Context, payload []byte, targetVersion string) (NormalizeResponse, error)
-
-	// Marshal raw payload into an entity type.  The resulting interface will implement `Envelope`
-	Read(payload []byte) (interface{}, error)
-
-	// Given a well defined object, create the expected payload
-	Write(interface{}) ([]byte, error)
-
-	// Identify referenced items
-	GetReferences(interface{}) []EntityLocator
-
 	// The expected go type from read
 	GoType() interface{}
 
+	// GetIndexFields returns a list of fields that we will be extracted from a payload when indexed
+	// The field names will match values returned from the "prepare" call, and can be added to a DataFrame summary
+	GetIndexFields() []IndexField
+
+	// The result will be sanitized, safe to write to disk and have clearly identified index data
+	Parse(ctx context.Context, payload []byte, details bool) (ParseResponse, error)
+
+	// The result will be sanitized, safe to write to disk and have clearly identified index data
+	GetIndexInfo(ctx context.Context, entity interface{}) (IndexResponse, error)
+
+	// Given a go object (m), create the expected payload
+	ToPayload(ctx context.Context, entity interface{}) (ParseResponse, error)
+
+	// Migrate from one version to another
+	Migrate(ctx context.Context, payload []byte, targetVersion string) ([]byte, error)
+
 	// List possible schema versions
 	GetSchemaVersions() []string
-
-	// For non-raw formats, this can be used to validate externally
-	GetJSONSchema(schemaVersion string) []byte
 }
 
-type NormalizeResponse struct {
+type ParseResponse struct {
 	Valid bool `json:"valid"`
+
+	// When this exists, the payload has been sanitized and is considered safe to save
+	Body []byte `json:"-"`
+
+	// The payload parsed into a golang type
+	Entity interface{} `json:"-"`
 
 	// This includes potential errors and warnings
 	Info []data.Notice `json:"info,omitempty"`
 
-	// Some kinds may have more detailed response objects
+	// Some kinds may have more detailed response objects.  This can include line numbers etc
 	Details interface{} `json:"details,omitempty"`
+}
 
-	// When this exists, the payload has been sanitized and is considered safe to save
-	Result []byte `json:"result,omitempty"`
+type IndexResponse struct {
+	// Key value lookup for values that should be saved in the index.
+	// NOTE: the keys must match field names defined in the kind `IndexStructure` response
+	Fields map[string]interface{} `json:"fields,omitempty"`
+
+	// Return a list of linked references
+	References []EntityReference `json:"references,omitempty"`
+
+	// ??? if we want text for search engine that is not actually saved
+	// NonStoredSearchText string `json:"searchText,omitempty"`
+}
+
+type EntityReference struct {
+	// UID may contain / to indicate parent folder's
+	UID string `json:"UID,omitempty"`
+
+	// dashboard, datasource, folder, etc
+	Kind string `json:"kind,omitempty"`
+
+	// prometheus etc
+	Type string `json:"type,omitempty"`
 }
 
 // The Kind indicator for folders
@@ -80,3 +104,5 @@ var FolderKind = NewGenericKind(KindInfo{
 	ID:          FolderKindID,
 	Description: "Folder",
 })
+
+type SecureValues map[string]string


### PR DESCRIPTION
This modifies the proposed API so that `kind` also has a clear index definition that we can write to a DataFrame and/or a search index