### PR TITLE
Testing: Add more error logging to golden checker

### DIFF
--- a/experimental/golden_response_checker.go
+++ b/experimental/golden_response_checker.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -160,7 +159,7 @@ func writeGoldenFile(path string, dr *backend.DataResponse) error {
 	}
 	str += "\n"
 
-	return ioutil.WriteFile(path, []byte(str), 0600)
+	return os.WriteFile(path, []byte(str), 0600)
 }
 
 const machineStr = "🌟 This was machine generated.  Do not edit. 🌟\n"
@@ -220,13 +219,16 @@ func CheckGoldenJSONResponse(t *testing.T, dir string, name string, dr *backend.
 }
 
 func readGoldenJSONFile(fpath string) (string, error) {
-	raw, err := ioutil.ReadFile(fpath)
+	raw, err := os.ReadFile(fpath)
 	if err != nil {
 		return "", err
 	}
+	if len(raw) < 3 {
+		return "", fmt.Errorf("empty file found: %s", fpath)
+	}
 	chunks := strings.Split(string(raw), "//  "+machineStr)
 	if len(chunks) < 3 {
-		return "", fmt.Errorf("no golden data found in: %s", fpath)
+		return "", fmt.Errorf("no golden data found in: %s (%d bytes)", fpath, len(raw))
 	}
 	return chunks[2], nil
 }
@@ -239,5 +241,5 @@ func writeGoldenJSONFile(fpath string, dr *backend.DataResponse) error {
 		return err
 	}
 	str += string(raw)
-	return ioutil.WriteFile(fpath, []byte(str), 0600)
+	return os.WriteFile(fpath, []byte(str), 0600)
 }

--- a/experimental/golden_response_checker.go
+++ b/experimental/golden_response_checker.go
@@ -2,7 +2,9 @@ package experimental
 
 import (
 	"bufio"
+	"crypto/sha1"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -223,12 +225,13 @@ func readGoldenJSONFile(fpath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if len(raw) < 3 {
+	if len(raw) == 0 {
 		return "", fmt.Errorf("empty file found: %s", fpath)
 	}
 	chunks := strings.Split(string(raw), "//  "+machineStr)
 	if len(chunks) < 3 {
-		return "", fmt.Errorf("no golden data found in: %s (%d bytes)", fpath, len(raw))
+		hash := sha1.Sum(raw)
+		return "", fmt.Errorf("no golden data found in: %s (%d bytes, sha1: %s)", fpath, len(raw), hex.EncodeToString(hash[:]))
 	}
 	return chunks[2], nil
 }

--- a/experimental/golden_response_checker.go
+++ b/experimental/golden_response_checker.go
@@ -233,6 +233,8 @@ func readGoldenJSONFile(fpath string) (string, error) {
 	}
 	chunks := strings.Split(string(raw), "//  "+machineStr)
 	if len(chunks) < 3 {
+		// ignoring the G401 so that the checksum matches git hash
+		// nolint:gosec
 		hash := sha1.Sum(raw)
 		return "", fmt.Errorf("no golden data found in: %s (%d bytes, sha1: %s)", fpath, len(raw), hex.EncodeToString(hash[:]))
 	}

--- a/experimental/golden_response_checker.go
+++ b/experimental/golden_response_checker.go
@@ -208,6 +208,9 @@ func CheckGoldenJSONResponse(t *testing.T, dir string, name string, dr *backend.
 
 	expected, err := readGoldenJSONFile(fpath)
 	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
 
 	actual, err := json.Marshal(dr)
 	assert.NoError(t, err)

--- a/experimental/golden_response_checker.go
+++ b/experimental/golden_response_checker.go
@@ -2,6 +2,8 @@ package experimental
 
 import (
 	"bufio"
+	// ignoring the G505 so that the checksum matches git hash
+	// nolint:gosec
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/hex"

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -3,7 +3,6 @@ package standalone
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -62,7 +61,7 @@ func GetInfo(id string) (Args, error) {
 	}
 
 	// Check the local file for address
-	addrBytes, err := ioutil.ReadFile(filePath)
+	addrBytes, err := os.ReadFile(filePath)
 	if address == "" {
 		if err == nil && len(addrBytes) > 0 {
 			address = string(addrBytes)
@@ -75,7 +74,7 @@ func GetInfo(id string) (Args, error) {
 		if info.Address == "" {
 			return info, fmt.Errorf("standalone address must be specified")
 		}
-		_ = ioutil.WriteFile(filePath, []byte(info.Address), 0600)
+		_ = os.WriteFile(filePath, []byte(info.Address), 0600)
 		// sadly vs-code can not listen to shutdown events
 		// https://github.com/golang/vscode-go/issues/120
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -3,13 +3,13 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 )
 
 func GetStringValueFromJSON(fpath string, key string) (string, error) {
-	byteValue, err := ioutil.ReadFile(fpath)
+	byteValue, err := os.ReadFile(fpath)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
We have some flakey tests that use the golden file checker:
https://github.com/grafana/grafana/issues/59442

It is unclear how this is happening -- this PR adds the size info to the response so we can see if it is corrupted or something 