### PR TITLE
CODEOWNERS: Set dataplane wg to own experimental/sdata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone opens a pull request.
 * @grafana/plugins-platform-backend
-/data @grafana/data-plane-wg
-/experimental/sdata @grafana/data-plane-wg
+/data/ @grafana/data-plane-wg
+/experimental/sdata/ @grafana/data-plane-wg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 # these will be requested for review when someone opens a pull request.
 * @grafana/plugins-platform-backend
 data @grafana/data-plane-wg
+experimental/sdata @grafana/data-plane-wg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone opens a pull request.
 * @grafana/plugins-platform-backend
-data @grafana/data-plane-wg
-experimental/sdata @grafana/data-plane-wg
+/data @grafana/data-plane-wg
+/experimental/sdata @grafana/data-plane-wg


### PR DESCRIPTION
Also fix paths

> ```
> # In this example, @octocat owns any file in an apps directory
> # anywhere in your repository.
> apps/ @octocat
> 
> # In this example, @doctocat owns any file in the `/docs`
> # directory in the root of your repository and any of its
> # subdirectories.
> /docs/ @doctocat
> ```