### PR TITLE
logs contract: more robust field finding, backward compatible approach

### DIFF
--- a/data/contract_docs/logs.md
+++ b/data/contract_docs/logs.md
@@ -15,12 +15,10 @@ Version: 0.0
 
 - **Time field** - _required_
   - There must be at least one non nullable time field
-  - If there are multiple time fields present, following will decide the priority
-    - First matching time field with name `timestamp`
+  - The first non nullable time field is chosen
 - **Message field** - _required_
   - There must be at lease one non nullable string field must present
-  - If more than one string fields found, the following will decide the priority
-    - First matching string field with name `body`
+  - The first non nullable string field is chosen
 - **Severity field** - _optional_
   - This is optional field
   - Level/Severity of the log line can be represented with this field.


### PR DESCRIPTION
(there are two approaches, i created two PRs for the two approaches. this one, and https://github.com/grafana/grafana-plugin-sdk-go/pull/660. we should only merge on of them)

this PR adjusts the `timestamp` and `message` field finding so that it is the same as used currently in the grafana-logs-visualization.
pro: this makes it more backward compatible
con: someone can make a dataframe, where there will be 2 string fields, `id` and `message`, and if the `id` field goes first, it will be mistaken for the log-message-field. 

