### PR TITLE
Add RunQuery helper to sqlutil

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,15 +9,6 @@ platform:
   os: linux
   arch: amd64
 
-services:
-  - image: mysql:8.0
-    name: "mysql"
-    environment:
-      MYSQL_USER: mysql
-      MYSQL_PASSWORD: mysql
-      MYSQL_DATABASE: mysql
-      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-
 trigger:
   branch: main
   event:
@@ -38,14 +29,6 @@ steps:
   image: grafana/grafana-plugin-ci:1.6.1-alpine
   commands:
   - mage -v testRace
-
-- name: integration_tests
-  image: grafana/grafana-plugin-ci:1.6.1-alpine
-  environment:
-    INTEGRATION_TESTS: "true"
-    MYSQL_URL: "mysql:mysql@tcp(mysql:3306)/mysql"
-  commands:
-    - mage -v test
 ---
 kind: pipeline
 type: docker
@@ -54,15 +37,6 @@ name: pr
 platform:
   os: linux
   arch: amd64
-
-services:
-  - image: mysql:8.0
-    name: "mysql"
-    environment:
-      MYSQL_USER: mysql
-      MYSQL_PASSWORD: mysql
-      MYSQL_DATABASE: mysql
-      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
 
 trigger:
   event:
@@ -83,14 +57,6 @@ steps:
   image: grafana/grafana-plugin-ci:1.6.1-alpine
   commands:
   - mage -v testRace
-
-- name: integration_tests
-  image: grafana/grafana-plugin-ci:1.6.1-alpine
-  environment:
-    INTEGRATION_TESTS: "true"
-    MYSQL_URL: "mysql:mysql@tcp(mysql:3306)/mysql"
-  commands:
-    - mage -v test
 
 ---
 kind: signature

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,6 +9,15 @@ platform:
   os: linux
   arch: amd64
 
+services:
+  - image: mysql:8.0
+    name: "mysql"
+    environment:
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: mysql
+      MYSQL_DATABASE: mysql
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+
 trigger:
   branch: main
   event:
@@ -29,6 +38,14 @@ steps:
   image: grafana/grafana-plugin-ci:1.6.1-alpine
   commands:
   - mage -v testRace
+
+- name: integration_tests
+  image: grafana/grafana-plugin-ci:1.6.1-alpine
+  environment:
+    INTEGRATION_TESTS: "true"
+    MYSQL_URL: "mysql:mysql@tcp(mysql:3306)/mysql"
+  commands:
+    - mage -v test
 ---
 kind: pipeline
 type: docker
@@ -37,6 +54,15 @@ name: pr
 platform:
   os: linux
   arch: amd64
+
+services:
+  - image: mysql:8.0
+    name: "mysql"
+    environment:
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: mysql
+      MYSQL_DATABASE: mysql
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
 
 trigger:
   event:
@@ -57,6 +83,14 @@ steps:
   image: grafana/grafana-plugin-ci:1.6.1-alpine
   commands:
   - mage -v testRace
+
+- name: integration_tests
+  image: grafana/grafana-plugin-ci:1.6.1-alpine
+  environment:
+    INTEGRATION_TESTS: "true"
+    MYSQL_URL: "mysql:mysql@tcp(mysql:3306)/mysql"
+  commands:
+    - mage -v test
 
 ---
 kind: signature

--- a/data/sqlutil/query.go
+++ b/data/sqlutil/query.go
@@ -2,15 +2,12 @@ package sqlutil
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
-
-var ErrorJSON = errors.New("error unmarshaling query JSON to the Query Model")
 
 // FormatQueryOption defines how the user has chosen to represent the data
 type FormatQueryOption uint32

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -1,11 +1,29 @@
 package sqlutil
 
 import (
+	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
+
+var (
+	// ErrorJSON is returned when the query couldn't be unmarshaled
+	ErrorJSON = errors.New("error unmarshaling query JSON to the Query Model")
+	// ErrorQuery is returned when the query could not complete / execute
+	ErrorQuery = errors.New("error querying the database")
+	// ErrorNoResults is returned if there were no results returned
+	ErrorNoResults = errors.New("no results returned from query")
+)
+
+// Connection represents a SQL connection and is satisfied by the *sql.DB type
+// For now, we only add the functions that we need/actively use.
+type Connection interface {
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+}
 
 // FrameFromRows returns a new Frame populated with the data from rows. The field types
 // will be nullable ([]*T) if the SQL column is nullable or if the nullable property is unknown.
@@ -69,4 +87,86 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 	}
 
 	return frame, nil
