### PR TITLE
Data: change Field.Len() to be more like len()

### DIFF
--- a/data/field.go
+++ b/data/field.go
@@ -166,6 +166,7 @@ func (f *Field) At(idx int) interface{} {
 }
 
 // Len returns the number of elements in the Field.
+// It will return 0 if the field is nil.
 func (f *Field) Len() int {
 	if f == nil || f.vector == nil {
 		return 0

--- a/data/field.go
+++ b/data/field.go
@@ -167,6 +167,9 @@ func (f *Field) At(idx int) interface{} {
 
 // Len returns the number of elements in the Field.
 func (f *Field) Len() int {
+	if f == nil || f.vector == nil {
+		return 0
+	}
 	return f.vector.Len()
 }
 

--- a/data/field_test.go
+++ b/data/field_test.go
@@ -71,6 +71,13 @@ func TestField_NullableFloat64(t *testing.T) {
 	})
 }
 
+func TestFieldLen(t *testing.T) {
+	var fp *data.Field
+	var f data.Field
+	require.Equal(t, 0, fp.Len())
+	require.Equal(t, 0, f.Len())
+}
+
 func TestField_String(t *testing.T) {
 	field := data.NewField("value", nil, make([]*string, 3))
 


### PR DESCRIPTION
This returns 0 on nil Field or Field.vector instead of a panic. This makes the method more in line with go's built-in `len()`.

It also makes it so a reader doesn't have to do a nil and length check on a field.