### PR TITLE
Contract Docs: Add README.md symlink to contract.md

### DIFF
--- a/data/contract_docs/README.md
+++ b/data/contract_docs/README.md
@@ -1,0 +1,1 @@
+contract.md


### PR DESCRIPTION
Maybe this will display the main doc without having to do a rename and possibly break some links?

Fixes #

**Special notes for your reviewer**:
Not entirely sure if this will work, but can just revert if doesn't.
