### PR TITLE
logs contract: more robust field finding, explicit approach

### DIFF
--- a/data/contract_docs/logs.md
+++ b/data/contract_docs/logs.md
@@ -17,10 +17,12 @@ Version: 0.0
   - There must be at least one non nullable time field
   - If there are multiple time fields present, following will decide the priority
     - First matching time field with name `timestamp`
+      - If there are multiple time fields, and none of them is named `timestamp`, it is considered an error.
 - **Message field** - _required_
   - There must be at lease one non nullable string field must present
   - If more than one string fields found, the following will decide the priority
     - First matching string field with name `body`
+      - If there are multiple string fields, and none of them is named `body`, it is considered an error.
 - **Severity field** - _optional_
   - This is optional field
   - Level/Severity of the log line can be represented with this field.


### PR DESCRIPTION
(there are two approaches, i created two PRs for the two approaches. this one, and https://github.com/grafana/grafana-plugin-sdk-go/pull/661. we should only merge one of them)

this PR clarifies a corner-case that can happen when finding the `timestamp` and the `message` field.

(please note, both the `severity` and `id` fields are string-fields, so as soon as any of these two is added to the dataframe, we will hit the "two string fields" situation.)

pro: explicit about what happens when more than one string fields exist
con: non backward-compatible (for example, Loki&Elastic dataframes simply make sure the message field is the first string field)