### PR TITLE
test: use `t.Setenv` and `t.TempDir`

### DIFF
--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -28,12 +28,12 @@ func TestNewSecureSocksProxy(t *testing.T) {
 	// The gosec G304 warning can be ignored because all values come from the test
 	_, err := os.Create(tempEmptyFile)
 	require.NoError(t, err)
-	os.Setenv(PluginSecureSocksProxyClientCert, settings.clientCert)
-	os.Setenv(PluginSecureSocksProxyClientKey, settings.clientKey)
-	os.Setenv(PluginSecureSocksProxyRootCACert, settings.rootCA)
-	os.Setenv(PluginSecureSocksProxyProxyAddress, settings.proxyAddress)
-	os.Setenv(PluginSecureSocksProxyServerName, settings.serverName)
-	os.Setenv(PluginSecureSocksProxyEnabled, "true")
+	t.Setenv(PluginSecureSocksProxyClientCert, settings.clientCert)
+	t.Setenv(PluginSecureSocksProxyClientKey, settings.clientKey)
+	t.Setenv(PluginSecureSocksProxyRootCACert, settings.rootCA)
+	t.Setenv(PluginSecureSocksProxyProxyAddress, settings.proxyAddress)
+	t.Setenv(PluginSecureSocksProxyServerName, settings.serverName)
+	t.Setenv(PluginSecureSocksProxyEnabled, "true")
 
 	t.Run("New socks proxy should be properly configured when all settings are valid", func(t *testing.T) {
 		require.NoError(t, ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Timeouts: &TimeoutOptions{Timeout: time.Duration(30), KeepAlive: time.Duration(15)}, Auth: &AuthOptions{Username: "user1"}}))
@@ -42,10 +42,9 @@ func TestNewSecureSocksProxy(t *testing.T) {
 	t.Run("Client cert must be valid", func(t *testing.T) {
 		clientCertBefore := settings.clientCert
 		settings.clientCert = tempEmptyFile
-		os.Setenv(PluginSecureSocksProxyClientCert, settings.clientCert)
+		t.Setenv(PluginSecureSocksProxyClientCert, settings.clientCert)
 		t.Cleanup(func() {
 			settings.clientCert = clientCertBefore
-			os.Setenv(PluginSecureSocksProxyClientCert, settings.clientCert)
 		})
 		require.Error(t, ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Enabled: true}))
 	})
@@ -53,10 +52,9 @@ func TestNewSecureSocksProxy(t *testing.T) {
 	t.Run("Client key must be valid", func(t *testing.T) {
 		clientKeyBefore := settings.clientKey
 		settings.clientKey = tempEmptyFile
-		os.Setenv(PluginSecureSocksProxyClientKey, settings.clientKey)
+		t.Setenv(PluginSecureSocksProxyClientKey, settings.clientKey)
 		t.Cleanup(func() {
 			settings.clientKey = clientKeyBefore
-			os.Setenv(PluginSecureSocksProxyClientKey, settings.clientKey)
 		})
 		require.Error(t, ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Enabled: true}))
 	})
@@ -64,10 +62,9 @@ func TestNewSecureSocksProxy(t *testing.T) {
 	t.Run("Root CA must be valid", func(t *testing.T) {
 		rootCABefore := settings.rootCA
 		settings.rootCA = tempEmptyFile
-		os.Setenv(PluginSecureSocksProxyRootCACert, settings.rootCA)
+		t.Setenv(PluginSecureSocksProxyRootCACert, settings.rootCA)
 		t.Cleanup(func() {
 			settings.rootCA = rootCABefore
-			os.Setenv(PluginSecureSocksProxyRootCACert, settings.rootCA)
 		})
 		require.Error(t, ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Enabled: true}))
 	})
