### PR TITLE
Adding `With` in logger to keep logging key/value pairs

### DIFF
--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -22,6 +22,7 @@ type Logger interface {
 	Info(msg string, args ...interface{})
 	Warn(msg string, args ...interface{})
 	Error(msg string, args ...interface{})
+	With(args ...interface{}) Logger
 	Level() Level
 }
 
@@ -80,6 +81,13 @@ func (l *hclogWrapper) Level() Level {
 		return Error
 	}
 	return NoLevel
+}
+
+// With creates a sub-logger that will always have the given key/value pairs.
+func (l *hclogWrapper) With(args ...interface{}) Logger {
+	return &hclogWrapper{
+		logger: l.logger.With(args...),
+	}
 }
 
 // DefaultLogger is the default logger.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
Currently, the `log` package contains a very simple logger.
A common pattern in loggers is to re-use fields between logging statements, by creating "sub-loggers" that retain and always include wanted key/value pairs.

A way to achieve this would be to create a new function, called With, with the following signature
```go
func (r *hclogWrapper) With(args ...interface{}) Logger
```

and use `github.com/hashicorp/go-hclog` `Logger.With` to build and return this new sub-logger.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #577 