### PR TITLE
check nil frame to avoid panic

### DIFF
--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -142,7 +142,7 @@ func (t ConvertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.
 	}
 	for refID, dr := range res.Responses {
 		for _, f := range dr.Frames {
-			if f.RefID == "" {
+			if f != nil && f.RefID == "" {
 				f.RefID = refID
 			}
 		}

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"errors"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
@@ -142,7 +143,10 @@ func (t ConvertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.
 	}
 	for refID, dr := range res.Responses {
 		for _, f := range dr.Frames {
-			if f != nil && f.RefID == "" {
+			if f == nil {
+				return nil, errors.New("frame can not be nil")
+			}
+			if f.RefID == "" {
 				f.RefID = refID
 			}
 		}

--- a/data/arrow.go
+++ b/data/arrow.go
@@ -794,6 +794,9 @@ func (frames Frames) MarshalArrow() ([][]byte, error) {
 	bs := make([][]byte, len(frames))
 	var err error
 	for i, frame := range frames {
+		if frame == nil {
+			continue
+		}
 		bs[i], err = frame.MarshalArrow()
 		if err != nil {
 			return nil, err

--- a/data/arrow.go
+++ b/data/arrow.go
@@ -795,7 +795,7 @@ func (frames Frames) MarshalArrow() ([][]byte, error) {
 	var err error
 	for i, frame := range frames {
 		if frame == nil {
-			continue
+			return nil, errors.New("frame can not be nil")
 		}
 		bs[i], err = frame.MarshalArrow()
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Frame can potentially be nil since frames is []*Frame.  Catch cases where frame is nil and causes a panic.

**Which issue(s) this PR fixes**:
https://github.com/grafana/support-escalations/issues/5063

**Special notes for your reviewer**:
Relates to: https://github.com/grafana/splunk-datasource/pull/379