### PR TITLE
fix - scan row not providing all rows

### DIFF
--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -113,7 +113,7 @@ func (r *RowConverter) append(name string, kind reflect.Type, conv Converter) {
 }
 
 func (r *RowConverter) hasConverter(i int) bool {
-	return len(r.Converters) >= i
+	return len(r.Converters) > i
 }
 
 func (r *RowConverter) NewScannableRow() []any {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug where scan row isn't providing all the rows

