### PR TITLE
allow sql.NullX types as valid convertable values

### DIFF
--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -155,7 +156,8 @@ func DefaultConverterFunc(t reflect.Type) func(in interface{}) (interface{}, err
 // NewDefaultConverter creates a Converter that assumes that the value is scannable into a String, and placed into the dataframe as a nullable string.
 func NewDefaultConverter(name string, nullable bool, t reflect.Type) Converter {
 	slice := reflect.MakeSlice(reflect.SliceOf(t), 0, 0).Interface()
-	if !data.ValidFieldType(slice) {
+	kind := fmt.Sprint(t)
+	if !strings.HasPrefix(kind, "sql.Null") && !data.ValidFieldType(slice) {
 		return Converter{
 			Name:          fmt.Sprintf("[%s] String converter", t),
 			InputScanType: reflect.TypeOf(sql.NullString{}),
@@ -283,6 +285,26 @@ var (
 		},
 	}
 
+	// NullInt16Converter creates a *int16 using the scan type of `sql.NullInt16`
+	NullInt16Converter = Converter{
+		Name:          "NULLABLE int16 converter",
+		InputScanType: reflect.TypeOf(sql.NullInt16{}),
+		InputTypeName: "INTEGER",
+		FrameConverter: FrameConverter{
+			FieldType: data.FieldTypeNullableInt16,
+			ConverterFunc: func(n any) (any, error) {
+				v := n.(*sql.NullInt16)
+
+				if !v.Valid {
+					return (*int16)(nil), nil
+				}
+
+				f := v.Int16
+				return &f, nil
+			},
+		},
+	}
+
 	// NullTimeConverter creates a *time.time using the scan type of `sql.NullTime`
 	NullTimeConverter = Converter{
 		Name:          "NULLABLE time.Time converter",
@@ -321,17 +343,45 @@ var (
 			},
 		},
 	}
+
+	// NullByteConverter creates a *string using the scan type of `sql.NullByte`
+	NullByteConverter = Converter{
+		Name:          "nullable byte converter",
+		InputScanType: reflect.TypeOf(sql.NullByte{}),
+		InputTypeName: "BYTE",
+		FrameConverter: FrameConverter{
+			FieldType: data.FieldTypeNullableString,
+			ConverterFunc: func(n any) (any, error) {
+				v := n.(*sql.NullByte)
+
+				if !v.Valid {
+					return (*string)(nil), nil
+				}
+
+				val := string(v.Byte)
+				return &val, nil
+			},
+		},
+	}
 )
 
 // NullConverters is a map of data type names (from reflect.TypeOf(...).String()) to converters
 // Converters supplied here are used as defaults for fields that do not have a supplied Converter
 var NullConverters = map[reflect.Type]Converter{
-	reflect.TypeOf(float64(0)):  NullDecimalConverter,
-	reflect.TypeOf(int64(0)):    NullInt64Converter,
-	reflect.TypeOf(int32(0)):    NullInt32Converter,
-	reflect.TypeOf(""):          NullStringConverter,
-	reflect.TypeOf(time.Time{}): NullTimeConverter,
-	reflect.TypeOf(false):       NullBoolConverter,
+	reflect.TypeOf(float64(0)):        NullDecimalConverter,
+	reflect.TypeOf(int64(0)):          NullInt64Converter,
+	reflect.TypeOf(int32(0)):          NullInt32Converter,
+	reflect.TypeOf(""):                NullStringConverter,
+	reflect.TypeOf(time.Time{}):       NullTimeConverter,
+	reflect.TypeOf(false):             NullBoolConverter,
+	reflect.TypeOf(sql.NullFloat64{}): NullDecimalConverter,
+	reflect.TypeOf(sql.NullTime{}):    NullTimeConverter,
+	reflect.TypeOf(sql.NullBool{}):    NullBoolConverter,
+	reflect.TypeOf(sql.NullInt64{}):   NullInt64Converter,
+	reflect.TypeOf(sql.NullInt32{}):   NullInt32Converter,
+	reflect.TypeOf(sql.NullInt16{}):   NullInt16Converter,
+	reflect.TypeOf(sql.NullByte{}):    NullByteConverter,
+	reflect.TypeOf(sql.NullString{}):  NullStringConverter,
 }
 
 // IntOrFloatToNullableFloat64 returns an error if the input is not a variation of int or float.

--- a/data/sqlutil/converter_test.go
+++ b/data/sqlutil/converter_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -98,6 +99,61 @@ func TestDefaultConverter(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:     "nullable sql bool",
+			Type:     reflect.TypeOf(sql.NullBool{}),
+			Nullable: true,
+			Expected: sqlutil.Converter{
+				InputScanType: reflect.TypeOf(sql.NullBool{}),
+				FrameConverter: sqlutil.FrameConverter{
+					FieldType: data.FieldTypeBool.NullableType(),
+				},
+			},
+		},
+		{
+			Name:     "nullable sql float",
+			Type:     reflect.TypeOf(sql.NullFloat64{}),
+			Nullable: true,
+			Expected: sqlutil.Converter{
+				InputScanType: reflect.TypeOf(sql.NullFloat64{}),
+				FrameConverter: sqlutil.FrameConverter{
+					FieldType: data.FieldTypeFloat64.NullableType(),
+				},
+			},
+		},
+		{
+			Name:     "nullable sql string",
+			Type:     reflect.TypeOf(sql.NullString{}),
+			Nullable: true,
+			Expected: sqlutil.Converter{
+				InputScanType: reflect.TypeOf(sql.NullString{}),
+				FrameConverter: sqlutil.FrameConverter{
+					FieldType: data.FieldTypeString.NullableType(),
+				},
+			},
+		},
+		{
+			Name:     "nullable sql time",
+			Type:     reflect.TypeOf(sql.NullTime{}),
+			Nullable: true,
+			Expected: sqlutil.Converter{
+				InputScanType: reflect.TypeOf(sql.NullTime{}),
+				FrameConverter: sqlutil.FrameConverter{
+					FieldType: data.FieldTypeTime.NullableType(),
+				},
+			},
+		},
+		{
+			Name:     "nullable sql time",
+			Type:     reflect.TypeOf(sql.NullInt64{}),
+			Nullable: true,
+			Expected: sqlutil.Converter{
+				InputScanType: reflect.TypeOf(sql.NullInt64{}),
+				FrameConverter: sqlutil.FrameConverter{
+					FieldType: data.FieldTypeInt64.NullableType(),
+				},
+			},
+		},
 	}
 
 	for i, v := range suite {
@@ -116,7 +172,15 @@ func TestDefaultConverter(t *testing.T) {
 					assert.Equal(t, reflect.TypeOf(value).String(), v.Type.String())
 				} else {
 					// nullable fields should not exactly match
-					assert.Equal(t, reflect.TypeOf(value).String(), reflect.PtrTo(v.Type).String())
+					kind := reflect.PtrTo(v.Type).String()
+					valueKind := reflect.TypeOf(value).String()
+					if !strings.HasPrefix(kind, "*sql.Null") {
+						assert.Equal(t, valueKind, kind)
+					} else {
+						valueType := strings.Replace(valueKind, "*", "", 1)
+						valueType = strings.Split(valueType, ".")[0]
+						assert.Contains(t, strings.ToLower(kind), valueType)
+					}
 				}
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
allows sql.NullX types as valid convertible values

**Which issue(s) this PR fixes**:
Ref # https://github.com/grafana/support-escalations/issues/4923

**Special notes for your reviewer**:
Some drivers return these sql types instead of native go types.