### PR TITLE
BUGFIX (dataframes): support nil values in maps

### DIFF
--- a/data/framestruct/converter.go
+++ b/data/framestruct/converter.go
@@ -196,6 +196,11 @@ func (c *converter) convertMap(toConvert interface{}, tags, prefix string) error
 
 	for _, name := range sortedKeys(m) {
 		value := m[name]
+		if value == nil {
+			// skip nil values (as they will lead to "nil" values later on anyways);
+			// and the reflection code below crashes on nil.
+			continue
+		}
 		fieldName := c.fieldName(name, tags, prefix)
 		v := c.ensureValue(reflect.ValueOf(value))
 		if err := c.handleValue(v, "", fieldName); err != nil {

--- a/data/framestruct/converter_test.go
+++ b/data/framestruct/converter_test.go
@@ -311,6 +311,45 @@ func TestSlices(t *testing.T) {
 		require.Nil(t, frame.Fields[2].At(0))
 		require.Equal(t, "baz1", fromPointer(frame.Fields[2].At(1)))
 	})
+
+	t.Run("it flattens a slice of maps that contains nil values", func(t *testing.T) {
+		// like the testcase above, just with "nil" instead of non-defined map keys.
+		maps := []map[string]interface{}{
+			{
+				"Thing1": "foo",
+				"Thing2": int32(36),
+				"Thing3": nil,
+			},
+			{
+				"Thing1": "foo1",
+				"Thing2": nil,
+				"Thing3": "baz1",
+			},
+		}
+
+		// result
+		// | Thing1 | Thing2 | Thing3 |
+		// |--------+--------+--------|
+		// | foo    | 36     | nil    |
+		// | foo1   | nil    | baz1   |
+
+		frame, err := framestruct.ToDataFrame("results", maps)
+		require.Nil(t, err)
+
+		require.Len(t, frame.Fields, 3)
+		require.Equal(t, 2, frame.Fields[0].Len())
+		require.Equal(t, 2, frame.Fields[1].Len())
+		require.Equal(t, 2, frame.Fields[2].Len())
+
+		require.Equal(t, "foo", fromPointer(frame.Fields[0].At(0)))
+		require.Equal(t, "foo1", fromPointer(frame.Fields[0].At(1)))
+
+		require.Equal(t, int32(36), fromPointer(frame.Fields[1].At(0)))
+		require.Nil(t, frame.Fields[1].At(1))
+
+		require.Nil(t, frame.Fields[2].At(0))
+		require.Equal(t, "baz1", fromPointer(frame.Fields[2].At(1)))
+	})
 }
 
 func TestMaps(t *testing.T) {


### PR DESCRIPTION
While the code supports undefined map keys (converting them to `nil` as expected), it crashes when the map value is `nil`.

This change handles `nil` map values in the same way as undefined map keys.

