### PR TITLE
Data: Add Numeric Kind constants, link to DP docs

### DIFF
--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -147,10 +147,10 @@ const KindUnknown FrameTypeKind = ""
 
 // KindTimeSeries means the FrameType's Kind is time series. See [Data Plane Time Series Kind].
 //
-// [Data Plane Time Series Kind Formats]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md
+// [Data Plane Time Series Kind]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md
 const KindTimeSeries FrameTypeKind = "timeseries"
 
 // KindNumeric means the FrameType's Kind is numeric. See [Data Plane Numeric Kind].
 //
-// [Data Plane Numeric]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/numeric.md
+// [Data Plane Numeric Kind]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/numeric.md
 const KindNumeric FrameTypeKind = "numeric"

--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -25,11 +25,12 @@ const FrameTypeTimeSeriesWide FrameType = "timeseries-wide"
 // [Developer Data Frame Documentation on Long Format]: https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/#long-format
 const FrameTypeTimeSeriesLong FrameType = "timeseries-long"
 
-// FrameTypeTimeSeriesMany is the same as "Wide" with exactly one numeric value field
+// FrameTypeTimeSeriesMany is the same as "Wide" with exactly one numeric value field.
+//
 // Deprecated: use FrameTypeTimeSeriesMulti instead.
 const FrameTypeTimeSeriesMany FrameType = "timeseries-many"
 
-// FrameTypeTimeSeriesMulti is documented in the [Time Series Multi Format in the Data Plane Contract]
+// FrameTypeTimeSeriesMulti is documented in the [Time Series Multi Format in the Data Plane Contract].
 // This replaces FrameTypeTimeSeriesMany.
 //
 // [Time Series Multi Format in the Data Plane Contract]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md#time-series-multi-format-timeseriesmulti

--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -75,7 +75,12 @@ func (p FrameType) IsKnownType() bool {
 	case
 		FrameTypeTimeSeriesWide,
 		FrameTypeTimeSeriesLong,
-		FrameTypeTimeSeriesMany:
+		FrameTypeTimeSeriesMulti,
+		FrameTypeTimeSeriesMany,
+
+		FrameTypeNumericWide,
+		FrameTypeNumericLong,
+		FrameTypeNumericMulti:
 		return true
 	}
 	return false
@@ -86,18 +91,66 @@ func FrameTypes() []FrameType {
 	return []FrameType{
 		FrameTypeTimeSeriesWide,
 		FrameTypeTimeSeriesLong,
+		FrameTypeTimeSeriesMulti,
 		FrameTypeTimeSeriesMany,
+
+		FrameTypeNumericWide,
+		FrameTypeNumericLong,
+		FrameTypeNumericMulti,
 	}
 }
 
-// IsTimeSeries checks if the type represents a timeseries
+// IsTimeSeries checks if the FrameType is KindTimeSeries
 func (p FrameType) IsTimeSeries() bool {
 	switch p {
 	case
 		FrameTypeTimeSeriesWide,
 		FrameTypeTimeSeriesLong,
+		FrameTypeTimeSeriesMulti,
 		FrameTypeTimeSeriesMany:
 		return true
 	}
 	return false
 }
+
+// IsNumeric checks if the FrameType is KindNumeric.
+func (p FrameType) IsNumeric() bool {
+	switch p {
+	case
+		FrameTypeNumericWide,
+		FrameTypeNumericLong,
+		FrameTypeNumericMulti:
+		return true
+	}
+	return false
+}
+
+// Kind returns the FrameTypeKind from the FrameType.
+func (p FrameType) Kind() FrameTypeKind {
+	switch {
+	case p.IsTimeSeries():
+		return KindTimeSeries
+	case p.IsNumeric():
+		return KindNumeric
+	default:
+		return KindUnknown
+	}
+}
+
+// FrameTypeKind represents the Kind a particular FrameType falls into. See [Kinds and Formats] in
+// the data plane documentation.
+//
+// [Kinds and Formats]: https://github.com/grafana/grafana-plugin-sdk-go/tree/main/data/contract_docs#kinds-and-formats
+type FrameTypeKind string
+
+const KindUnknown FrameTypeKind = ""
+
+// KindTimeSeries means the FrameType's Kind is time series. See [Data Plane Time Series Kind].
+//
+// [Data Plane Time Series Kind Formats]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md
+const KindTimeSeries FrameTypeKind = "timeseries"
+
+// KindNumeric means the FrameType's Kind is numeric. See [Data Plane Numeric Kind].
+//
+// [Data Plane Numeric]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/numeric.md
+const KindNumeric FrameTypeKind = "numeric"

--- a/data/frame_type.go
+++ b/data/frame_type.go
@@ -6,60 +6,68 @@ package data
 // the Frame correspond to a defined FrameType.
 type FrameType string
 