+}
+
+// QueryDB sends the query to the connection and converts the rows to a dataframe.
+func QueryDB(ctx context.Context, db Connection, converters []Converter, fillMode *data.FillMissing, query *Query, args ...interface{}) (data.Frames, error) {
+	// Query the rows from the database
+	rows, err := db.QueryContext(ctx, query.RawSQL, args...)
+	if err != nil {
+		errType := ErrorQuery
+		if errors.Is(err, context.Canceled) {
+			errType = context.Canceled
+		}
+
+		return ErrorFrameFromQuery(query), fmt.Errorf("%w: %s", errType, err.Error())
+	}
+
+	// Check for an error response
+	if err := rows.Err(); err != nil {
+		if err == sql.ErrNoRows {
+			// Should we even response with an error here?
+			// The panel will simply show "no data"
+			return ErrorFrameFromQuery(query), fmt.Errorf("%s: %w", "No results from query", err)
+		}
+		return ErrorFrameFromQuery(query), fmt.Errorf("%s: %w", "Error response from database", err)
+	}
+
+	defer func() {
+		if err := rows.Close(); err != nil {
+			backend.Logger.Error(err.Error())
+		}
+	}()
+
+	// Convert the response to frames
+	res, err := getFrames(rows, -1, converters, fillMode, query)
+	if err != nil {
+		return ErrorFrameFromQuery(query), fmt.Errorf("%w: %s", err, "Could not process SQL results")
+	}
+
+	return res, nil
+}
+
+func getFrames(rows *sql.Rows, limit int64, converters []Converter, fillMode *data.FillMissing, query *Query) (data.Frames, error) {
+	frame, err := FrameFromRows(rows, limit, converters...)
+	if err != nil {
+		return nil, err
+	}
+	frame.Name = query.RefID
+	if frame.Meta == nil {
+		frame.Meta = &data.FrameMeta{}
+	}
+
+	frame.Meta.ExecutedQueryString = query.RawSQL
+	frame.Meta.PreferredVisualization = data.VisTypeGraph
+
+	if query.Format == FormatOptionTable {
+		frame.Meta.PreferredVisualization = data.VisTypeTable
+		return data.Frames{frame}, nil
+	}
+
+	if query.Format == FormatOptionLogs {
+		frame.Meta.PreferredVisualization = data.VisTypeLogs
+		return data.Frames{frame}, nil
+	}
+
+	count, err := frame.RowLen()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if count == 0 {
+		return nil, ErrorNoResults
+	}
+
+	if frame.TimeSeriesSchema().Type == data.TimeSeriesTypeLong {
+		frame, err := data.LongToWide(frame, fillMode)
+		if err != nil {
+			return nil, err
+		}
+		return data.Frames{frame}, nil
+	}
+
+	return data.Frames{frame}, nil
 }

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -104,7 +104,7 @@ func QueryDB(ctx context.Context, db Connection, converters []Converter, fillMod
 
 	// Check for an error response
 	if err := rows.Err(); err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			// Should we even response with an error here?
 			// The panel will simply show "no data"
 			return ErrorFrameFromQuery(query), fmt.Errorf("%s: %w", "No results from query", err)

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -89,8 +89,8 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 	return frame, nil
 }
 
