### PR TITLE
httpclient: Don't forward HTTP headers by default

### DIFF
--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -23,6 +23,10 @@ func withHeaderMiddleware(ctx context.Context, headers http.Header) context.Cont
 	if len(headers) > 0 {
 		ctx = httpclient.WithContextualMiddleware(ctx,
 			httpclient.MiddlewareFunc(func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+				if !opts.ForwardHTTPHeaders {
+					return next
+				}
+
 				return httpclient.RoundTripperFunc(func(qreq *http.Request) (*http.Response, error) {
 					// Only set a header if it is not already set.
 					for k, v := range headers {

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -64,26 +64,53 @@ func (f *fakeDataHandlerWithOAuth) QueryData(ctx context.Context, req *QueryData
 func TestQueryData(t *testing.T) {
 	handler := newFakeDataHandlerWithOAuth()
 	adapter := newDataSDKAdapter(handler)
-	ctx := context.Background()
-	_, err := adapter.QueryData(ctx, &pluginv2.QueryDataRequest{
-		Headers: map[string]string{
-			"Authorization": "Bearer 123",
-		},
-		PluginContext: &pluginv2.PluginContext{},
+
+	t.Run("When forward HTTP headers enabled should forward headers", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := adapter.QueryData(ctx, &pluginv2.QueryDataRequest{
+			Headers: map[string]string{
+				"Authorization": "Bearer 123",
+			},
+			PluginContext: &pluginv2.PluginContext{},
+		})
+		require.NoError(t, err)
+
+		middlewares := httpclient.ContextualMiddlewareFromContext(handler.lastReq.Context())
+		require.Len(t, middlewares, 1)
+
+		reqClone := handler.lastReq.Clone(handler.lastReq.Context())
+		// clean up headers to be sure they are injected
+		reqClone.Header = http.Header{}
+
+		res, err := middlewares[0].CreateMiddleware(httpclient.Options{ForwardHTTPHeaders: true}, finalRoundTripper).RoundTrip(reqClone)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+		require.Len(t, reqClone.Header, 1)
+		require.Equal(t, "Bearer 123", reqClone.Header.Get("Authorization"))
 	})
-	require.NoError(t, err)
 
-	middlewares := httpclient.ContextualMiddlewareFromContext(handler.lastReq.Context())
-	require.Len(t, middlewares, 1)
+	t.Run("When forward HTTP headers disable should not forward headers", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := adapter.QueryData(ctx, &pluginv2.QueryDataRequest{
+			Headers: map[string]string{
+				"Authorization": "Bearer 123",
+			},
+			PluginContext: &pluginv2.PluginContext{},
+		})
+		require.NoError(t, err)
 
-	reqClone := handler.lastReq.Clone(handler.lastReq.Context())
-	// clean up headers to be sure they are injected
-	reqClone.Header = http.Header{}
-	res, err := middlewares[0].CreateMiddleware(httpclient.Options{}, finalRoundTripper).RoundTrip(reqClone)
-	require.NoError(t, err)
-	require.NoError(t, res.Body.Close())
-	require.Len(t, reqClone.Header, 1)
-	require.Equal(t, "Bearer 123", reqClone.Header.Get("Authorization"))
+		middlewares := httpclient.ContextualMiddlewareFromContext(handler.lastReq.Context())
+		require.Len(t, middlewares, 1)
+
+		reqClone := handler.lastReq.Clone(handler.lastReq.Context())
+		// clean up headers to be sure they are injected
+		reqClone.Header = http.Header{}
+
+		res, err := middlewares[0].CreateMiddleware(httpclient.Options{ForwardHTTPHeaders: false}, finalRoundTripper).RoundTrip(reqClone)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+		require.Empty(t, reqClone.Header)
+	})
 }
 
 var finalRoundTripper = httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/backend/httpclient/options.go
+++ b/backend/httpclient/options.go
@@ -62,6 +62,12 @@ type Options struct {
 	// ConfigureTLSConfig optionally provide a ConfigureTLSConfigFunc
 	// to modify the created http.Client.
 	ConfigureTLSConfig ConfigureTLSConfigFunc
+
+	// ForwardHTTPHeaders enable forwarding of all HTTP headers
+	// included in backend.QueryDataRequest, backend.CallResourceRequest,
+	// backend.CheckHealthRequest, e.g. based on if Allowed cookies or
+	// Forward OAuth Identity is configured.
+	ForwardHTTPHeaders bool
 }
 
 // BasicAuthOptions basic authentication options.

--- a/backend/httpclient/options.go
+++ b/backend/httpclient/options.go
@@ -66,7 +66,8 @@ type Options struct {
 	// ForwardHTTPHeaders enable forwarding of all HTTP headers
 	// included in backend.QueryDataRequest, backend.CallResourceRequest,
 	// backend.CheckHealthRequest, e.g. based on if Allowed cookies or
-	// Forward OAuth Identity is configured.
+	// Forward OAuth Identity is configured for the datasource or any
+	// other forwarded HTTP header from Grafana.
 	ForwardHTTPHeaders bool
 }
 


### PR DESCRIPTION
Based on discussion in #612 enable automatic forwarding of HTTP headers did introduce problems for several plugins. This disables automatic forwarding of HTTP headers and requires `httpclient.Options.ForwardHTTPHeaders` to be configued to `true` for HTTP headers to be forwarded. This doesn't affect core Grafana plugins since we already override the default middlewares there.

Consider the alternative of removing adding the `httpclient.ContextualMiddleware` to `httpclient.DefaultMiddlewares`. Then you would had to do something like this
```go
opt := httpclient.Options{
  Middlewares: []httpclient.Middleware{...httpclient.DefaultMiddlewares, httpclient.ContextualMiddleware},
}
```

Feels like there might be other use cases for `httpclient.ContextualMiddleware` in the future why having it as default make sense and why I opted for these changes instead.

Would have to update the following if we merge:
- https://github.com/grafana/grafana-plugin-examples/blob/39369a57f90e62eeb34a5a72197ea49121809f1d/examples/datasource-http-backend/pkg/plugin/datasource.go#LL52C74-L53C32
- proper release notes since it could be a breaking change