### PR TITLE
Data: Add ValueSlice() to Field

### DIFF
--- a/data/field.go
+++ b/data/field.go
@@ -218,6 +218,13 @@ func (f *Field) Nullable() bool {
 	return f.Type().Nullable()
 }
 
+// ValueSlice returns the underlying slice of values for the field
+// as its underlying type. The underlying type that is returned
+// is not part of this library stability guarantees and therefore may change.
+func (f *Field) ValueSlice() interface{} {
+	return f.vector.ValueSlice()
+}
+
 // FloatAt returns a float64 at the specified index idx for all supported Field types.
 // It will panic if idx is out of range.
 //

--- a/data/field_type_enum.go
+++ b/data/field_type_enum.go
@@ -52,6 +52,10 @@ func (v *enumVector) Extend(i int) {
 	*v = append(*v, make([]uint16, i)...)
 }
 
+func (v *enumVector) ValueSlice() interface{} {
+	return []uint16(*v)
+}
+
 func (v *enumVector) Insert(i int, val interface{}) {
 	switch {
 	case i < v.Len():
@@ -151,4 +155,8 @@ func (v *nullableEnumVector) Insert(i int, val interface{}) {
 
 func (v *nullableEnumVector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *nullableEnumVector) ValueSlice() interface{} {
+	return []*uint16(*v)
 }

--- a/data/generic_nullable_vector.go
+++ b/data/generic_nullable_vector.go
@@ -90,3 +90,7 @@ func (v *nullablegenVector) Insert(i int, val interface{}) {
 func (v *nullablegenVector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
+
+func (v *nullablegenVector) ValueSlice() interface{} {
+	return ([]*gen)(*v)
+}

--- a/data/generic_vector.go
+++ b/data/generic_vector.go
@@ -77,3 +77,7 @@ func (v *genVector) Insert(i int, val interface{}) {
 func (v *genVector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
+
+func (v *genVector) ValueSlice() interface{} {
+	return ([]gen)(*v)
+}

--- a/data/nullable_vector.gen.go
+++ b/data/nullable_vector.gen.go
@@ -100,6 +100,10 @@ func (v *nullableUint8Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *nullableUint8Vector) ValueSlice() interface{} {
+	return ([]*uint8)(*v)
+}
+
 type nullableUint16Vector []*uint16
 
 func newNullableUint16Vector(n int) *nullableUint16Vector {
@@ -189,6 +193,10 @@ func (v *nullableUint16Vector) Insert(i int, val interface{}) {
 
 func (v *nullableUint16Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *nullableUint16Vector) ValueSlice() interface{} {
+	return ([]*uint16)(*v)
 }
 
 type nullableUint32Vector []*uint32
@@ -282,6 +290,10 @@ func (v *nullableUint32Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *nullableUint32Vector) ValueSlice() interface{} {
+	return ([]*uint32)(*v)
+}
+
 type nullableUint64Vector []*uint64
 
 func newNullableUint64Vector(n int) *nullableUint64Vector {
@@ -371,6 +383,10 @@ func (v *nullableUint64Vector) Insert(i int, val interface{}) {
 
 func (v *nullableUint64Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *nullableUint64Vector) ValueSlice() interface{} {
+	return ([]*uint64)(*v)
 }
 
 type nullableInt8Vector []*int8
@@ -464,6 +480,10 @@ func (v *nullableInt8Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *nullableInt8Vector) ValueSlice() interface{} {
+	return ([]*int8)(*v)
+}
+
 type nullableInt16Vector []*int16
 
 func newNullableInt16Vector(n int) *nullableInt16Vector {
@@ -553,6 +573,10 @@ func (v *nullableInt16Vector) Insert(i int, val interface{}) {
 
 func (v *nullableInt16Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *nullableInt16Vector) ValueSlice() interface{} {
+	return ([]*int16)(*v)
 }
 
 type nullableInt32Vector []*int32
@@ -646,6 +670,10 @@ func (v *nullableInt32Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *nullableInt32Vector) ValueSlice() interface{} {
+	return ([]*int32)(*v)
+}
+
 type nullableInt64Vector []*int64
 
 func newNullableInt64Vector(n int) *nullableInt64Vector {
@@ -735,6 +763,10 @@ func (v *nullableInt64Vector) Insert(i int, val interface{}) {
 
 func (v *nullableInt64Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *nullableInt64Vector) ValueSlice() interface{} {
+	return ([]*int64)(*v)
 }
 
 type nullableFloat32Vector []*float32
@@ -828,6 +860,10 @@ func (v *nullableFloat32Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *nullableFloat32Vector) ValueSlice() interface{} {
+	return ([]*float32)(*v)
+}
+
 type nullableFloat64Vector []*float64
 
 func newNullableFloat64Vector(n int) *nullableFloat64Vector {
@@ -917,6 +953,10 @@ func (v *nullableFloat64Vector) Insert(i int, val interface{}) {
 
 func (v *nullableFloat64Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *nullableFloat64Vector) ValueSlice() interface{} {
+	return ([]*float64)(*v)
 }
 
 type nullableStringVector []*string
@@ -1010,6 +1050,10 @@ func (v *nullableStringVector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *nullableStringVector) ValueSlice() interface{} {
+	return ([]*string)(*v)
+}
+
 type nullableBoolVector []*bool
 
 func newNullableBoolVector(n int) *nullableBoolVector {
@@ -1099,6 +1143,10 @@ func (v *nullableBoolVector) Insert(i int, val interface{}) {
 
 func (v *nullableBoolVector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *nullableBoolVector) ValueSlice() interface{} {
+	return ([]*bool)(*v)
 }
 
 type nullableTimeTimeVector []*time.Time
@@ -1192,6 +1240,10 @@ func (v *nullableTimeTimeVector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *nullableTimeTimeVector) ValueSlice() interface{} {
+	return ([]*time.Time)(*v)
+}
+
 type nullableJsonRawMessageVector []*json.RawMessage
 
 func newNullableJsonRawMessageVector(n int) *nullableJsonRawMessageVector {
@@ -1281,4 +1333,8 @@ func (v *nullableJsonRawMessageVector) Insert(i int, val interface{}) {
 
 func (v *nullableJsonRawMessageVector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *nullableJsonRawMessageVector) ValueSlice() interface{} {
+	return ([]*json.RawMessage)(*v)
 }

--- a/data/vector.gen.go
+++ b/data/vector.gen.go
@@ -81,6 +81,10 @@ func (v *uint8Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *uint8Vector) ValueSlice() interface{} {
+	return ([]uint8)(*v)
+}
+
 type uint16Vector []uint16
 
 func newUint16Vector(n int) *uint16Vector {
@@ -151,6 +155,10 @@ func (v *uint16Vector) Insert(i int, val interface{}) {
 
 func (v *uint16Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *uint16Vector) ValueSlice() interface{} {
+	return ([]uint16)(*v)
 }
 
 type uint32Vector []uint32
@@ -225,6 +233,10 @@ func (v *uint32Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *uint32Vector) ValueSlice() interface{} {
+	return ([]uint32)(*v)
+}
+
 type uint64Vector []uint64
 
 func newUint64Vector(n int) *uint64Vector {
@@ -295,6 +307,10 @@ func (v *uint64Vector) Insert(i int, val interface{}) {
 
 func (v *uint64Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *uint64Vector) ValueSlice() interface{} {
+	return ([]uint64)(*v)
 }
 
 type int8Vector []int8
@@ -369,6 +385,10 @@ func (v *int8Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *int8Vector) ValueSlice() interface{} {
+	return ([]int8)(*v)
+}
+
 type int16Vector []int16
 
 func newInt16Vector(n int) *int16Vector {
@@ -439,6 +459,10 @@ func (v *int16Vector) Insert(i int, val interface{}) {
 
 func (v *int16Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *int16Vector) ValueSlice() interface{} {
+	return ([]int16)(*v)
 }
 
 type int32Vector []int32
@@ -513,6 +537,10 @@ func (v *int32Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *int32Vector) ValueSlice() interface{} {
+	return ([]int32)(*v)
+}
+
 type int64Vector []int64
 
 func newInt64Vector(n int) *int64Vector {
@@ -583,6 +611,10 @@ func (v *int64Vector) Insert(i int, val interface{}) {
 
 func (v *int64Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *int64Vector) ValueSlice() interface{} {
+	return ([]int64)(*v)
 }
 
 type float32Vector []float32
@@ -657,6 +689,10 @@ func (v *float32Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *float32Vector) ValueSlice() interface{} {
+	return ([]float32)(*v)
+}
+
 type float64Vector []float64
 
 func newFloat64Vector(n int) *float64Vector {
@@ -727,6 +763,10 @@ func (v *float64Vector) Insert(i int, val interface{}) {
 
 func (v *float64Vector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *float64Vector) ValueSlice() interface{} {
+	return ([]float64)(*v)
 }
 
 type stringVector []string
@@ -801,6 +841,10 @@ func (v *stringVector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *stringVector) ValueSlice() interface{} {
+	return ([]string)(*v)
+}
+
 type boolVector []bool
 
 func newBoolVector(n int) *boolVector {
@@ -871,6 +915,10 @@ func (v *boolVector) Insert(i int, val interface{}) {
 
 func (v *boolVector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *boolVector) ValueSlice() interface{} {
+	return ([]bool)(*v)
 }
 
 type timeTimeVector []time.Time
@@ -945,6 +993,10 @@ func (v *timeTimeVector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
 }
 
+func (v *timeTimeVector) ValueSlice() interface{} {
+	return ([]time.Time)(*v)
+}
+
 type jsonRawMessageVector []json.RawMessage
 
 func newJsonRawMessageVector(n int) *jsonRawMessageVector {
@@ -1015,4 +1067,8 @@ func (v *jsonRawMessageVector) Insert(i int, val interface{}) {
 
 func (v *jsonRawMessageVector) Delete(i int) {
 	*v = append((*v)[:i], (*v)[i+1:]...)
+}
+
+func (v *jsonRawMessageVector) ValueSlice() interface{} {
+	return ([]json.RawMessage)(*v)
 }

--- a/data/vector.go
+++ b/data/vector.go
@@ -18,6 +18,7 @@ type vector interface {
 	SetConcrete(i int, val interface{})
 	Insert(i int, val interface{})
 	Delete(i int)
+	ValueSlice() interface{}
 }
 
 // nolint:gocyclo


### PR DESCRIPTION
allows readers to access the slice as whole after a type assertion

This effect gives a way to expose the underlying vector property. For example, one can get the []float64 slice without making a new one.



