### PR TITLE
Fix go manifest permissions

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -191,7 +191,8 @@ func (Build) GenerateManifestFile() error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(manifestFilePath, []byte(manifestContent), 0600)
+	// #nosec G306 - we need reading permissions for this file
+	err = os.WriteFile(manifestFilePath, []byte(manifestContent), 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Fixes a problem where the go manifest file is generated with too low permissions and grafana instances can not load it if they run in a different group than the installer

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
