### PR TITLE
feat: Improve `mage coverage` command: add -coverpkg option and -func report

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -271,12 +271,16 @@ func Test() error {
 
 // Coverage runs backend tests and makes a coverage report.
 func Coverage() error {
-	// Create a coverage file if it does not already exist
+	// Create a coverage folder if it does not already exist
 	if err := os.MkdirAll(filepath.Join(".", "coverage"), os.ModePerm); err != nil {
 		return err
 	}
 
-	if err := sh.RunV("go", "test", "./pkg/...", "-v", "-cover", "-coverprofile=coverage/backend.out"); err != nil {
+	if err := sh.RunV("go", "test", "./pkg/...", "-coverpkg", "./...", "-v", "-cover", "-coverprofile=coverage/backend.out"); err != nil {
+		return err
+	}
+
+	if err := sh.RunV("go", "tool", "cover", "-func=coverage/backend.out", "-o", "coverage/backend.txt"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Changes:

- Add `-coverpkg ./...` option to the `mage coverage` command
- Add `-func` report to the `mage coverage` command

With `-coverpkg ./...` the total coverage is different, and the `-func` report includes files with 0% coverage.

Below you can find the coverage diff screenshot from [github-datasource](https://github.com/grafana/github-datasource).

On the left (without `-coverpkg`, total coverage 45.5%):
```
go test ./pkg/... -v -cover -coverprofile=coverage/backend.out && go tool cover -func=coverage/backend.out -o coverage/backend.txt
```

On the right (with `-coverpkg`, total coverage 39.9%):
```
go test ./pkg/... -coverpkg ./... -v -cover -coverprofile=coverage/backend.out && go tool cover -func=coverage/backend.out -o coverage/backend.txt
```

![image](https://user-images.githubusercontent.com/1436174/220365118-c0ee85fc-dd05-4e21-98e3-d0bc83ba64c1.png)

![image](https://user-images.githubusercontent.com/1436174/220365130-d55cc237-0758-4729-bab0-66efdcf95dc3.png)
