### PR TITLE
Add Query type to sqlutil

### DIFF
--- a/data/sqlutil/query.go
+++ b/data/sqlutil/query.go
@@ -1,0 +1,96 @@
+package sqlutil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+var ErrorJSON = errors.New("error unmarshaling query JSON to the Query Model")
+
+// FormatQueryOption defines how the user has chosen to represent the data
+type FormatQueryOption uint32
+
+const (
+	// FormatOptionTimeSeries formats the query results as a timeseries using "WideToLong"
+	FormatOptionTimeSeries FormatQueryOption = iota
+	// FormatOptionTable formats the query results as a table using "LongToWide"
+	FormatOptionTable
+	// FormatOptionLogs sets the preferred visualization to logs
+	FormatOptionLogs
+)
+
+// Query is the model that represents the query that users submit from the panel/queryeditor.
+// For the sake of backwards compatibility, when making changes to this type, ensure that changes are
+// only additive.
+type Query struct {
+	RawSQL         string            `json:"rawSql"`
+	Format         FormatQueryOption `json:"format"`
+	ConnectionArgs json.RawMessage   `json:"connectionArgs"`
+
+	RefID         string            `json:"-"`
+	Interval      time.Duration     `json:"-"`
+	TimeRange     backend.TimeRange `json:"-"`
+	MaxDataPoints int64             `json:"-"`
+	FillMissing   *data.FillMissing `json:"fillMode,omitempty"`
+
+	// Macros
+	Schema string `json:"schema,omitempty"`
+	Table  string `json:"table,omitempty"`
+	Column string `json:"column,omitempty"`
+}
+
+// WithSQL copies the Query, but with a different RawSQL value.
+// This is mostly useful in the Interpolate function, where the RawSQL value is modified in a loop
+func (q *Query) WithSQL(query string) *Query {
+	return &Query{
+		RawSQL:         query,
+		Format:         q.Format,
+		ConnectionArgs: q.ConnectionArgs,
+		RefID:          q.RefID,
+		Interval:       q.Interval,
+		TimeRange:      q.TimeRange,
+		MaxDataPoints:  q.MaxDataPoints,
+		FillMissing:    q.FillMissing,
+		Schema:         q.Schema,
+		Table:          q.Table,
+		Column:         q.Column,
+	}
+}
+
+// GetQuery returns a Query object given a backend.DataQuery using json.Unmarshal
+func GetQuery(query backend.DataQuery) (*Query, error) {
+	model := &Query{}
+
+	if err := json.Unmarshal(query.JSON, &model); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrorJSON, err)
+	}
+
+	// Copy directly from the well typed query
+	return &Query{
+		RawSQL:         model.RawSQL,
+		Format:         model.Format,
+		ConnectionArgs: model.ConnectionArgs,
+		RefID:          query.RefID,
+		Interval:       query.Interval,
+		TimeRange:      query.TimeRange,
+		MaxDataPoints:  query.MaxDataPoints,
+		FillMissing:    model.FillMissing,
+		Schema:         model.Schema,
+		Table:          model.Table,
+		Column:         model.Column,
+	}, nil
+}
+
+// ErrorFrameFromQuery returns a error frames with empty data and meta fields
+func ErrorFrameFromQuery(query *Query) data.Frames {
+	frame := data.NewFrame(query.RefID)
+	frame.Meta = &data.FrameMeta{
+		ExecutedQueryString: query.RawSQL,
+	}
+	return data.Frames{frame}
+}

--- a/data/sqlutil/query_test.go
+++ b/data/sqlutil/query_test.go
@@ -1,0 +1,47 @@
+package sqlutil_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuery(t *testing.T) {
+	t.Run("GetQuery", func(t *testing.T) {
+		timeRange := backend.TimeRange{From: time.Now().Add(-time.Hour), To: time.Now()}
+		dataQuery := backend.DataQuery{
+			RefID:         "foo",
+			MaxDataPoints: 10,
+			Interval:      time.Second,
+			TimeRange:     timeRange,
+			JSON: json.RawMessage(`{
+			"rawSql":"abc",
+			"format":1,
+			"connectionArgs":"options",
+			"fillMode":{"mode":1},
+			"schema":"x",
+			"table":"y",
+			"column":"z"
+		}`),
+		}
+
+		parsedQuery, err := sqlutil.GetQuery(dataQuery)
+		assert.NoError(t, err)
+		assert.Equal(t, parsedQuery.RawSQL, "abc")
+		assert.Equal(t, parsedQuery.Format, sqlutil.FormatOptionTable)
+		assert.Equal(t, parsedQuery.ConnectionArgs, json.RawMessage(`"options"`))
+		assert.Equal(t, parsedQuery.RefID, "foo")
+		assert.Equal(t, parsedQuery.Interval, time.Second)
+		assert.Equal(t, parsedQuery.TimeRange, timeRange)
+		assert.Equal(t, parsedQuery.MaxDataPoints, int64(10))
+		assert.Equal(t, parsedQuery.FillMissing.Mode, data.FillModeNull)
+		assert.Equal(t, parsedQuery.Schema, "x")
+		assert.Equal(t, parsedQuery.Table, "y")
+		assert.Equal(t, parsedQuery.Column, "z")
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
Copies the Query utilities from https://github.com/grafana/sqlds/blob/e3b8b30e5c64464b2940297c8a231ccba2c7596a/query.go into sqlutil. This is part of an [epic](https://github.com/grafana/cloud-data-sources/issues/94) to separate out the utility functions from the actual datasource object created in sqlds for datasources that want to reuse the parsing and macros code without using the actual sqlds datasource.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #582 

**Special notes for your reviewer**:
