### PR TITLE
Add secure socks proxy to sdk

### DIFF
--- a/backend/http_settings.go
+++ b/backend/http_settings.go
@@ -45,6 +45,8 @@ type HTTPSettings struct {
 	SigV4AccessKey     string
 	SigV4SecretKey     string
 
+	SecureSocksProxyEnabled bool
+
 	JSONData       map[string]interface{}
 	SecureJSONData map[string]string
 }
@@ -52,9 +54,10 @@ type HTTPSettings struct {
 // HTTPClientOptions creates and returns httpclient.Options.
 func (s *HTTPSettings) HTTPClientOptions() httpclient.Options {
 	opts := httpclient.Options{
-		Headers:       s.Headers,
-		Labels:        map[string]string{},
-		CustomOptions: map[string]interface{}{},
+		Headers:                 s.Headers,
+		Labels:                  map[string]string{},
+		CustomOptions:           map[string]interface{}{},
+		SecureSocksProxyEnabled: s.SecureSocksProxyEnabled,
 	}
 
 	opts.Timeouts = &httpclient.TimeoutOptions{
@@ -263,6 +266,11 @@ func parseHTTPSettings(jsonData json.RawMessage, secureJSONData map[string]strin
 		if v, exists := secureJSONData["sigV4SecretKey"]; exists {
 			s.SigV4SecretKey = v
 		}
+	}
+
+	// secure socks proxy
+	if v, exists := dat["enableSecureSocksProxy"]; exists {
+		s.SecureSocksProxyEnabled = v.(bool)
 	}
 
 	// headers

--- a/backend/http_settings.go
+++ b/backend/http_settings.go
@@ -105,7 +105,7 @@ func (s *HTTPSettings) HTTPClientOptions() httpclient.Options {
 
 	if s.SecureSocksProxyEnabled {
 		opts.ProxyOptions = &proxy.Options{
-			EnabledOnDS: s.SecureSocksProxyEnabled,
+			Enabled: s.SecureSocksProxyEnabled,
 			Timeouts: &proxy.TimeoutOptions{
 				Timeout:   s.Timeout,
 				KeepAlive: s.KeepAlive,

--- a/backend/http_settings.go
+++ b/backend/http_settings.go
@@ -294,7 +294,7 @@ func parseHTTPSettings(jsonData json.RawMessage, secureJSONData map[string]strin
 			s.SecureSocksProxyUsername = v.(string)
 		}
 		if v, exists := secureJSONData["secureSocksProxyPassword"]; exists {
-			s.SecureSocksProxyUsername = v
+			s.SecureSocksProxyPass = v
 		}
 	}
 

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -86,11 +86,9 @@ func GetTransport(opts ...Options) (http.RoundTripper, error) {
 		clientOpts.Middlewares = clientOpts.ConfigureMiddleware(clientOpts, clientOpts.Middlewares)
 	}
 
-	if proxy.SecureSocksProxyEnabled(clientOpts.ProxyOptions) {
-		err = proxy.NewSecureSocksHTTPProxy(transport, clientOpts.ProxyOptions)
-		if err != nil {
-			return nil, err
-		}
+	err = proxy.ConfigureSecureSocksHTTPProxy(transport, clientOpts.ProxyOptions)
+	if err != nil {
+		return nil, err
 	}
 
 	return roundTripperFromMiddlewares(clientOpts, clientOpts.Middlewares, transport), nil

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -87,7 +87,13 @@ func GetTransport(opts ...Options) (http.RoundTripper, error) {
 	}
 
 	if proxy.SecureSocksProxyEnabled() && clientOpts.SecureSocksProxyEnabled {
-		err = proxy.NewSecureSocksHTTPProxy(transport, clientOpts.Labels["datasource_uid"])
+		err = proxy.NewSecureSocksHTTPProxy(transport,
+			&proxy.Options{
+				KeepAlive: clientOpts.Timeouts.KeepAlive,
+				Timeout:   clientOpts.Timeouts.Timeout,
+			},
+			clientOpts.Labels["datasource_uid"],
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"net"
 	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 )
 
 // New creates a new http.Client.
@@ -82,6 +84,13 @@ func GetTransport(opts ...Options) (http.RoundTripper, error) {
 
 	if clientOpts.ConfigureMiddleware != nil {
 		clientOpts.Middlewares = clientOpts.ConfigureMiddleware(clientOpts, clientOpts.Middlewares)
+	}
+
+	if proxy.SecureSocksProxyEnabled(nil) && clientOpts.SecureSocksProxyEnabled {
+		err = proxy.NewSecureSocksHTTPProxy(nil, transport, clientOpts.Labels["datasource_uid"])
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return roundTripperFromMiddlewares(clientOpts, clientOpts.Middlewares, transport), nil

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -86,8 +86,8 @@ func GetTransport(opts ...Options) (http.RoundTripper, error) {
 		clientOpts.Middlewares = clientOpts.ConfigureMiddleware(clientOpts, clientOpts.Middlewares)
 	}
 
-	if proxy.SecureSocksProxyEnabled(nil) && clientOpts.SecureSocksProxyEnabled {
-		err = proxy.NewSecureSocksHTTPProxy(nil, transport, clientOpts.Labels["datasource_uid"])
+	if proxy.SecureSocksProxyEnabled() && clientOpts.SecureSocksProxyEnabled {
+		err = proxy.NewSecureSocksHTTPProxy(transport, clientOpts.Labels["datasource_uid"])
 		if err != nil {
 			return nil, err
 		}

--- a/backend/httpclient/options.go
+++ b/backend/httpclient/options.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"net/http"
 	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 )
 
 // ConfigureClientFunc function signature for configuring http.Client.
@@ -30,8 +32,8 @@ type Options struct {
 	TLS   *TLSOptions
 	SigV4 *SigV4Config
 
-	// Secure socks proxy related option.
-	SecureSocksProxyEnabled bool
+	// Proxy related options.
+	ProxyOptions *proxy.Options
 
 	// Headers custom headers.
 	Headers map[string]string

--- a/backend/httpclient/options.go
+++ b/backend/httpclient/options.go
@@ -30,6 +30,9 @@ type Options struct {
 	TLS   *TLSOptions
 	SigV4 *SigV4Config
 
+	// Secure socks proxy related option.
+	SecureSocksProxyEnabled bool
+
 	// Headers custom headers.
 	Headers map[string]string
 

--- a/backend/proxy/doc.go
+++ b/backend/proxy/doc.go
@@ -1,0 +1,2 @@
+// Package proxy provides utilities for updating a data source plugin connection to go through a proxy.
+package proxy

--- a/backend/proxy/options.go
+++ b/backend/proxy/options.go
@@ -2,22 +2,42 @@ package proxy
 
 import "time"
 
-// Options defines options for creating the proxy dialer.
+// Options defines per datasource options for creating the proxy dialer.
 type Options struct {
+	EnabledOnDS bool
+	Auth        *AuthOptions
+	Timeouts    *TimeoutOptions
+}
+
+// AuthOptions socks5 username and password options.
+// Every datasource can have separate credentials to the proxy.
+type AuthOptions struct {
+	Username string
+	Password string
+}
+
+// TimeoutOptions timeout/connection options.
+type TimeoutOptions struct {
 	Timeout   time.Duration
 	KeepAlive time.Duration
 }
 
-// DefaultOptions default timeout/connection options for the proxy.
-var DefaultOptions = Options{
-	Timeout:   180 * time.Second,
+// DefaultTimeoutOptions default timeout/connection options for the proxy.
+var DefaultTimeoutOptions = TimeoutOptions{
+	Timeout:   30 * time.Second,
 	KeepAlive: 30 * time.Second,
 }
 
 func createOptions(providedOpts *Options) Options {
+	var opts Options
 	if providedOpts == nil {
-		return DefaultOptions
+		return opts
 	}
 
-	return *providedOpts
+	opts = *providedOpts
+	if opts.Timeouts == nil {
+		opts.Timeouts = &DefaultTimeoutOptions
+	}
+
+	return opts
 }

--- a/backend/proxy/options.go
+++ b/backend/proxy/options.go
@@ -1,0 +1,23 @@
+package proxy
+
+import "time"
+
+// Options defines options for creating the proxy dialer.
+type Options struct {
+	Timeout   time.Duration
+	KeepAlive time.Duration
+}
+
+// DefaultOptions default timeout/connection options for the proxy.
+var DefaultOptions = Options{
+	Timeout:   180 * time.Second,
+	KeepAlive: 30 * time.Second,
+}
+
+func createOptions(providedOpts *Options) Options {
+	if providedOpts == nil {
+		return DefaultOptions
+	}
+
+	return *providedOpts
+}

--- a/backend/proxy/options.go
+++ b/backend/proxy/options.go
@@ -4,9 +4,9 @@ import "time"
 
 // Options defines per datasource options for creating the proxy dialer.
 type Options struct {
-	EnabledOnDS bool
-	Auth        *AuthOptions
-	Timeouts    *TimeoutOptions
+	Enabled  bool
+	Auth     *AuthOptions
+	Timeouts *TimeoutOptions
 }
 
 // AuthOptions socks5 username and password options.

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -1,0 +1,162 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"golang.org/x/net/proxy"
+)
+
+var (
+	PluginSecureSocksProxyClientCert   = "GF_SECURE_SOCKS_DATASOURCE_PROXY_CLIENT_CERT"
+	PluginSecureSocksProxyClientKey    = "GF_SECURE_SOCKS_DATASOURCE_PROXY_CLIENT_KEY"
+	PluginSecureSocksProxyRootCACert   = "GF_SECURE_SOCKS_DATASOURCE_PROXY_ROOT_CA_CERT"
+	PluginSecureSocksProxyProxyAddress = "GF_SECURE_SOCKS_DATASOURCE_PROXY_PROXY_ADDRESS"
+	PluginSecureSocksProxyServerName   = "GF_SECURE_SOCKS_DATASOURCE_PROXY_SERVER_NAME"
+	PluginSecureSocksProxyEnabled      = "GF_SECURE_SOCKS_DATASOURCE_PROXY_SERVER_ENABLED"
+)
+
+type secureSocksConfig struct {
+	clientCert   string
+	clientKey    string
+	rootCA       string
+	proxyAddress string
+	serverName   string
+}
+
+func SecureSocksProxyEnabled() bool {
+	if value, ok := os.LookupEnv(PluginSecureSocksProxyEnabled); ok {
+		res, err := strconv.ParseBool(value)
+		if err != nil {
+			return false
+		}
+
+		return res
+	}
+
+	return false
+}
+
+// NewSecureSocksHTTPProxy takes a http.DefaultTransport and wraps it in a socks5 proxy with TLS
+func NewSecureSocksHTTPProxy(transport *http.Transport) error {
+	dialSocksProxy, err := NewSecureSocksProxyContextDialer()
+	if err != nil {
+		return err
+	}
+
+	contextDialer, ok := dialSocksProxy.(proxy.ContextDialer)
+	if !ok {
+		return errors.New("unable to cast socks proxy dialer to context proxy dialer")
+	}
+
+	transport.DialContext = contextDialer.DialContext
+	return nil
+}
+
+// NewSecureSocksProxyContextDialer returns a proxy context dialer that will wrap connections in a secure socks proxy
+func NewSecureSocksProxyContextDialer() (proxy.Dialer, error) {
+	cfg, err := getConfigFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	certPool := x509.NewCertPool()
+	for _, rootCAFile := range strings.Split(cfg.rootCA, " ") {
+		// nolint:gosec
+		// The gosec G304 warning can be ignored because `rootCAFile` comes from config ini.
+		pem, err := os.ReadFile(rootCAFile)
+		if err != nil {
+			return nil, err
+		}
+		if !certPool.AppendCertsFromPEM(pem) {
+			return nil, errors.New("failed to append CA certificate " + rootCAFile)
+		}
+	}
+
+	cert, err := tls.LoadX509KeyPair(cfg.clientCert, cfg.clientKey)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsDialer := &tls.Dialer{
+		Config: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			ServerName:   cfg.serverName,
+			RootCAs:      certPool,
+		},
+	}
+	dialSocksProxy, err := proxy.SOCKS5("tcp", cfg.proxyAddress, nil, tlsDialer)
+	if err != nil {
+		return nil, err
+	}
+
+	return dialSocksProxy, nil
+}
+
+// SecureSocksProxyEnabledOnDS checks the datasource json data to see if the secure socks proxy is enabled on it
+func SecureSocksProxyEnabledOnDS(opts sdkhttpclient.Options) bool {
+	jsonData := backend.JSONDataFromHTTPClientOptions(opts)
+	res, enabled := jsonData["enableSecureSocksProxy"]
+	if !enabled {
+		return false
+	}
+
+	if val, ok := res.(bool); ok {
+		return val
+	}
+
+	return false
+}
+
+func getConfigFromEnv() (*secureSocksConfig, error) {
+	clientCert := ""
+	if value, ok := os.LookupEnv(PluginSecureSocksProxyClientCert); ok {
+		clientCert = value
+	} else {
+		return nil, fmt.Errorf("missing client cert")
+	}
+
+	clientKey := ""
+	if value, ok := os.LookupEnv(PluginSecureSocksProxyClientKey); ok {
+		clientKey = value
+	} else {
+		return nil, fmt.Errorf("missing client key")
+	}
+
+	rootCA := ""
+	if value, ok := os.LookupEnv(PluginSecureSocksProxyRootCACert); ok {
+		rootCA = value
+	} else {
+		return nil, fmt.Errorf("missing root ca")
+	}
+
+	proxyAddress := ""
+	if value, ok := os.LookupEnv(PluginSecureSocksProxyProxyAddress); ok {
+		proxyAddress = value
+	} else {
+		return nil, fmt.Errorf("missing proxy address")
+	}
+
+	serverName := ""
+	if value, ok := os.LookupEnv(PluginSecureSocksProxyServerName); ok {
+		serverName = value
+	} else {
+		return nil, fmt.Errorf("missing server name")
+	}
+
+	return &secureSocksConfig{
+		clientCert:   clientCert,
+		clientKey:    clientKey,
+		rootCA:       rootCA,
+		proxyAddress: proxyAddress,
+		serverName:   serverName,
+	}, nil
+}

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -54,7 +54,7 @@ func SecureSocksProxyEnabled(opts *Options) bool {
 		return false
 	}
 
-	if !opts.EnabledOnDS {
+	if !opts.Enabled {
 		return false
 	}
 
@@ -85,8 +85,13 @@ func SecureSocksProxyEnabledOnDS(jsonData map[string]interface{}) bool {
 	return false
 }
 
-// NewSecureSocksHTTPProxy takes a http.DefaultTransport and wraps it in a socks5 proxy with TLS
-func NewSecureSocksHTTPProxy(transport *http.Transport, opts *Options) error {
+// ConfigureSecureSocksHTTPProxy takes a http.DefaultTransport and wraps it in a socks5 proxy with TLS
+// if it is enabled on the datasource and the grafana instance
+func ConfigureSecureSocksHTTPProxy(transport *http.Transport, opts *Options) error {
+	if !SecureSocksProxyEnabled(opts) {
+		return nil
+	}
+
 	dialSocksProxy, err := NewSecureSocksProxyContextDialer(opts)
 	if err != nil {
 		return err

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -48,7 +48,7 @@ type secureSocksProxyConfig struct {
 }
 
 // SecureSocksProxyEnabled checks if the Grafana instance allows the secure socks proxy to be used
-// and datasource specifies to use the proxy
+// and the datasource options specify to use the proxy
 func SecureSocksProxyEnabled(opts *Options) bool {
 	if opts == nil {
 		return false

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -15,14 +15,29 @@ import (
 )
 
 var (
-	PluginSecureSocksProxyEnabled      = "GF_SECURE_SOCKS_DATASOURCE_PROXY_SERVER_ENABLED"
-	PluginSecureSocksProxyClientCert   = "GF_SECURE_SOCKS_DATASOURCE_PROXY_CLIENT_CERT"
-	PluginSecureSocksProxyClientKey    = "GF_SECURE_SOCKS_DATASOURCE_PROXY_CLIENT_KEY"
-	PluginSecureSocksProxyRootCACert   = "GF_SECURE_SOCKS_DATASOURCE_PROXY_ROOT_CA_CERT"
+
+	// PluginSecureSocksProxyEnabled is a constant for the GF_SECURE_SOCKS_DATASOURCE_PROXY_SERVER_ENABLED
+	// environment variable used to specify if a secure socks proxy is allowed to be used for datasource connections.
+	PluginSecureSocksProxyEnabled = "GF_SECURE_SOCKS_DATASOURCE_PROXY_SERVER_ENABLED"
+	// PluginSecureSocksProxyClientCert is a constant for the GF_SECURE_SOCKS_DATASOURCE_PROXY_CLIENT_CERT
+	// environment variable used to specify the file location of the client cert for the secure socks proxy.
+	PluginSecureSocksProxyClientCert = "GF_SECURE_SOCKS_DATASOURCE_PROXY_CLIENT_CERT"
+	// PluginSecureSocksProxyClientKey is a constant for the GF_SECURE_SOCKS_DATASOURCE_PROXY_CLIENT_KEY
+	// environment variable used to specify the file location of the client key for the secure socks proxy.
+	PluginSecureSocksProxyClientKey = "GF_SECURE_SOCKS_DATASOURCE_PROXY_CLIENT_KEY"
+	// PluginSecureSocksProxyRootCACert is a constant for the GF_SECURE_SOCKS_DATASOURCE_PROXY_ROOT_CA_CERT
+	// environment variable used to specify the file location of the root ca for the secure socks proxy.
+	PluginSecureSocksProxyRootCACert = "GF_SECURE_SOCKS_DATASOURCE_PROXY_ROOT_CA_CERT"
+	// PluginSecureSocksProxyProxyAddress is a constant for the GF_SECURE_SOCKS_DATASOURCE_PROXY_PROXY_ADDRESS
+	// environment variable used to specify the secure socks proxy server address to proxy the connections to.
 	PluginSecureSocksProxyProxyAddress = "GF_SECURE_SOCKS_DATASOURCE_PROXY_PROXY_ADDRESS"
-	PluginSecureSocksProxyServerName   = "GF_SECURE_SOCKS_DATASOURCE_PROXY_SERVER_NAME"
+	// PluginSecureSocksProxyServerName is a constant for the GF_SECURE_SOCKS_DATASOURCE_PROXY_SERVER_NAME
+	// environment variable used to specify the server name of the secure socks proxy.
+	PluginSecureSocksProxyServerName = "GF_SECURE_SOCKS_DATASOURCE_PROXY_SERVER_NAME"
 )
 
+// SecureSocksProxyConfig contains the information needed to allow datasource connections to be
+// proxied to a secure socks proxy
 type SecureSocksProxyConfig struct {
 	Enabled      bool
 	ClientCert   string
@@ -51,7 +66,8 @@ func SecureSocksProxyEnabled(cfg *SecureSocksProxyConfig) bool {
 	return false
 }
 
-// SecureSocksProxyEnabledOnDS checks the datasource json data to see if the secure socks proxy is enabled on it
+// SecureSocksProxyEnabledOnDS checks the datasource json data for `enableSecureSocksProxy`
+// to determine if the secure socks proxy should be enabled on it
 func SecureSocksProxyEnabledOnDS(jsonData map[string]interface{}) bool {
 	res, enabled := jsonData["enableSecureSocksProxy"]
 	if !enabled {
@@ -81,7 +97,7 @@ func NewSecureSocksHTTPProxy(cfg *SecureSocksProxyConfig, transport *http.Transp
 	return nil
 }
 
-// NewSecureSocksProxyContextDialer returns a proxy context dialer that will wrap connections in a secure socks proxy
+// NewSecureSocksProxyContextDialer returns a proxy context dialer that can be used to allow datasource connections to go through a secure socks proxy
 func NewSecureSocksProxyContextDialer(cfg *SecureSocksProxyConfig, dsUID string) (proxy.Dialer, error) {
 	var err error
 	// use the config, if passed in, otherwise attempt to get the values from the env
@@ -137,7 +153,7 @@ func NewSecureSocksProxyContextDialer(cfg *SecureSocksProxyConfig, dsUID string)
 	return dialSocksProxy, nil
 }
 
-// getConfigFromEnv gets the proxy information via env variables that were set by Grafana with values from the config ini
+// getConfigFromEnv gets the needed proxy information from the env variables that Grafana set with the values from the config ini
 func getConfigFromEnv() (*SecureSocksProxyConfig, error) {
 	clientCert := ""
 	if value, ok := os.LookupEnv(PluginSecureSocksProxyClientCert); ok {

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -36,7 +36,7 @@ func TestNewSecureSocksProxy(t *testing.T) {
 	os.Setenv(PluginSecureSocksProxyEnabled, "true")
 
 	t.Run("New socks proxy should be properly configured when all settings are valid", func(t *testing.T) {
-		require.NoError(t, NewSecureSocksHTTPProxy(&http.Transport{}, "uid"))
+		require.NoError(t, NewSecureSocksHTTPProxy(&http.Transport{}, &Options{Timeout: time.Duration(30), KeepAlive: time.Duration(15)}, "uid"))
 	})
 
 	t.Run("Client cert must be valid", func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestNewSecureSocksProxy(t *testing.T) {
 			settings.clientCert = clientCertBefore
 			os.Setenv(PluginSecureSocksProxyClientCert, settings.clientCert)
 		})
-		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, "uid"))
+		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, &Options{}, "uid"))
 	})
 
 	t.Run("Client key must be valid", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestNewSecureSocksProxy(t *testing.T) {
 			settings.clientKey = clientKeyBefore
 			os.Setenv(PluginSecureSocksProxyClientKey, settings.clientKey)
 		})
-		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, "uid"))
+		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, &Options{}, "uid"))
 	})
 
 	t.Run("Root CA must be valid", func(t *testing.T) {
@@ -69,7 +69,7 @@ func TestNewSecureSocksProxy(t *testing.T) {
 			settings.rootCA = rootCABefore
 			os.Setenv(PluginSecureSocksProxyRootCACert, settings.rootCA)
 		})
-		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, "uid"))
+		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, &Options{}, "uid"))
 	})
 }
 
@@ -139,7 +139,7 @@ func TestPreventInvalidRootCA(t *testing.T) {
 		})
 		require.NoError(t, err)
 		os.Setenv(PluginSecureSocksProxyRootCACert, rootCACert)
-		_, err = NewSecureSocksProxyContextDialer("test")
+		_, err = NewSecureSocksProxyContextDialer("test", nil)
 		require.Contains(t, err.Error(), "root ca is invalid")
 	})
 	t.Run("root ca has to have valid content", func(t *testing.T) {
@@ -147,7 +147,7 @@ func TestPreventInvalidRootCA(t *testing.T) {
 		err := os.WriteFile(rootCACert, []byte("this is not a pem encoded file"), fs.ModeAppend)
 		require.NoError(t, err)
 		os.Setenv(PluginSecureSocksProxyRootCACert, rootCACert)
-		_, err = NewSecureSocksProxyContextDialer("test")
+		_, err = NewSecureSocksProxyContextDialer("test", nil)
 		require.Contains(t, err.Error(), "root ca is invalid")
 	})
 }

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -28,11 +28,11 @@ func TestNewSecureSocksProxy(t *testing.T) {
 	// The gosec G304 warning can be ignored because all values come from the test
 	_, err := os.Create(tempEmptyFile)
 	require.NoError(t, err)
-	os.Setenv(PluginSecureSocksProxyClientCert, settings.ClientCert)
-	os.Setenv(PluginSecureSocksProxyClientKey, settings.ClientKey)
-	os.Setenv(PluginSecureSocksProxyRootCACert, settings.RootCA)
-	os.Setenv(PluginSecureSocksProxyProxyAddress, settings.ProxyAddress)
-	os.Setenv(PluginSecureSocksProxyServerName, settings.ServerName)
+	os.Setenv(PluginSecureSocksProxyClientCert, settings.clientCert)
+	os.Setenv(PluginSecureSocksProxyClientKey, settings.clientKey)
+	os.Setenv(PluginSecureSocksProxyRootCACert, settings.rootCA)
+	os.Setenv(PluginSecureSocksProxyProxyAddress, settings.proxyAddress)
+	os.Setenv(PluginSecureSocksProxyServerName, settings.serverName)
 	os.Setenv(PluginSecureSocksProxyEnabled, "true")
 
 	t.Run("New socks proxy should be properly configured when all settings are valid", func(t *testing.T) {
@@ -40,34 +40,34 @@ func TestNewSecureSocksProxy(t *testing.T) {
 	})
 
 	t.Run("Client cert must be valid", func(t *testing.T) {
-		clientCertBefore := settings.ClientCert
-		settings.ClientCert = tempEmptyFile
-		os.Setenv(PluginSecureSocksProxyClientCert, settings.ClientCert)
+		clientCertBefore := settings.clientCert
+		settings.clientCert = tempEmptyFile
+		os.Setenv(PluginSecureSocksProxyClientCert, settings.clientCert)
 		t.Cleanup(func() {
-			settings.ClientCert = clientCertBefore
-			os.Setenv(PluginSecureSocksProxyClientCert, settings.ClientCert)
+			settings.clientCert = clientCertBefore
+			os.Setenv(PluginSecureSocksProxyClientCert, settings.clientCert)
 		})
 		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, "uid"))
 	})
 
 	t.Run("Client key must be valid", func(t *testing.T) {
-		clientKeyBefore := settings.ClientKey
-		settings.ClientKey = tempEmptyFile
-		os.Setenv(PluginSecureSocksProxyClientKey, settings.ClientKey)
+		clientKeyBefore := settings.clientKey
+		settings.clientKey = tempEmptyFile
+		os.Setenv(PluginSecureSocksProxyClientKey, settings.clientKey)
 		t.Cleanup(func() {
-			settings.ClientKey = clientKeyBefore
-			os.Setenv(PluginSecureSocksProxyClientKey, settings.ClientKey)
+			settings.clientKey = clientKeyBefore
+			os.Setenv(PluginSecureSocksProxyClientKey, settings.clientKey)
 		})
 		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, "uid"))
 	})
 
 	t.Run("Root CA must be valid", func(t *testing.T) {
-		rootCABefore := settings.RootCA
-		settings.RootCA = tempEmptyFile
-		os.Setenv(PluginSecureSocksProxyRootCACert, settings.RootCA)
+		rootCABefore := settings.rootCA
+		settings.rootCA = tempEmptyFile
+		os.Setenv(PluginSecureSocksProxyRootCACert, settings.rootCA)
 		t.Cleanup(func() {
-			settings.RootCA = rootCABefore
-			os.Setenv(PluginSecureSocksProxyRootCACert, settings.RootCA)
+			settings.rootCA = rootCABefore
+			os.Setenv(PluginSecureSocksProxyRootCACert, settings.rootCA)
 		})
 		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, "uid"))
 	})
