### PR TITLE
Ignore `mage_output_file.go` in `mage watch` config

### DIFF
--- a/build/tmpl/bra.toml
+++ b/build/tmpl/bra.toml
@@ -8,12 +8,14 @@ init_cmds = [
 ]
 watch_all = true
 follow_symlinks = false
+ignore = [".git", "node_modules", "dist"]
+ignore_files = ["mage_output_file.go"]
 watch_dirs = [
   "pkg",
   "src",
 ]
 watch_exts = [".go", ".json"]
-build_delay = 1500
+build_delay = 2000
 cmds = [
   ["mage", "-v", "build:backend"],
   ["mage", "-v" , "reloadPlugin"]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

@yesoreyeram reported that the generation of `mage_output_file.go` was causing an infinite loop:
```
[Bra] 11-18 12:58:55 [DEBUG] Running: mage [-v reloadPlugin]
[Bra] 11-18 12:58:55 [ INFO] "$WORKDIR/mage_output_file.go": CREATE
[Bra] 11-18 12:58:55 [DEBUG] Running: mage [-v build:backend]
```

my best guess is that the plugin build is taking longer than `build_delay` for @yesoreyeram's plugin, and in my case it's completing and removing `mage_output_file.go` before the `build_delay` expires.

adding `mage_output_file.go` to the `ignore_files` list seems to fix this issue

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
