### PR TITLE
Dataplane: Spec - Update NoData to allow for no frames

### DIFF
--- a/data/contract_docs/contract.md
+++ b/data/contract_docs/contract.md
@@ -59,7 +59,7 @@ Although there is remainder data, there are still cases where the reader should 
 
 There are two named cases for when a response is lacking data and also doesn't have an error.
 
- **_"No Data"_** is for when we retrieve a response from a datasource but the response has no data items. The encoding for the form of a type is a single frame, with the data type declaration, and a zero length of fields (null or []). This is for the case when the entire set has no items.
+**_"No Data"_** is for when we retrieve a response from a datasource but the response has no data items. The encoding for the form of a type is a single frame, with the data type declaration, and a zero length of fields (null or []). This is for the case when the entire set has no items. No Data may also be a response with no frames (and no error). However, in this case the Type and other metadata can not be returned -- so the single frame form is usually preferable.
 
 We retrieve one or more data items from a datasource but an item has no values, that item is said to be an "**_Empty value_**". In this case, the required dataframe fields should still be present (but the fields themselves each have no values).
 


### PR DESCRIPTION
Stating the no frames (e.g. `"A": Frames: []`) is valid for "NoData", but the single frame form is preferable in most cases.

Adding this because I think it is likely what a fair amount of datasources already do, and if there is no metadata to add then nothing is added by adding the frame.

But open to arguments against since this adds more variation for readers.
 

 