-const (
-	// FrameTypeUnknown indicates that we do not know the field type
-	FrameTypeUnknown FrameType = ""
+// ---
+// Docs Note: Constants need to be on their own line for links to work with the pkgsite docs.
+// ---
 
-	// FrameTypeTimeSeriesWide has at least two fields:
-	// field[0]:
-	//  * type time
-	//  * unique ascending values
-	// field[1..n]:
-	//  * distinct labels may be attached to each field
-	//  * numeric & boolean fields can be drawn as lines on a graph
-	// See https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/#wide-format
-	FrameTypeTimeSeriesWide = "timeseries-wide"
+// FrameTypeUnknown indicates that we do not know the frame type
+const FrameTypeUnknown FrameType = ""
 
-	// FrameTypeTimeSeriesLong uses string fields to define dimensions.  I has at least two fields:
-	// field[0]:
-	//  * type time
-	//  * ascending values
-	//  * duplicate times exist for multiple dimensions
-	// field[1..n]:
-	//  * string fields define series dimensions
-	//  * non-string fields define the series progression
-	// See https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/#long-format
-	FrameTypeTimeSeriesLong = "timeseries-long"
+// FrameTypeTimeSeriesWide uses labels on fields to define dimensions and is documented in [Time Series Wide Format in the Data Plane Contract]. There is additional documentation in the [Developer Data Frame Documentation on the Wide Format].
+//
+// [Time Series Wide Format in the Data Plane Contract]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md#time-series-wide-format-timeserieswide
+// [Developer Data Frame Documentation on the Wide Format]: https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/#wide-format
+const FrameTypeTimeSeriesWide FrameType = "timeseries-wide"
 
-	// FrameTypeTimeSeriesMany is the same as "Wide" with exactly one numeric value field
-	// field[0]:
-	//  * type time
-	//  * ascending values
-	// field[1]:
-	//  * number field
-	//  * labels represent the series dimensions
-	// This structure is typically part of a list of frames with the same structure
-	FrameTypeTimeSeriesMany = "timeseries-many"
+// FrameTypeTimeSeriesLong uses string fields to define dimensions and is documented in [Time Series Long Format in the Data Plane Contract]. There is additional documentation in the [Developer Data Frame Documentation on Long Format].
+//
+// [Time Series Long Format in the Data Plane Contract]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md#time-series-long-format-timeserieslong-sql-like
+// [Developer Data Frame Documentation on Long Format]: https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/#long-format
+const FrameTypeTimeSeriesLong FrameType = "timeseries-long"
 
-	// Soon?
-	// "timeseries-wide-ohlc" -- known fields for open/high/low/close
-	// "histogram" -- BucketMin, BucketMax, values...
-	// "trace" -- ??
-	// "node-graph-nodes"
-	// "node-graph-edges"
+// FrameTypeTimeSeriesMany is the same as "Wide" with exactly one numeric value field
+// Deprecated: use FrameTypeTimeSeriesMulti instead.
+const FrameTypeTimeSeriesMany FrameType = "timeseries-many"
 
-	// FrameTypeDirectoryListing represents the items in a directory
-	// field[0]:
-	//  * name
-	//  * new paths can be constructed from the parent path + separator + name
-	// field[1]:
-	//  * media-type
-	//  * when "directory" it can be nested
-	FrameTypeDirectoryListing = "directory-listing"
+// FrameTypeTimeSeriesMulti is documented in the [Time Series Multi Format in the Data Plane Contract]
+// This replaces FrameTypeTimeSeriesMany.
+//
+// [Time Series Multi Format in the Data Plane Contract]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md#time-series-multi-format-timeseriesmulti
+const FrameTypeTimeSeriesMulti FrameType = "timeseries-multi"
 
-	// FrameTypeTable represents an arbitrary table structure with no constraints
-	FrameTypeTable = "table"
-)
+// FrameTypeDirectoryListing represents the items in a directory
+// field[0]:
+//  * name
+//  * new paths can be constructed from the parent path + separator + name
+// field[1]:
+//  * media-type
+//  * when "directory" it can be nested
+const FrameTypeDirectoryListing FrameType = "directory-listing"
+
+// FrameTypeTable represents an arbitrary table structure with no constraints.
+const FrameTypeTable FrameType = "table"
+
+// FrameTypeNumericWide is documented in the [Numeric Wide Format in the Data Plane Contract].
+//
+// [Numeric Wide Format in the Data Plane Contract]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/numeric.md#numeric-wide-format-numericwide
+const FrameTypeNumericWide FrameType = "numeric-wide"
+
+// FrameTypeNumericMulti is documented in the [Numeric Multi Format in the Data Plane Contract].
+//
+// [Numeric Multi Format in the Data Plane Contract]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/numeric.md#numeric-multi-format-numericmulti
+const FrameTypeNumericMulti FrameType = "numeric-multi"
+
+// FrameTypeNumericLong is documented in the [Numeric Long Format in the Data Plane Contract].
+//
+// [Numeric Long Format in the Data Plane Contract]: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/numeric.md#numeric-long-format-numericlong-sql-table-like
+const FrameTypeNumericLong FrameType = "numeric-long"
+
+// Soon?
+// "timeseries-wide-ohlc" -- known fields for open/high/low/close
+// "histogram" -- BucketMin, BucketMax, values...
+// "trace" -- ??
+// "node-graph-nodes"
+// "node-graph-edges"
 
 // IsKnownType checks if the value is a known structure
 func (p FrameType) IsKnownType() bool {

--- a/experimental/sdata/timeseries/multi_test.go
+++ b/experimental/sdata/timeseries/multi_test.go
@@ -82,7 +82,7 @@ func TestMultiFrameSeriesValidate_WithFrames_InvalidCases(t *testing.T) {
 		{
 			name: "frame with only value field is not valid, missing time field",
 			mfs: &timeseries.MultiFrame{
-				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMany),
+				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMulti),
 					data.NewField("", nil, []float64{})),
 			},
 			errContains: "missing a []time.Time field",