@@ -79,18 +79,18 @@ func TestSecureSocksProxyEnabled(t *testing.T) {
 }
 
 func TestSecureSocksProxyConfigEnv(t *testing.T) {
-	expected := SecureSocksProxyConfig{
-		ClientCert:   "client.crt",
-		ClientKey:    "client.key",
-		RootCA:       "ca.crt",
-		ProxyAddress: "localhost:8080",
-		ServerName:   "testServer",
+	expected := secureSocksProxyConfig{
+		clientCert:   "client.crt",
+		clientKey:    "client.key",
+		rootCA:       "ca.crt",
+		proxyAddress: "localhost:8080",
+		serverName:   "testServer",
 	}
-	os.Setenv(PluginSecureSocksProxyClientCert, expected.ClientCert)
-	os.Setenv(PluginSecureSocksProxyClientKey, expected.ClientKey)
-	os.Setenv(PluginSecureSocksProxyRootCACert, expected.RootCA)
-	os.Setenv(PluginSecureSocksProxyProxyAddress, expected.ProxyAddress)
-	os.Setenv(PluginSecureSocksProxyServerName, expected.ServerName)
+	os.Setenv(PluginSecureSocksProxyClientCert, expected.clientCert)
+	os.Setenv(PluginSecureSocksProxyClientKey, expected.clientKey)
+	os.Setenv(PluginSecureSocksProxyRootCACert, expected.rootCA)
+	os.Setenv(PluginSecureSocksProxyProxyAddress, expected.proxyAddress)
+	os.Setenv(PluginSecureSocksProxyServerName, expected.serverName)
 
 	actual, err := getConfigFromEnv()
 	assert.NoError(t, err)
@@ -152,7 +152,8 @@ func TestPreventInvalidRootCA(t *testing.T) {
 	})
 }
 