@@ -75,19 +72,19 @@ func TestNewSecureSocksProxy(t *testing.T) {
 
 func TestSecureSocksProxyEnabled(t *testing.T) {
 	t.Run("not enabled if not enabled on grafana instance", func(t *testing.T) {
-		os.Setenv(PluginSecureSocksProxyEnabled, "false")
+		t.Setenv(PluginSecureSocksProxyEnabled, "false")
 		assert.Equal(t, false, SecureSocksProxyEnabled(&Options{Enabled: true}))
 	})
 	t.Run("not enabled if not enabled on datasource", func(t *testing.T) {
-		os.Setenv(PluginSecureSocksProxyEnabled, "true")
+		t.Setenv(PluginSecureSocksProxyEnabled, "true")
 		assert.Equal(t, false, SecureSocksProxyEnabled(&Options{Enabled: false}))
 	})
 	t.Run("not enabled if not enabled on datasource", func(t *testing.T) {
-		os.Setenv(PluginSecureSocksProxyEnabled, "true")
+		t.Setenv(PluginSecureSocksProxyEnabled, "true")
 		assert.Equal(t, false, SecureSocksProxyEnabled(nil))
 	})
 	t.Run("enabled, if enabled on grafana instance and datasource", func(t *testing.T) {
-		os.Setenv(PluginSecureSocksProxyEnabled, "true")
+		t.Setenv(PluginSecureSocksProxyEnabled, "true")
 		assert.Equal(t, true, SecureSocksProxyEnabled(&Options{Enabled: true}))
 	})
 }
@@ -100,11 +97,11 @@ func TestSecureSocksProxyConfigEnv(t *testing.T) {
 		proxyAddress: "localhost:8080",
 		serverName:   "testServer",
 	}
-	os.Setenv(PluginSecureSocksProxyClientCert, expected.clientCert)
-	os.Setenv(PluginSecureSocksProxyClientKey, expected.clientKey)
-	os.Setenv(PluginSecureSocksProxyRootCACert, expected.rootCA)
-	os.Setenv(PluginSecureSocksProxyProxyAddress, expected.proxyAddress)
-	os.Setenv(PluginSecureSocksProxyServerName, expected.serverName)
+	t.Setenv(PluginSecureSocksProxyClientCert, expected.clientCert)
+	t.Setenv(PluginSecureSocksProxyClientKey, expected.clientKey)
+	t.Setenv(PluginSecureSocksProxyRootCACert, expected.rootCA)
+	t.Setenv(PluginSecureSocksProxyProxyAddress, expected.proxyAddress)
+	t.Setenv(PluginSecureSocksProxyServerName, expected.serverName)
 
 	actual, err := getConfigFromEnv()
 	assert.NoError(t, err)
@@ -143,6 +140,11 @@ func TestSecureSocksProxyEnabledOnDS(t *testing.T) {
 
 func TestPreventInvalidRootCA(t *testing.T) {
 	tempDir := t.TempDir()
+	t.Setenv(PluginSecureSocksProxyClientCert, "client.crt")
+	t.Setenv(PluginSecureSocksProxyClientKey, "client.key")
+	t.Setenv(PluginSecureSocksProxyProxyAddress, "localhost:8080")
+	t.Setenv(PluginSecureSocksProxyServerName, "testServer")
+
 	t.Run("root ca must be of the type CERTIFICATE", func(t *testing.T) {
 		rootCACert := filepath.Join(tempDir, "ca.cert")
 		caCertFile, err := os.Create(rootCACert)
@@ -152,7 +154,7 @@ func TestPreventInvalidRootCA(t *testing.T) {
 			Bytes: []byte("testing"),
 		})
 		require.NoError(t, err)
-		os.Setenv(PluginSecureSocksProxyRootCACert, rootCACert)
+		t.Setenv(PluginSecureSocksProxyRootCACert, rootCACert)
 		_, err = NewSecureSocksProxyContextDialer(nil)
 		require.Contains(t, err.Error(), "root ca is invalid")
 	})
@@ -160,7 +162,7 @@ func TestPreventInvalidRootCA(t *testing.T) {
 		rootCACert := filepath.Join(tempDir, "ca.cert")
 		err := os.WriteFile(rootCACert, []byte("this is not a pem encoded file"), fs.ModeAppend)
 		require.NoError(t, err)
-		os.Setenv(PluginSecureSocksProxyRootCACert, rootCACert)
+		t.Setenv(PluginSecureSocksProxyRootCACert, rootCACert)
 		_, err = NewSecureSocksProxyContextDialer(nil)
 		require.Contains(t, err.Error(), "root ca is invalid")
 	})

--- a/build/info_test.go
+++ b/build/info_test.go
@@ -18,18 +18,11 @@ func TestFillBuildInfo(t *testing.T) {
 	})
 
 	t.Run("drone", func(t *testing.T) {
-		os.Setenv("DRONE_REPO_LINK", "https://github.com/octocat/hello-world")
-		os.Setenv("DRONE_BRANCH", "main")
-		os.Setenv("DRONE_COMMIT_SHA", "bcdd4bf0245c82c060407b3b24b9b87301d15ac1")
-		os.Setenv("DRONE_BUILD_NUMBER", "22")
-		os.Setenv("DRONE_PULL_REQUEST", "33")
-		t.Cleanup(func() {
-			_ = os.Unsetenv("DRONE_REPO_LINK")
-			_ = os.Unsetenv("DRONE_BRANCH")
-			_ = os.Unsetenv("DRONE_COMMIT_SHA")
-			_ = os.Unsetenv("DRONE_BUILD_NUMBER")
-			_ = os.Unsetenv("DRONE_PULL_REQUEST")
-		})
+		t.Setenv("DRONE_REPO_LINK", "https://github.com/octocat/hello-world")
+		t.Setenv("DRONE_BRANCH", "main")
+		t.Setenv("DRONE_COMMIT_SHA", "bcdd4bf0245c82c060407b3b24b9b87301d15ac1")
+		t.Setenv("DRONE_BUILD_NUMBER", "22")
+		t.Setenv("DRONE_PULL_REQUEST", "33")
 
 		info := getBuildInfoFromEnvironment()
 		require.NotNil(t, info)
@@ -40,18 +33,12 @@ func TestFillBuildInfo(t *testing.T) {
 	})
 
 	t.Run("circle", func(t *testing.T) {
-		os.Setenv("CIRCLE_PROJECT_REPONAME", "https://github.com/octocat/hello-world")
-		os.Setenv("CIRCLE_BRANCH", "main")
-		os.Setenv("CIRCLE_SHA1", "bcdd4bf0245c82c060407b3b24b9b87301d15ac1")
-		os.Setenv("CIRCLE_BUILD_NUM", "22")
-		os.Setenv("CI_PULL_REQUEST", "33")
-		t.Cleanup(func() {
-			_ = os.Unsetenv("CIRCLE_PROJECT_REPONAME")
-			_ = os.Unsetenv("CIRCLE_BRANCH")
-			_ = os.Unsetenv("CIRCLE_SHA1")
-			_ = os.Unsetenv("CIRCLE_BUILD_NUM")
-			_ = os.Unsetenv("CI_PULL_REQUEST")
-		})
+		os.Clearenv() // Clear DRONE env vars in CI environment
+		t.Setenv("CIRCLE_PROJECT_REPONAME", "https://github.com/octocat/hello-world")
+		t.Setenv("CIRCLE_BRANCH", "main")
+		t.Setenv("CIRCLE_SHA1", "bcdd4bf0245c82c060407b3b24b9b87301d15ac1")
+		t.Setenv("CIRCLE_BUILD_NUM", "22")
+		t.Setenv("CI_PULL_REQUEST", "33")
 
 		info := getBuildInfoFromEnvironment()
 		require.NotNil(t, info)

--- a/build/utils/copy_test.go
+++ b/build/utils/copy_test.go
@@ -36,18 +36,14 @@ func TestCopyFile_NonExistentDestDir(t *testing.T) {
 }
 
 func TestCopyRecursive_NonExistentDest(t *testing.T) {
-	src, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(src)
+	src := t.TempDir()
 
-	err = os.MkdirAll(path.Join(src, "data"), 0755)
+	err := os.MkdirAll(path.Join(src, "data"), 0755)
 	require.NoError(t, err)
 	err = os.WriteFile(path.Join(src, "data", "file.txt"), []byte("Test"), 0600)
 	require.NoError(t, err)
 
-	dstParent, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dstParent)
+	dstParent := t.TempDir()
 
 	dst := path.Join(dstParent, "dest")
 
@@ -58,18 +54,14 @@ func TestCopyRecursive_NonExistentDest(t *testing.T) {
 }
 
 func TestCopyRecursive_ExistentDest(t *testing.T) {
-	src, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(src)
+	src := t.TempDir()
 
-	err = os.MkdirAll(path.Join(src, "data"), 0755)
+	err := os.MkdirAll(path.Join(src, "data"), 0755)
 	require.NoError(t, err)
 	err = os.WriteFile(path.Join(src, "data", "file.txt"), []byte("Test"), 0600)
 	require.NoError(t, err)
 
-	dst, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dst)
+	dst := t.TempDir()
 
 	err = CopyRecursive(src, dst)
 	require.NoError(t, err)

--- a/experimental/http_logger/http_logger_test.go
+++ b/experimental/http_logger/http_logger_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestHTTPLogger(t *testing.T) {
 	t.Run("saved file should match example", func(t *testing.T) {
-		c, f := setup(true)
+		c, f := setup(t, true)
 		res, err := c.Get("http://example.com")
 		require.NoError(t, err)
 		defer res.Body.Close()
@@ -35,7 +35,7 @@ func TestHTTPLogger(t *testing.T) {
 	})
 
 	t.Run("file should not be created by storage if http logging is disabled", func(t *testing.T) {
-		c, f := setup(false)
+		c, f := setup(t, false)
 		res, err := c.Get("http://example.com")
 		require.NoError(t, err)
 		defer res.Body.Close()
@@ -51,8 +51,8 @@ func TestHTTPLogger(t *testing.T) {
 
 	t.Run("should set path and enabled overrides", func(t *testing.T) {
 		// ensure env variables are not set
-		os.Setenv(httplogger.PluginHARLogEnabledEnv, "false")
-		os.Setenv(httplogger.PluginHARLogPathEnv, "")
+		t.Setenv(httplogger.PluginHARLogEnabledEnv, "false")
+		t.Setenv(httplogger.PluginHARLogPathEnv, "")
 
 		f, err := os.CreateTemp("", "test_*.har")
 		defer os.Remove(f.Name())
@@ -83,7 +83,9 @@ func TestHTTPLogger(t *testing.T) {
 	})
 }
 
-func setup(enabled bool) (*http.Client, *os.File) {
+func setup(t *testing.T, enabled bool) (*http.Client, *os.File) {
+	t.Helper()
+
 	f, err := os.CreateTemp("", "example_*.har")
 	defer os.Remove(f.Name())
 	if err != nil {
@@ -91,10 +93,10 @@ func setup(enabled bool) (*http.Client, *os.File) {
 	}
 
 	if enabled {
-		os.Setenv(httplogger.PluginHARLogEnabledEnv, "true")
-		os.Setenv(httplogger.PluginHARLogPathEnv, f.Name())
+		t.Setenv(httplogger.PluginHARLogEnabledEnv, "true")
+		t.Setenv(httplogger.PluginHARLogPathEnv, f.Name())
 	} else {
-		os.Setenv(httplogger.PluginHARLogEnabledEnv, "false")
+		t.Setenv(httplogger.PluginHARLogEnabledEnv, "false")
 	}
 
 	h := httplogger.NewHTTPLogger("example-plugin-id", &fakeRoundTripper{})


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit replaces:
	1. `os.Setenv` with `t.Setenv`
	2. `os.MkdirTemp` with `t.TempDir`

With `t.Setenv`, the environment variable is automatically restored to its original value when the test and all its subtests complete.

The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.Setenv
Reference: https://pkg.go.dev/testing#T.TempDir

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
