### PR TITLE
Generates a go_plugin_build_manifest file when building a plugin

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -181,13 +181,17 @@ func (Build) GenerateManifestFile() error {
 	if outputPath == "" {
 		outputPath = defaultOutputBinaryPath
 	}
-	manifestContent := utils.GenerateManifest()
-	manifestFile := filepath.Join(outputPath, "go_plugin_build_manifest")
+	manifestContent, err := utils.GenerateManifest()
+	if err != nil {
+		return err
+	}
+
+	manifestFilePath := filepath.Join(outputPath, "go_plugin_build_manifest")
 	err = os.MkdirAll(outputPath, 0755)
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(manifestFile, []byte(manifestContent), 0600)
+	err = os.WriteFile(manifestFilePath, []byte(manifestContent), 0600)
 	if err != nil {
 		return err
 	}

--- a/build/utils/manifest.go
+++ b/build/utils/manifest.go
@@ -4,7 +4,8 @@ import (
 	// sha1 is not cryptographically secure
 	// but we just want to generate a reproducible fast hash
 	// to compare the contents of the files
-	"crypto/sha1" // nolint:gosec
+	// nolint:gosec
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -53,7 +54,7 @@ func insecureHashFileContent(path string) (string, error) {
 	}()
 
 	buf := make([]byte, 1024*1024)
-	h := sha1.New() // nolint:gosec
+	h := sha256.New() // nolint:gosec
 
 	for {
 		bytesRead, err := f.Read(buf)

--- a/build/utils/manifest.go
+++ b/build/utils/manifest.go
@@ -1,10 +1,6 @@
 package utils
 
 import (
-	// sha1 is not cryptographically secure
-	// but we just want to generate a reproducible fast hash
-	// to compare the contents of the files
-	// nolint:gosec
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -23,7 +19,7 @@ func GenerateManifest() (string, error) {
 			return err
 		}
 		if !d.IsDir() && strings.HasSuffix(path, ".go") {
-			hash, err := insecureHashFileContent(path)
+			hash, err := hashFileContent(path)
 			if err != nil {
 				return err
 			}
@@ -35,9 +31,8 @@ func GenerateManifest() (string, error) {
 	return manifest, err
 }
 
-// insecureHashFileContent returns the SHA1 hash of the file content.
-// It is not cryptographically secure. do not use for anything else
-func insecureHashFileContent(path string) (string, error) {
+// hashFileContent returns the sha256 hash of the file content.
+func hashFileContent(path string) (string, error) {
 	// Handle hashing big files.
 	// Source: https://stackoverflow.com/q/60328216/1722542
 
@@ -49,12 +44,12 @@ func insecureHashFileContent(path string) (string, error) {
 	defer func() {
 		err = f.Close()
 		if err != nil {
-			fmt.Println("error closing file for hashing", err)
+			fmt.Printf("error closing file for hashing %v", err)
 		}
 	}()
 
 	buf := make([]byte, 1024*1024)
-	h := sha256.New() // nolint:gosec
+	h := sha256.New()
 
 	for {
 		bytesRead, err := f.Read(buf)

--- a/build/utils/manifest.go
+++ b/build/utils/manifest.go
@@ -45,7 +45,7 @@ func hashFileContent(path string) (string, error) {
 	defer func() {
 		err = f.Close()
 		if err != nil {
-			fmt.Printf("error closing file for hashing %v", err)
+			fmt.Printf("error closing file for hashing: %v", err)
 		}
 	}()
 

--- a/build/utils/manifest.go
+++ b/build/utils/manifest.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	// sha1 is not cryptographically secure
+	// but we just want to generate a reproducible fast hash
+	// to compare the contents of the files
+	"crypto/sha1" // nolint:gosec
+	"encoding/hex"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func GenerateManifest() string {
+	manifest := ""
+	_ = filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".go") {
+			hash, err := insecureHashFileContent(path)
+			if err != nil {
+				return nil
+			}
+			manifest = manifest + hash + ":" + path + "\n"
+		}
+		return nil
+	})
+
+	return manifest
+}
+
+// insecureHashFileContent returns the SHA1 hash of the file content.
+// It is not cryptographically secure. do not use for anything else
+func insecureHashFileContent(path string) (string, error) {
+	// Handle hashing big files.
+	// Source: https://stackoverflow.com/q/60328216/1722542
+
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	buf := make([]byte, 1024*1024)
+	h := sha1.New() // nolint:gosec
+
+	for {
+		bytesRead, err := f.Read(buf)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				return "", err
+			}
+			_, err = h.Write(buf[:bytesRead])
+			if err != nil {
+				return "", err
+			}
+			break
+		}
+		_, err = h.Write(buf[:bytesRead])
+		if err != nil {
+			return "", err
+		}
+	}
+
+	fileHash := hex.EncodeToString(h.Sum(nil))
+	return fileHash, nil
+}

--- a/build/utils/manifest.go
+++ b/build/utils/manifest.go
@@ -13,7 +13,7 @@ import (
 )
 
 func GenerateManifest() (string, error) {
-	manifest := ""
+	var manifest strings.Builder
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -23,12 +23,13 @@ func GenerateManifest() (string, error) {
 			if err != nil {
 				return err
 			}
-			manifest = manifest + hash + ":" + path + "\n"
+			// manifest = manifest + hash + ":" + path + "\n"
+			manifest.WriteString(hash + ":" + path + "\n")
 		}
 		return nil
 	})
 
-	return manifest, err
+	return manifest.String(), err
 }
 
 // hashFileContent returns the sha256 hash of the file content.

--- a/build/utils/manifest.go
+++ b/build/utils/manifest.go
@@ -14,23 +14,23 @@ import (
 	"strings"
 )
 
-func GenerateManifest() string {
+func GenerateManifest() (string, error) {
 	manifest := ""
-	_ = filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if !d.IsDir() && strings.HasSuffix(path, ".go") {
 			hash, err := insecureHashFileContent(path)
 			if err != nil {
-				return nil
+				return err
 			}
 			manifest = manifest + hash + ":" + path + "\n"
 		}
 		return nil
 	})
 
-	return manifest
+	return manifest, err
 }
 
 // insecureHashFileContent returns the SHA1 hash of the file content.
@@ -45,7 +45,7 @@ func insecureHashFileContent(path string) (string, error) {
 	}
 
 	defer func() {
-		_ = f.Close()
+		err = f.Close()
 	}()
 
 	buf := make([]byte, 1024*1024)

--- a/build/utils/manifest.go
+++ b/build/utils/manifest.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha1" // nolint:gosec
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -46,6 +47,9 @@ func insecureHashFileContent(path string) (string, error) {
 
 	defer func() {
 		err = f.Close()
+		if err != nil {
+			fmt.Println("error closing file for hashing", err)
+		}
 	}()
 
 	buf := make([]byte, 1024*1024)


### PR DESCRIPTION
**What this PR does / why we need it**:

We (grafana) want to check the integrity of plugins binary files at submission time. 

We can use this manifest file to compare it against the source code we are provided and make sure no mistakes were made at submission.

Note that it is clear this manifest can be tampered with and this is not meant to be a fool-proof way of replicating builds. This is not a strict security feature against an intentional attack. This is oriented to prevent plugins submissions to mistakenly submit the wrong source code.

**Special notes for your reviewer**:

## Performance

Using [hyperfine](https://github.com/sharkdp/hyperfine) to run benchmarks against a [known plugin](https://github.com/alexanderzobnin/grafana-zabbix/) go code. 50 runs with 5 warm up runs (to fill the go build cache) and removing all dist files between runs:

### Zabbix datasource (around 4200 lines of code) 

#### With manifest generation

```
❯ hyperfine --runs 50 'mage buildAll' --warmup 5 --prepare 'rm -rf dist'
Benchmark 1: mage buildAll
  Time (mean ± σ):     945.4 ms ±  45.8 ms    [User: 5086.5 ms, System: 1636.5 ms]
  Range (min … max):   844.4 ms … 1049.5 ms    50 runs
```

#### Without manifest generation

```
❯ hyperfine --runs 50 'mage buildAll' --warmup 5 --prepare 'rm -rf dist'
Benchmark 1: mage buildAll
  Time (mean ± σ):     942.6 ms ±  49.5 ms    [User: 4885.4 ms, System: 1501.2 ms]
  Range (min … max):   843.3 ms … 1088.3 ms    50 runs
```

The difference in compile times speed were around 3ms and given the calculated margin of error this can be deemed as negligible.

### testing datadogs (larger code base ~6800 lines of code)
#### With manifest code
```
❯ hyperfine --runs 50 'mage buildAll' --prepare 'rm -rf dist' --warmup 3
Benchmark 1: mage buildAll
  Time (mean ± σ):      1.291 s ±  0.058 s    [User: 6.978 s, System: 1.789 s]
  Range (min … max):    1.191 s …  1.427 s    50 runs
```

#### Without manifest code
```
❯ hyperfine --runs 50 'mage buildAll' --prepare 'rm -rf dist' --warmup 3
Benchmark 1: mage buildAll
  Time (mean ± σ):      1.264 s ±  0.052 s    [User: 6.768 s, System: 1.690 s]
  Range (min … max):    1.185 s …  1.420 s    50 runs
```

### Using system commands instead of Walking and crypto.

A similar and much faster result can be achieved by using `find` and `sha1sum` commands but these are not compatible with windows development.