### PR TITLE
allow using the scan type from the db

### DIFF
--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -54,7 +54,7 @@ func (s *ScanRow) NewScannableRow() []interface{} {
 // Applicable converters will substitute the SQL scan type with the one provided by the converter.
 // The list of returned converters is the same length as the SQL rows and corresponds with the rows at the same index. (e.g. value at slice element 3 corresponds with the converter at slice element 3)
 // If no converter is provided for a row that has a type that does not fit into a dataframe, it is skipped.
-func MakeScanRow(colTypes []*sql.ColumnType, colNames []string, converters ...Converter) (*rowConverter, error) {
+func MakeScanRow(colTypes []*sql.ColumnType, colNames []string, converters ...Converter) (*RowConverter, error) {
 	// In the future we can probably remove this restriction. But right now we map names to Arrow Field Names.
 	// Arrow Field names must be unique: https://github.com/grafana/grafana-plugin-sdk-go/issues/59
 	seen := map[string]int{}
@@ -97,25 +97,25 @@ func scanKind(v Converter, t reflect.Type) reflect.Type {
 	return t
 }
 
-type rowConverter struct {
+type RowConverter struct {
 	Row        *ScanRow
 	Converters []Converter
 }
 
-func NewRowConverter() *rowConverter {
-	return &rowConverter{Row: NewScanRow(0)}
+func NewRowConverter() *RowConverter {
+	return &RowConverter{Row: NewScanRow(0)}
 }
 
-func (r *rowConverter) append(name string, kind reflect.Type, conv Converter) {
+func (r *RowConverter) append(name string, kind reflect.Type, conv Converter) {
 	r.Row.Append(name, kind)
 	r.Converters = append(r.Converters, conv)
 }
 
-func (r *rowConverter) hasConverter(i int) bool {
+func (r *RowConverter) hasConverter(i int) bool {
 	return len(r.Converters) >= i
 }
 
-func (r *rowConverter) NewScannableRow() []any {
+func (r *RowConverter) NewScannableRow() []any {
 	return r.Row.NewScannableRow()
 }
 

--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -76,21 +76,21 @@ func MakeScanRow(colTypes []*sql.ColumnType, colNames []string, converters ...Co
 
 		for _, v := range converters {
 			if m := match(v, colType, colName); m {
-				rc.append(colName, scanKind(v, colType.ScanType()), v)
+				rc.append(colName, scanType(v, colType.ScanType()), v)
 				break
 			}
 		}
 
 		if !rc.hasConverter(i) {
 			v := NewDefaultConverter(colType.Name(), nullable, colType.ScanType())
-			rc.append(colName, scanKind(v, colType.ScanType()), v)
+			rc.append(colName, scanType(v, colType.ScanType()), v)
 		}
 	}
 
 	return rc, nil
 }
 
-func scanKind(v Converter, t reflect.Type) reflect.Type {
+func scanType(v Converter, t reflect.Type) reflect.Type {
 	if v.InputScanType != nil {
 		return v.InputScanType
 	}

--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -120,7 +120,12 @@ func (r *RowConverter) NewScannableRow() []any {
 }
 
 func match(v Converter, colType *sql.ColumnType, colName string) bool {
-	return (v.InputTypeRegex != nil && v.InputTypeRegex.MatchString(colType.DatabaseTypeName())) ||
-		(v.InputColumnName == colName && v.InputColumnName != "") ||
-		v.InputTypeName == colType.DatabaseTypeName()
+	if v.InputColumnName == colName && v.InputColumnName != "" {
+		return true
+	}
+	if colType == nil {
+		return false
+	}
+	return v.InputTypeName == colType.DatabaseTypeName() ||
+		(v.InputTypeRegex != nil && v.InputTypeRegex.MatchString(colType.DatabaseTypeName()))
 }

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -35,12 +35,12 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 		return nil, err
 	}
 
-	scanner, converters, err := MakeScanRow(types, names, converters...)
+	scanRow, err := MakeScanRow(types, names, converters...)
 	if err != nil {
 		return nil, err
 	}
 
-	frame := NewFrame(names, converters...)
+	frame := NewFrame(names, scanRow.Converters...)
 
 	var i int64
 	for rows.Next() {
@@ -52,12 +52,12 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 			break
 		}
 
-		r := scanner.NewScannableRow()
+		r := scanRow.NewScannableRow()
 		if err := rows.Scan(r...); err != nil {
 			return nil, err
 		}
 
-		if err := Append(frame, r, converters...); err != nil {
+		if err := Append(frame, r, scanRow.Converters...); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we can't use the scan type returned from the database on a converter.  If we define a converter, it would always override the scan type returned from the database.

This PR allows using the scan type defined by the database, so now setting it on the converter is optional.  Setting it on the converter will override the scan type defined by the database.  This is useful when doing regex matching where the underlying scan type may not always be the same.  For example in SAP Hana:  "Fixed8" data type can return [driver.Decimal or driver.NullDecimal](https://github.com/grafana/saphana-datasource/pull/73/files#diff-ee17992c987df01645f07024591cfd9212594ea65f8d7f7a06446d49523fa7d5R52) as the scan type.

The code was a bit gnarly so cleaned it up a bit.

**Which issue(s) this PR fixes**:
https://github.com/grafana/support-escalations/issues/4943