@@ -90,7 +90,7 @@ func TestMultiFrameSeriesValidate_WithFrames_InvalidCases(t *testing.T) {
 		{
 			name: "frame with only a time field and no value is not valid",
 			mfs: &timeseries.MultiFrame{
-				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMany),
+				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMulti),
 					data.NewField("", nil, []time.Time{})),
 			},
 			errContains: "must have at least one value field",
@@ -98,7 +98,7 @@ func TestMultiFrameSeriesValidate_WithFrames_InvalidCases(t *testing.T) {
 		{
 			name: "fields must be of the same length",
 			mfs: &timeseries.MultiFrame{
-				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMany),
+				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMulti),
 					data.NewField("", nil, []float64{1, 2}),
 					data.NewField("", nil, []time.Time{time.UnixMilli(1)})),
 			},
@@ -107,7 +107,7 @@ func TestMultiFrameSeriesValidate_WithFrames_InvalidCases(t *testing.T) {
 		{
 			name: "frame with unsorted time is not valid",
 			mfs: &timeseries.MultiFrame{
-				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMany),
+				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMulti),
 					data.NewField("", nil, []float64{1, 2}),
 					data.NewField("", nil, []time.Time{time.UnixMilli(2), time.UnixMilli(1)})),
 			},
@@ -117,10 +117,10 @@ func TestMultiFrameSeriesValidate_WithFrames_InvalidCases(t *testing.T) {
 		{
 			name: "duplicate metrics as identified by name + labels are invalid",
 			mfs: &timeseries.MultiFrame{
-				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMany),
+				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMulti),
 					data.NewField("os.cpu", data.Labels{"host": "a", "iface": "eth0"}, []float64{1, 2}),
 					data.NewField("", nil, []time.Time{time.UnixMilli(1), time.UnixMilli(2)})),
-				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMany),
+				addFields(emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMulti),
 					data.NewField("os.cpu", data.Labels{"iface": "eth0", "host": "a"}, []float64{1, 2}),
 					data.NewField("", nil, []time.Time{time.UnixMilli(1), time.UnixMilli(2)})),
 			},
@@ -167,7 +167,7 @@ func TestMultiFrameSeriesGetMetricRefs_Empty_Invalid_Edge_Cases(t *testing.T) {
 		s := timeseries.NewMultiFrame()
 
 		// (s.AddMetric) would alter the first frame which would be the "right thing" to do.
-		*s = append(*s, emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMany))
+		*s = append(*s, emptyFrameWithTypeMD(data.FrameTypeTimeSeriesMulti))
 		(*s)[1].Fields = append((*s)[1].Fields,
 			data.NewField("time", nil, []time.Time{}),
 			data.NewField("cpu", nil, []float64{}),

--- a/experimental/sdata/timeseries/series.go
+++ b/experimental/sdata/timeseries/series.go
@@ -44,7 +44,7 @@ func CollectionReaderFromFrames(frames []*data.Frame) (CollectionReader, error) 
 	var tcr CollectionReader
 
 	switch {
-	case mt == data.FrameTypeTimeSeriesMany: // aka multi
+	case mt == data.FrameTypeTimeSeriesMulti:
 		mfs := MultiFrame(frames)
 		tcr = &mfs
 	case mt == data.FrameTypeTimeSeriesLong:


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fixes FrameTypeXYZ contstant to be of type FrameType  instead of an untyped string.
- Deprecates TimeSeriesMany in favor of TimeSeriesMulti
- Adds Numeric FrameTypes, And IsNumeric()
- Add FrameTypeKind
- Links FrameTypes and FrameKinds to Dataplane documentation

**Special notes for your reviewer**:
Puts things in their own constant lines so the link documentation works with `pkgsite` (go package documentation).

Didn't do heatmap yet, that could be another PR.