### PR TITLE
Makes sure go build manifest file is generated with POSIX separators

### DIFF
--- a/build/utils/manifest.go
+++ b/build/utils/manifest.go
@@ -24,7 +24,7 @@ func GenerateManifest() (string, error) {
 				return err
 			}
 			// manifest = manifest + hash + ":" + path + "\n"
-			manifest.WriteString(hash + ":" + path + "\n")
+			manifest.WriteString(hash + ":" + filepath.ToSlash(path) + "\n")
 		}
 		return nil
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
It makes sure the generated go manifest file outputs POSIX paths in all systems.
With the previous version, manifests generated in windows machines would use back slashes instead of forward slashes.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

I tested this change using a windows 11 virtual machine with the latest go 1.20.x. It looks like pathfile.ToSlash behaves different based on the OS. In linux doesn't convert backslashes to forward-slashes.