-func setupTestSecureSocksProxySettings(t *testing.T) *SecureSocksProxyConfig {
+func setupTestSecureSocksProxySettings(t *testing.T) *secureSocksProxyConfig {
+	t.Helper()
 	proxyAddress := "localhost:3000"
 	serverName := "localhost"
 	tempDir := t.TempDir()
@@ -224,11 +225,11 @@ func setupTestSecureSocksProxySettings(t *testing.T) *SecureSocksProxyConfig {
 	})
 	require.NoError(t, err)
 
-	return &SecureSocksProxyConfig{
-		ClientCert:   clientCert,
-		ClientKey:    clientKey,
-		RootCA:       rootCACert,
-		ServerName:   serverName,
-		ProxyAddress: proxyAddress,
+	return &secureSocksProxyConfig{
+		clientCert:   clientCert,
+		clientKey:    clientKey,
+		rootCA:       rootCACert,
+		serverName:   serverName,
+		proxyAddress: proxyAddress,
 	}
 }

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -36,7 +36,7 @@ func TestNewSecureSocksProxy(t *testing.T) {
 	os.Setenv(PluginSecureSocksProxyEnabled, "true")
 
 	t.Run("New socks proxy should be properly configured when all settings are valid", func(t *testing.T) {
-		require.NoError(t, NewSecureSocksHTTPProxy(&http.Transport{}, &Options{Timeouts: &TimeoutOptions{Timeout: time.Duration(30), KeepAlive: time.Duration(15)}, Auth: &AuthOptions{Username: "user1"}}))
+		require.NoError(t, ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Timeouts: &TimeoutOptions{Timeout: time.Duration(30), KeepAlive: time.Duration(15)}, Auth: &AuthOptions{Username: "user1"}}))
 	})
 
 	t.Run("Client cert must be valid", func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestNewSecureSocksProxy(t *testing.T) {
 			settings.clientCert = clientCertBefore
 			os.Setenv(PluginSecureSocksProxyClientCert, settings.clientCert)
 		})
