### PR TITLE
Fix findAndKillCurrentPlugin for long names

### DIFF
--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -147,7 +147,7 @@ func findAndKillCurrentPlugin(dir string) {
 		return
 	}
 
-	out, err := exec.Command("pgrep", exeprefix).Output()
+	out, err := exec.Command("pgrep", "-f", exeprefix).Output()
 	if err != nil {
 		fmt.Printf("error running pgrep: %s (%s)", err.Error(), exeprefix)
 		return


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

When the executable name is longer than 15 characters, `pgrep` with no flags won't work. See:

https://unix.stackexchange.com/questions/267007/pgrep-full-match-not-work-only-part-why

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
