### PR TITLE
sdata/timeseries: fix bug in long on wrong field type

### DIFF
--- a/experimental/sdata/timeseries/long.go
+++ b/experimental/sdata/timeseries/long.go
@@ -84,7 +84,7 @@ func validateAndGetRefsLong(ls *LongFrame, validateData, getRefs bool) (Collecti
 
 	factorFieldIndices := frame.TypeIndices(data.FieldTypeString, data.FieldTypeNullableString)
 
-	appendToMetric := func(metricName string, l data.Labels, t time.Time, value interface{}) error {
+	appendToMetric := func(metricName string, l data.Labels, t time.Time, value interface{}, valType data.FieldType) error {
 		if mm[metricName] == nil {
 			mm[metricName] = make(map[string]MetricRef)
 		}
@@ -93,8 +93,7 @@ func validateAndGetRefsLong(ls *LongFrame, validateData, getRefs bool) (Collecti
 		if ref, ok := mm[metricName][lbStr]; !ok {
 			ref.TimeField = data.NewField(timeField.Name, nil, []time.Time{t})
 
-			vt := data.FieldTypeFor(value)
-			ref.ValueField = data.NewFieldFromFieldType(vt, 1)
+			ref.ValueField = data.NewFieldFromFieldType(valType, 1)
 			ref.ValueField.Set(0, value)
 			ref.ValueField.Name = metricName
 			ref.ValueField.Labels = l
@@ -126,7 +125,7 @@ func validateAndGetRefsLong(ls *LongFrame, validateData, getRefs bool) (Collecti
 			}
 			for _, vFieldIdx := range valueFieldIndices {
 				valueField := frame.Fields[vFieldIdx]
-				if err := appendToMetric(valueField.Name, l, timeField.At(rowIdx).(time.Time), valueField.At(rowIdx)); err != nil {
+				if err := appendToMetric(valueField.Name, l, timeField.At(rowIdx).(time.Time), valueField.At(rowIdx), valueField.Type()); err != nil {
 					return c, err
 				}
 			}


### PR DESCRIPTION
Fix in reading long time series in experimental/sdata. data.FieldTypeFor doesn't do what I thought it did.
