### PR TITLE
Data: Document no nil entires in Fields / Frames

### DIFF
--- a/data/frame.go
+++ b/data/frame.go
@@ -38,6 +38,7 @@ type Frame struct {
 
 	// Fields are the columns of a frame.
 	// All Fields must be of the same the length when marshalling the Frame for transmission.
+	// There should be no `nil` entries in the Fields slice (making them pointers was a mistake).
 	Fields []*Field
 
 	// RefID is a property that can be set to match a Frame to its originating query.
@@ -69,6 +70,7 @@ func (f *Frame) MarshalJSON() ([]byte, error) {
 
 // Frames is a slice of Frame pointers.
 // It is the main data container within a backend.DataResponse.
+// There should be no `nil` entries in the Frames slice (making them pointers was a mistake).
 //
 //swagger:model
 type Frames []*Frame


### PR DESCRIPTION
This changes the documentation to state that there should be no nil entires in frame.Fields `[]*Field`, and same for the (Frames) type.

It also states that making them pointers was a mistake. Maybe this comment should be removed? If it wasn't a mistake, I can no longer see the reason for it (I think I may have been the one to do it, or at least allowed it to happen), so if anyone can see a reason it isn't a mistake - I would appreciate that insight. If it just is mistake, then perhaps someday we can make a change to undo it.
