### PR TITLE
Common: Add notice for Database field in DataSourceInstanceSettings

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -72,9 +72,9 @@ type DataSourceInstanceSettings struct {
 	// User is a configured user for a data source instance. This is not a Grafana user, rather an arbitrary string.
 	User string
 
-	// Database is the configured database for a data source instance. Only used by Elasticsearch and Influxdb.
-	//
-	// Deprecated: use JSONData to store information related to database.
+	// Database is the configured database for a data source instance.
+	// Only used by Elasticsearch and Influxdb.
+	// Please use JSONData to store information related to database.
 	Database string
 
 	// BasicAuthEnabled indicates if this data source instance should use basic authentication.

--- a/backend/common.go
+++ b/backend/common.go
@@ -72,7 +72,9 @@ type DataSourceInstanceSettings struct {
 	// User is a configured user for a data source instance. This is not a Grafana user, rather an arbitrary string.
 	User string
 
-	// Database is the configured database for a data source instance. (e.g. the default Database a SQL data source would connect to).
+	// Database is the configured database for a data source instance. Only used by Elasticsearch and Influxdb.
+	//
+	// Deprecated: use JSONData to store information related to database.
 	Database string
 
 	// BasicAuthEnabled indicates if this data source instance should use basic authentication.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a notice for the database field in the DataSourceInstanceSettings to let others know that they shouldn't use it anymore but the JSONData field for database related settings.