-// QueryDB sends the query to the connection and converts the rows to a dataframe.
-func QueryDB(ctx context.Context, db Connection, converters []Converter, fillMode *data.FillMissing, query *Query, args ...interface{}) (data.Frames, error) {
+// RunQuery sends the query to the connection and converts the rows to a dataframe.
+func RunQuery(ctx context.Context, db Connection, converters []Converter, fillMode *data.FillMissing, query *Query, args ...interface{}) (data.Frames, error) {
 	// Query the rows from the database
 	rows, err := db.QueryContext(ctx, query.RawSQL, args...)
 	if err != nil {

--- a/data/sqlutil/sql_test.go
+++ b/data/sqlutil/sql_test.go
@@ -34,7 +34,7 @@ func (t *testConnection) QueryContext(ctx context.Context, query string, args ..
 	}
 }
 
-func TestQuery_Timeout(t *testing.T) {
+func TestRunQuery_Timeout(t *testing.T) {
 	t.Run("it should return context.Canceled if the query timeout is exceeded", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 		defer cancel()
@@ -43,7 +43,7 @@ func TestQuery_Timeout(t *testing.T) {
 			QueryWait: time.Second * 5,
 		}
 
-		_, err := sqlutil.QueryDB(ctx, conn, []sqlutil.Converter{}, nil, &sqlutil.Query{})
+		_, err := sqlutil.RunQuery(ctx, conn, []sqlutil.Converter{}, nil, &sqlutil.Query{})
 
 		if !errors.Is(err, context.Canceled) {
 			t.Fatal("expected error to be context.Canceled, received", err)
@@ -62,7 +62,7 @@ func TestQuery_Timeout(t *testing.T) {
 			QueryWait: time.Second,
 		}
 
-		_, err := sqlutil.QueryDB(ctx, conn, []sqlutil.Converter{}, nil, &sqlutil.Query{})
+		_, err := sqlutil.RunQuery(ctx, conn, []sqlutil.Converter{}, nil, &sqlutil.Query{})
 
 		if !errors.Is(err, sqlutil.ErrorQuery) {
 			t.Fatal("expected function to complete, received error: ", err)

--- a/data/sqlutil/sql_test.go
+++ b/data/sqlutil/sql_test.go
@@ -1,1 +1,71 @@
 package sqlutil_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+)
+
+var errorQueryCompleted = errors.New("query completed")
+
+type testConnection struct {
+	QueryWait     time.Duration
+	QueryRunCount int
+}
+
+func (t *testConnection) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	t.QueryRunCount++
+
+	done := make(chan bool)
+	go func() {
+		time.Sleep(t.QueryWait)
+		done <- true
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, context.Canceled
+	case <-done:
+		return nil, errorQueryCompleted
+	}
+}
+
+func TestQuery_Timeout(t *testing.T) {
+	t.Run("it should return context.Canceled if the query timeout is exceeded", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+		defer cancel()
+
+		conn := &testConnection{
+			QueryWait: time.Second * 5,
+		}
+
+		_, err := sqlutil.QueryDB(ctx, conn, []sqlutil.Converter{}, nil, &sqlutil.Query{})
+
+		if !errors.Is(err, context.Canceled) {
+			t.Fatal("expected error to be context.Canceled, received", err)
+		}
+
+		if conn.QueryRunCount != 1 {
+			t.Fatal("expected the querycontext function to run only once, but ran", conn.QueryRunCount, "times")
+		}
+	})
+
+	t.Run("it should run to completion and not return a query timeout error", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+		defer cancel()
+
+		conn := &testConnection{
+			QueryWait: time.Second,
+		}
+
+		_, err := sqlutil.QueryDB(ctx, conn, []sqlutil.Converter{}, nil, &sqlutil.Query{})
+
+		if !errors.Is(err, sqlutil.ErrorQuery) {
+			t.Fatal("expected function to complete, received error: ", err)
+		}
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
Copies the `QueryDB` helper from https://github.com/grafana/sqlds/blob/e3b8b30e5c64464b2940297c8a231ccba2c7596a/query.go into sqlutil as `RunQuery`. This is part of an https://github.com/grafana/cloud-data-sources/issues/94 to separate out the utility functions from the actual datasource object created in sqlds for datasources that want to reuse the parsing and macros code without using the actual sqlds datasource.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #584 

**Special notes for your reviewer**:
There's a [drone integration test](https://github.com/grafana/sqlds/blob/e3b8b30e5c64464b2940297c8a231ccba2c7596a/query_integration_test.go) for `QueryDB` that I wasn't able to get to run here, but if someone is willing to help me configure it I'm happy to add it.

