### PR TITLE
experimental/sdata: Add RefID to writers and readers

### DIFF
--- a/experimental/sdata/numeric/long.go
+++ b/experimental/sdata/numeric/long.go
@@ -24,11 +24,11 @@ func LongFrameVersions() []data.FrameTypeVersion {
 	return []data.FrameTypeVersion{{0, 1}}
 }
 
-func NewLongFrame(v data.FrameTypeVersion) (*LongFrame, error) {
+func NewLongFrame(refID string, v data.FrameTypeVersion) (*LongFrame, error) {
 	if v.Greater(LongFrameVersionLatest) {
 		return nil, fmt.Errorf("can not create LongFrame of version %s because it is newer than library version %v", v, LongFrameVersionLatest)
 	}
-	return &LongFrame{emptyFrameWithTypeMD(data.FrameTypeNumericLong, v)}, nil
+	return &LongFrame{emptyFrameWithTypeMD(refID, data.FrameTypeNumericLong, v)}, nil
 }
 
 func (lf *LongFrame) GetCollection(validateData bool) (Collection, error) {
@@ -45,6 +45,8 @@ func validateAndGetRefsLong(lf *LongFrame, validateData bool) (Collection, error
 	if lf == nil || lf.Frame == nil {
 		return c, fmt.Errorf("nil frame is invalid")
 	}
+
+	c.RefID = lf.Frame.RefID
 
 	if !frameHasType(lf.Frame, data.FrameTypeNumericLong) {
 		return c, fmt.Errorf("frame is missing %s type indicator", data.FrameTypeNumericLong)

--- a/experimental/sdata/numeric/multi.go
+++ b/experimental/sdata/numeric/multi.go
@@ -19,12 +19,12 @@ func MultiFrameVersions() []data.FrameTypeVersion {
 	return []data.FrameTypeVersion{{0, 1}}
 }
 
-func NewMultiFrame(v data.FrameTypeVersion) (*MultiFrame, error) {
+func NewMultiFrame(refID string, v data.FrameTypeVersion) (*MultiFrame, error) {
 	if v.Greater(MultiFrameVersionLatest) {
 		return nil, fmt.Errorf("can not create MultiFrame of version %s because it is newer than library version %v", v, MultiFrameVersionLatest)
 	}
 	return &MultiFrame{
-		emptyFrameWithTypeMD(data.FrameTypeNumericMulti, v),
+		emptyFrameWithTypeMD(refID, data.FrameTypeNumericMulti, v),
 	}, nil
 }
 
@@ -87,6 +87,15 @@ func validateAndGetRefsMulti(mf *MultiFrame, validateData bool) (Collection, err
 	}
 
 	var c Collection
+	if mf == nil {
+		return c, fmt.Errorf("frame collection is nil")
+	}
+
+	if len(*mf) == 0 {
+		return c, fmt.Errorf("must be at least one frame")
+	}
+
+	c.RefID = (*mf)[0].RefID
 
 	for _, frame := range *mf {
 		if !frameHasType(frame, data.FrameTypeNumericMulti) {

--- a/experimental/sdata/numeric/numeric.go
+++ b/experimental/sdata/numeric/numeric.go
@@ -54,6 +54,7 @@ func (n MetricRef) NullableFloat64Value() (*float64, bool, error) {
 }
 
 type Collection struct {
+	RefID            string
 	Refs             []MetricRef
 	RemainderIndices []sdata.FrameFieldIndex
 	Warning          error

--- a/experimental/sdata/numeric/numeric_test.go
+++ b/experimental/sdata/numeric/numeric_test.go
@@ -30,7 +30,7 @@ func TestSimpleNumeric(t *testing.T) {
 	t.Run("multi frame", func(t *testing.T) {
 		var mFrameNC numeric.CollectionRW
 		var err error
-		mFrameNC, err = numeric.NewMultiFrame(numeric.MultiFrameVersionLatest)
+		mFrameNC, err = numeric.NewMultiFrame("A", numeric.MultiFrameVersionLatest)
 		require.NoError(t, err)
 
 		addMetrics(mFrameNC)
@@ -45,7 +45,7 @@ func TestSimpleNumeric(t *testing.T) {
 	t.Run("wide frame", func(t *testing.T) {
 		var wFrameNC numeric.CollectionRW
 		var err error
-		wFrameNC, err = numeric.NewWideFrame(numeric.WideFrameVersionLatest)
+		wFrameNC, err = numeric.NewWideFrame("B", numeric.WideFrameVersionLatest)
 		require.NoError(t, err)
 
 		addMetrics(wFrameNC)
@@ -57,13 +57,11 @@ func TestSimpleNumeric(t *testing.T) {
 		require.Equal(t, expectedRefs, wc.Refs)
 	})
 	t.Run("long frame", func(t *testing.T) {
-		lfn := &numeric.LongFrame{
-			Frame: data.NewFrame("",
-				data.NewField("os.cpu", nil, []float64{1, 2}),
-				data.NewField("host", nil, []string{"a", "b"}),
-			).SetMeta(&data.FrameMeta{Type: data.FrameTypeNumericLong,
-				TypeVersion: numeric.LongFrameVersionLatest}),
-		}
+		lfn, err := numeric.NewLongFrame("C", numeric.LongFrameVersionLatest)
+		require.NoError(t, err)
+
+		lfn.Fields = append(lfn.Fields, data.NewField("os.cpu", nil, []float64{1, 2}),
+			data.NewField("host", nil, []string{"a", "b"}))
 		var lcr numeric.CollectionReader = lfn
 
 		lc, err := lcr.GetCollection(false)

--- a/experimental/sdata/numeric/util.go
+++ b/experimental/sdata/numeric/util.go
@@ -2,8 +2,10 @@ package numeric
 
 import "github.com/grafana/grafana-plugin-sdk-go/data"
 
-func emptyFrameWithTypeMD(t data.FrameType, v data.FrameTypeVersion) *data.Frame {
-	return data.NewFrame("").SetMeta(&data.FrameMeta{Type: t, TypeVersion: v})
+func emptyFrameWithTypeMD(refID string, t data.FrameType, v data.FrameTypeVersion) *data.Frame {
+	f := data.NewFrame("").SetMeta(&data.FrameMeta{Type: t, TypeVersion: v})
+	f.RefID = refID
+	return f
 }
 
 func frameHasType(f *data.Frame, t data.FrameType) bool {

--- a/experimental/sdata/numeric/wide.go
+++ b/experimental/sdata/numeric/wide.go
@@ -23,11 +23,12 @@ func WideFrameVersions() []data.FrameTypeVersion {
 	return []data.FrameTypeVersion{{0, 1}}
 }
 
-func NewWideFrame(v data.FrameTypeVersion) (*WideFrame, error) {
+func NewWideFrame(refID string, v data.FrameTypeVersion) (*WideFrame, error) {
 	if v.Greater(WideFrameVersionLatest) {
 		return nil, fmt.Errorf("can not create WideFrame of version %s because it is newer than library version %v", v, WideFrameVersionLatest)
 	}
 	f := data.NewFrame("")
+	f.RefID = refID
 	f.SetMeta(&data.FrameMeta{Type: data.FrameTypeNumericWide, TypeVersion: v})
 	return &WideFrame{f}, nil
 }
@@ -62,6 +63,11 @@ func validateAndGetRefsWide(wf *WideFrame, validateData bool) (Collection, error
 	}
 
 	var c Collection
+	if wf == nil {
+		return c, fmt.Errorf("frame is nil")
+	}
+
+	c.RefID = wf.RefID
 
 	if !frameHasType(wf.Frame, data.FrameTypeNumericWide) {
 		return c, fmt.Errorf("frame has wrong type, expected NumericWide but got %q", wf.Meta.Type)

--- a/experimental/sdata/reader/play_test.go
+++ b/experimental/sdata/reader/play_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCanReadBasedOnMeta(t *testing.T) {
 	t.Run("basic test", func(t *testing.T) {
-		tsWideNoData, err := timeseries.NewWideFrame(timeseries.WideFrameVersionLatest)
+		tsWideNoData, err := timeseries.NewWideFrame("A", timeseries.WideFrameVersionLatest)
 		require.NoError(t, err)
 
 		kind, err := reader.CanReadBasedOnMeta(tsWideNoData.Frames())
@@ -26,7 +26,7 @@ func TestCanReadBasedOnMeta(t *testing.T) {
 	})
 
 	t.Run("read something", func(t *testing.T) {
-		n, err := numeric.NewWideFrame(numeric.WideFrameVersionLatest)
+		n, err := numeric.NewWideFrame("A", numeric.WideFrameVersionLatest)
 		require.NoError(t, err)
 
 		err = n.AddMetric("cpu", data.Labels{"host": "king_sloth"}, 5.3)

--- a/experimental/sdata/timeseries/long.go
+++ b/experimental/sdata/timeseries/long.go
@@ -19,11 +19,11 @@ func LongFrameVersions() []data.FrameTypeVersion {
 	return []data.FrameTypeVersion{{0, 1}}
 }
 
-func NewLongFrame(v data.FrameTypeVersion) (*LongFrame, error) {
+func NewLongFrame(refID string, v data.FrameTypeVersion) (*LongFrame, error) {
 	if v.Greater(LongFrameVersionLatest) {
 		return nil, fmt.Errorf("can not create LongFrame of version %s because it is newer than library version %v", v, LongFrameVersionLatest)
 	}
-	return &LongFrame{emptyFrameWithTypeMD(data.FrameTypeTimeSeriesLong, v)}, nil
+	return &LongFrame{emptyFrameWithTypeMD(refID, data.FrameTypeTimeSeriesLong, v)}, nil
 }
 
 func (ls *LongFrame) GetCollection(validateData bool) (Collection, error) {
@@ -44,6 +44,8 @@ func validateAndGetRefsLong(ls *LongFrame, validateData, getRefs bool) (Collecti
 	if frame == nil {
 		return c, fmt.Errorf("frame 0 must not be nil")
 	}
+
+	c.RefID = frame.RefID
 
 	if !frameHasType(frame, data.FrameTypeTimeSeriesLong) {
 		return c, fmt.Errorf("frame 0 is missing long type indicator")

--- a/experimental/sdata/timeseries/multi_test.go
+++ b/experimental/sdata/timeseries/multi_test.go
@@ -21,7 +21,7 @@ func TestMultiFrameSeriesValidate_ValidCases(t *testing.T) {
 		{
 			name: "frame with no fields is valid (empty response)",
 			mfs: func() *timeseries.MultiFrame {
-				s, err := timeseries.NewMultiFrame(timeseries.WideFrameVersionLatest)
+				s, err := timeseries.NewMultiFrame("A", timeseries.WideFrameVersionLatest)
 				require.NoError(t, err)
 				return s
 			},
@@ -29,7 +29,7 @@ func TestMultiFrameSeriesValidate_ValidCases(t *testing.T) {
 		{
 			name: "basic example",
 			mfs: func() *timeseries.MultiFrame {
-				s, err := timeseries.NewMultiFrame(timeseries.WideFrameVersionLatest)
+				s, err := timeseries.NewMultiFrame("A", timeseries.WideFrameVersionLatest)
 				require.NoError(t, err)
 
 				err = s.AddSeries("one", nil, []time.Time{{}, time.Now().Add(time.Second)}, []float64{0, 1})
@@ -43,7 +43,7 @@ func TestMultiFrameSeriesValidate_ValidCases(t *testing.T) {
 		{
 			name: "there can be extraneous fields (but they have no specific platform-wide meaning)",
 			mfs: func() *timeseries.MultiFrame {
-				s, err := timeseries.NewMultiFrame(timeseries.WideFrameVersionLatest)
+				s, err := timeseries.NewMultiFrame("A", timeseries.WideFrameVersionLatest)
 				require.NoError(t, err)
 
 				err = s.AddSeries("one", nil, []time.Time{{}, time.Now().Add(time.Second)}, []float64{0, 1})
@@ -157,7 +157,7 @@ var _ = emptyFrameWithTypeMD(data.FrameTypeUnknown, data.FrameTypeVersion{0, 0})
 
 func TestMultiFrameSeriesGetMetricRefs_Empty_Invalid_Edge_Cases(t *testing.T) {
 	t.Run("empty response reads as zero length metric refs and nil ignoredFields", func(t *testing.T) {
-		s, err := timeseries.NewMultiFrame(timeseries.WideFrameVersionLatest)
+		s, err := timeseries.NewMultiFrame("A", timeseries.WideFrameVersionLatest)
 		require.NoError(t, err)
 
 		c, err := s.GetCollection(true)
@@ -169,7 +169,7 @@ func TestMultiFrameSeriesGetMetricRefs_Empty_Invalid_Edge_Cases(t *testing.T) {
 	})
 
 	t.Run("empty response frame with an additional frames cause additional frames to be ignored", func(t *testing.T) {
-		s, err := timeseries.NewMultiFrame(timeseries.WideFrameVersionLatest)
+		s, err := timeseries.NewMultiFrame("A", timeseries.WideFrameVersionLatest)
 		require.NoError(t, err)
 
 		// (s.AddMetric) would alter the first frame which would be the "right thing" to do.
@@ -199,7 +199,7 @@ func TestMultiFrameSeriesGetMetricRefs_Empty_Invalid_Edge_Cases(t *testing.T) {
 	})
 
 	t.Run("a nil frame (a nil entry in slice of frames (very odd)), is not a valid in a response", func(t *testing.T) {
-		s, err := timeseries.NewMultiFrame(timeseries.WideFrameVersionLatest)
+		s, err := timeseries.NewMultiFrame("A", timeseries.WideFrameVersionLatest)
 		require.NoError(t, err)
 		*s = append(*s, nil)
 

--- a/experimental/sdata/timeseries/series.go
+++ b/experimental/sdata/timeseries/series.go
@@ -29,6 +29,7 @@ type MetricRef struct {
 }
 
 type Collection struct {
+	RefID            string
 	Refs             []MetricRef
 	RemainderIndices []sdata.FrameFieldIndex
 	Warning          error

--- a/experimental/sdata/timeseries/series_test.go
+++ b/experimental/sdata/timeseries/series_test.go
@@ -29,7 +29,7 @@ func TestSeriesCollectionReaderInterface(t *testing.T) {
 	}
 
 	t.Run("multi frame", func(t *testing.T) {
-		sc, err := timeseries.NewMultiFrame(timeseries.WideFrameVersionLatest)
+		sc, err := timeseries.NewMultiFrame("A", timeseries.WideFrameVersionLatest)
 		require.NoError(t, err)
 
 		err = sc.AddSeries(metricName, data.Labels{"host": "a"}, timeSlice, valuesA)
@@ -49,7 +49,7 @@ func TestSeriesCollectionReaderInterface(t *testing.T) {
 	})
 
 	t.Run("wide frame", func(t *testing.T) {
-		sc, err := timeseries.NewWideFrame(timeseries.WideFrameVersionLatest)
+		sc, err := timeseries.NewWideFrame("B", timeseries.WideFrameVersionLatest)
 		require.NoError(t, err)
 
 		err = sc.SetTime("time", timeSlice)
@@ -101,13 +101,13 @@ func TestEmptyFromNew(t *testing.T) {
 	var multi, wide, long timeseries.CollectionReader
 	var err error
 
-	multi, err = timeseries.NewMultiFrame(timeseries.MultiFrameVersionLatest)
+	multi, err = timeseries.NewMultiFrame("A", timeseries.MultiFrameVersionLatest)
 	require.NoError(t, err)
 
-	wide, err = timeseries.NewWideFrame(timeseries.WideFrameVersionLatest)
+	wide, err = timeseries.NewWideFrame("B", timeseries.WideFrameVersionLatest)
 	require.NoError(t, err)
 
-	long, err = timeseries.NewLongFrame(timeseries.LongFrameVersionLatest)
+	long, err = timeseries.NewLongFrame("C", timeseries.LongFrameVersionLatest)
 	require.NoError(t, err)
 
 	emptyReqs := func(c timeseries.Collection, err error) {

--- a/experimental/sdata/timeseries/util.go
+++ b/experimental/sdata/timeseries/util.go
@@ -8,8 +8,10 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
 )
 
-func emptyFrameWithTypeMD(t data.FrameType, v data.FrameTypeVersion) *data.Frame {
-	return data.NewFrame("").SetMeta(&data.FrameMeta{Type: t, TypeVersion: v})
+func emptyFrameWithTypeMD(refId string, t data.FrameType, v data.FrameTypeVersion) *data.Frame {
+	f := data.NewFrame("").SetMeta(&data.FrameMeta{Type: t, TypeVersion: v})
+	f.RefID = refId
+	return f
 }
 
 func frameHasType(f *data.Frame, t data.FrameType) bool {

--- a/experimental/sdata/timeseries/util.go
+++ b/experimental/sdata/timeseries/util.go
@@ -8,9 +8,9 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/sdata"
 )
 
-func emptyFrameWithTypeMD(refId string, t data.FrameType, v data.FrameTypeVersion) *data.Frame {
+func emptyFrameWithTypeMD(refID string, t data.FrameType, v data.FrameTypeVersion) *data.Frame {
 	f := data.NewFrame("").SetMeta(&data.FrameMeta{Type: t, TypeVersion: v})
-	f.RefID = refId
+	f.RefID = refID
 	return f
 }
 

--- a/experimental/sdata/timeseries/wide.go
+++ b/experimental/sdata/timeseries/wide.go
@@ -19,11 +19,12 @@ func WideFrameVersions() []data.FrameTypeVersion {
 	return []data.FrameTypeVersion{{0, 1}}
 }
 
-func NewWideFrame(v data.FrameTypeVersion) (*WideFrame, error) {
+func NewWideFrame(refID string, v data.FrameTypeVersion) (*WideFrame, error) {
 	if v.Greater(WideFrameVersionLatest) {
 		return nil, fmt.Errorf("can not create WideFrame of version %s because it is newer than library version %v", v, WideFrameVersionLatest)
 	}
 	f := data.NewFrame("")
+	f.RefID = refID
 	f.SetMeta(&data.FrameMeta{Type: data.FrameTypeTimeSeriesWide, TypeVersion: v})
 	return &WideFrame{f}, nil
 }
@@ -114,6 +115,8 @@ func validateAndGetRefsWide(wf *WideFrame, validateData bool) (Collection, error
 	if frame == nil {
 		return c, fmt.Errorf("frame is nil which is invalid")
 	}
+
+	c.RefID = frame.RefID
 
 	if !frameHasType(frame, data.FrameTypeTimeSeriesWide) {
 		return c, fmt.Errorf("frame has wrong type, expected TimeSeriesWide but got %q", frame.Meta.Type)

--- a/experimental/sdata/timeseries/wide_test.go
+++ b/experimental/sdata/timeseries/wide_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestWideFrameAddMetric_ValidCases(t *testing.T) {
 	t.Run("add two metrics", func(t *testing.T) {
-		wf, err := timeseries.NewWideFrame(timeseries.WideFrameVersionLatest)
+		wf, err := timeseries.NewWideFrame("A", timeseries.WideFrameVersionLatest)
 		require.NoError(t, err)
 
 		err = wf.SetTime("time", []time.Time{time.UnixMilli(1), time.UnixMilli(2)})
@@ -30,6 +30,8 @@ func TestWideFrameAddMetric_ValidCases(t *testing.T) {
 			data.NewField("one", data.Labels{"host": "b"}, []float64{3, 4}),
 		).SetMeta(&data.FrameMeta{Type: data.FrameTypeTimeSeriesWide, TypeVersion: data.FrameTypeVersion{0, 1}})
 
+		expectedFrame.RefID = "A"
+
 		if diff := cmp.Diff(expectedFrame, (*wf)[0], data.FrameTestCompareOptions()...); diff != "" {
 			require.FailNow(t, "mismatch (-want +got):\n%s\n", diff)
 		}
@@ -38,7 +40,7 @@ func TestWideFrameAddMetric_ValidCases(t *testing.T) {
 
 func TestWideFrameSeriesGetMetricRefs(t *testing.T) {
 	t.Run("two metrics from wide to multi", func(t *testing.T) {
-		wf, err := timeseries.NewWideFrame(timeseries.WideFrameVersionLatest)
+		wf, err := timeseries.NewWideFrame("A", timeseries.WideFrameVersionLatest)
 		require.NoError(t, err)
 
 		err = wf.SetTime("time", []time.Time{time.UnixMilli(1), time.UnixMilli(2)})


### PR DESCRIPTION
This makes it so Frames are creating with a RefID which was skipped before. 

We do insert this in other parts of the SDK for datasources, but probably better to keep it clear, and I need to specify it in SSE.