-		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, &Options{}))
+		require.Error(t, ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Enabled: true}))
 	})
 
 	t.Run("Client key must be valid", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestNewSecureSocksProxy(t *testing.T) {
 			settings.clientKey = clientKeyBefore
 			os.Setenv(PluginSecureSocksProxyClientKey, settings.clientKey)
 		})
-		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, &Options{}))
+		require.Error(t, ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Enabled: true}))
 	})
 
 	t.Run("Root CA must be valid", func(t *testing.T) {
@@ -69,18 +69,18 @@ func TestNewSecureSocksProxy(t *testing.T) {
 			settings.rootCA = rootCABefore
 			os.Setenv(PluginSecureSocksProxyRootCACert, settings.rootCA)
 		})
-		require.Error(t, NewSecureSocksHTTPProxy(&http.Transport{}, &Options{}))
+		require.Error(t, ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Enabled: true}))
 	})
 }
 
 func TestSecureSocksProxyEnabled(t *testing.T) {
 	t.Run("not enabled if not enabled on grafana instance", func(t *testing.T) {
 		os.Setenv(PluginSecureSocksProxyEnabled, "false")
-		assert.Equal(t, false, SecureSocksProxyEnabled(&Options{EnabledOnDS: true}))
+		assert.Equal(t, false, SecureSocksProxyEnabled(&Options{Enabled: true}))
 	})
 	t.Run("not enabled if not enabled on datasource", func(t *testing.T) {
 		os.Setenv(PluginSecureSocksProxyEnabled, "true")
-		assert.Equal(t, false, SecureSocksProxyEnabled(&Options{EnabledOnDS: false}))
+		assert.Equal(t, false, SecureSocksProxyEnabled(&Options{Enabled: false}))
 	})
 	t.Run("not enabled if not enabled on datasource", func(t *testing.T) {
 		os.Setenv(PluginSecureSocksProxyEnabled, "true")
@@ -88,7 +88,7 @@ func TestSecureSocksProxyEnabled(t *testing.T) {
 	})
 	t.Run("enabled, if enabled on grafana instance and datasource", func(t *testing.T) {
 		os.Setenv(PluginSecureSocksProxyEnabled, "true")
-		assert.Equal(t, true, SecureSocksProxyEnabled(&Options{EnabledOnDS: true}))
+		assert.Equal(t, true, SecureSocksProxyEnabled(&Options{Enabled: true}))
 	})
 }
 

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -1,0 +1,201 @@
+package proxy
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSecureSocksProxy(t *testing.T) {
+	settings := setupTestSecureSocksProxySettings(t)
+
+	// create empty file for testing invalid configs
+	tempDir := t.TempDir()
+	tempEmptyFile := filepath.Join(tempDir, "emptyfile.txt")
+	// nolint:gosec
+	// The gosec G304 warning can be ignored because all values come from the test
+	_, err := os.Create(tempEmptyFile)
+	require.NoError(t, err)
+
+	t.Run("New socks proxy should be properly configured when all settings are valid", func(t *testing.T) {
+		require.NoError(t, NewSecureSocksHTTPProxy(settings, &http.Transport{}, "uid"))
+	})
+
+	t.Run("Client cert must be valid", func(t *testing.T) {
+		clientCertBefore := settings.ClientCert
+		settings.ClientCert = tempEmptyFile
+		t.Cleanup(func() {
+			settings.ClientCert = clientCertBefore
+		})
+		require.Error(t, NewSecureSocksHTTPProxy(settings, &http.Transport{}, "uid"))
+	})
+
+	t.Run("Client key must be valid", func(t *testing.T) {
+		clientKeyBefore := settings.ClientKey
+		settings.ClientKey = tempEmptyFile
+		t.Cleanup(func() {
+			settings.ClientKey = clientKeyBefore
+		})
+		require.Error(t, NewSecureSocksHTTPProxy(settings, &http.Transport{}, "uid"))
+	})
+
+	t.Run("Root CA must be valid", func(t *testing.T) {
+		rootCABefore := settings.RootCA
+		settings.RootCA = tempEmptyFile
+		t.Cleanup(func() {
+			settings.RootCA = rootCABefore
+		})
+		require.Error(t, NewSecureSocksHTTPProxy(settings, &http.Transport{}, "uid"))
+	})
+}
+
+func TestSecureSocksProxyEnabled(t *testing.T) {
+	t.Run("Secure socks proxy should be enabled if the config says so", func(t *testing.T) {
+		assert.Equal(t, true, SecureSocksProxyEnabled(&SecureSocksProxyConfig{Enabled: true}))
+	})
+	t.Run("Secure socks proxy should be enabled if the env variables say so", func(t *testing.T) {
+		os.Setenv(PluginSecureSocksProxyEnabled, "true")
+		assert.Equal(t, true, SecureSocksProxyEnabled(nil))
+	})
+}
+
+func TestSecureSocksProxyConfigEnv(t *testing.T) {
+	expected := SecureSocksProxyConfig{
+		ClientCert:   "client.crt",
+		ClientKey:    "client.key",
+		RootCA:       "ca.crt",
+		ProxyAddress: "localhost:8080",
+		ServerName:   "testServer",
+	}
+	os.Setenv(PluginSecureSocksProxyClientCert, expected.ClientCert)
+	os.Setenv(PluginSecureSocksProxyClientKey, expected.ClientKey)
+	os.Setenv(PluginSecureSocksProxyRootCACert, expected.RootCA)
+	os.Setenv(PluginSecureSocksProxyProxyAddress, expected.ProxyAddress)
+	os.Setenv(PluginSecureSocksProxyServerName, expected.ServerName)
+
+	actual, err := getConfigFromEnv()
+	assert.NoError(t, err)
+	assert.Equal(t, &expected, actual)
+}
+
+func TestSecureSocksProxyEnabledOnDS(t *testing.T) {
+	t.Run("Secure socks proxy should only be enabled when the json data contains enableSecureSocksProxy=true", func(t *testing.T) {
+		tests := []struct {
+			jsonData map[string]interface{}
+			enabled  bool
+		}{
+			{
+				jsonData: map[string]interface{}{},
+				enabled:  false,
+			},
+			{
+				jsonData: map[string]interface{}{"enableSecureSocksProxy": "nonbool"},
+				enabled:  false,
+			},
+			{
+				jsonData: map[string]interface{}{"enableSecureSocksProxy": false},
+				enabled:  false,
+			},
+			{
+				jsonData: map[string]interface{}{"enableSecureSocksProxy": true},
+				enabled:  true,
+			},
+		}
+
+		for _, tt := range tests {
+			assert.Equal(t, tt.enabled, SecureSocksProxyEnabledOnDS(tt.jsonData))
+		}
+	})
+}
+
+func setupTestSecureSocksProxySettings(t *testing.T) *SecureSocksProxyConfig {
+	proxyAddress := "localhost:3000"
+	serverName := "localhost"
+	tempDir := t.TempDir()
+
+	// generate test rootCA
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			Organization: []string{"Grafana Labs"},
+			CommonName:   "Grafana",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	require.NoError(t, err)
+	rootCACert := filepath.Join(tempDir, "ca.cert")
+	// nolint:gosec
+	// The gosec G304 warning can be ignored because all values come from the test
+	caCertFile, err := os.Create(rootCACert)
+	require.NoError(t, err)
+	err = pem.Encode(caCertFile, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+	require.NoError(t, err)
+
+	// generate test client cert & key
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			Organization: []string{"Grafana Labs"},
+			CommonName:   "Grafana",
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPrivKey)
+	require.NoError(t, err)
+	clientCert := filepath.Join(tempDir, "client.cert")
+	// nolint:gosec
+	// The gosec G304 warning can be ignored because all values come from the test
+	certFile, err := os.Create(clientCert)
+	require.NoError(t, err)
+	err = pem.Encode(certFile, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	require.NoError(t, err)
+	clientKey := filepath.Join(tempDir, "client.key")
+	// nolint:gosec
+	// The gosec G304 warning can be ignored because all values come from the test
+	keyFile, err := os.Create(clientKey)
+	require.NoError(t, err)
+	err = pem.Encode(keyFile, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	})
+	require.NoError(t, err)
+
+	return &SecureSocksProxyConfig{
+		ClientCert:   clientCert,
+		ClientKey:    clientKey,
+		RootCA:       rootCACert,
+		ServerName:   serverName,
+		ProxyAddress: proxyAddress,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Grafana users need to be able to connect to datasources that live in different networks than where Grafana is running. This PR adds new functionality that allows datasources to connect through a socks5 proxy with TLS. This will only be available to users if it is enabled on the instance (via the config.ini: `secure_socks_datasource_proxy`.`enabled`) and the datasource has `enableSecureSocksProxy=true` set in the json data. Optionally, datasources may specify different usernames and passwords to connect to the proxy.

**Which issue(s) this PR fixes**:

Relates to https://github.com/grafana/grafana/issues/15045
Closes https://github.com/grafana/hosted-grafana/issues/3369

**Special notes for your reviewer**:

- This functionality has already been running in Grafana, under a feature toggle, and now we're ready to move it into the sdk without a feature toggle (see [HTTP PR](https://github.com/grafana/grafana/pull/59254) and [SQL PR](https://github.com/grafana/grafana/pull/64630)). 
- [PR is up](https://github.com/grafana/grafana/pull/65878) for adding the env variables to Grafana, but we'll need to update the sdk version in Grafana before it will work
- [See draft PR of using this in Grafana's core datasources](https://github.com/grafana/grafana/pull/65876). At first, to accomodate the core datasources, I had added a config that could be passed in to the sdk, but it seemed cleaner to just set the needed environment variables in Grafana itself ([diff](https://github.com/grafana/grafana-plugin-sdk-go/pull/667/commits/3e2b8330e94e9d38f550419c0088e9d3e09d387a)). I'm happy to change it back to that, though, if that is better.
