### PR TITLE
return response with message when err occurs with a response

### DIFF
--- a/backend/diagnostics_adapter.go
+++ b/backend/diagnostics_adapter.go
@@ -50,7 +50,7 @@ func (a *diagnosticsSDKAdapter) CheckHealth(ctx context.Context, protoReq *plugi
 		parsedReq := FromProto().CheckHealthRequest(protoReq)
 		ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
 		res, err := a.checkHealthHandler.CheckHealth(ctx, parsedReq)
-		if err != nil {
+		if err != nil && res == nil {
 			return nil, err
 		}
 		return ToProto().CheckHealthResponse(res), nil

--- a/backend/diagnostics_adapter.go
+++ b/backend/diagnostics_adapter.go
@@ -50,7 +50,7 @@ func (a *diagnosticsSDKAdapter) CheckHealth(ctx context.Context, protoReq *plugi
 		parsedReq := FromProto().CheckHealthRequest(protoReq)
 		ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
 		res, err := a.checkHealthHandler.CheckHealth(ctx, parsedReq)
-		if err != nil && res == nil {
+		if err != nil && (res == nil || res.Status == HealthStatusUnknown) {
 			return nil, err
 		}
 		return ToProto().CheckHealthResponse(res), nil


### PR DESCRIPTION
**What this PR does / why we need it**:
When an error is returned we only receive a generic message "Plugin health check failed"
![image](https://github.com/grafana/grafana-plugin-sdk-go/assets/6108819/b1673095-41c0-4f48-86d9-74ee5ed4773c)

This change returns a response with the message and displays it on the health check page.
![image](https://github.com/grafana/grafana-plugin-sdk-go/assets/6108819/6e2d9f2b-0e4b-4cf6-b174-589dc2edbe37)

**Which issue(s) this PR fixes**:
https://github.com/grafana/support-escalations/issues/6150

