### PR TITLE
Rework standalone API

### DIFF
--- a/backend/serve.go
+++ b/backend/serve.go
@@ -114,26 +114,26 @@ func StandaloneServe(dsopts ServeOpts, address string) error {
 	// GracefulStandaloneServe has a new signature, this function keeps the old
 	// signature for existing plugins for backwards compatibility.
 	// Create a new standalone.Args and disable all the standalone-file-related features.
-	return GracefulStandaloneServe(dsopts, standalone.Args{Address: address})
+	return GracefulStandaloneServe(dsopts, standalone.NewServerSettings(address))
 }
 
 // GracefulStandaloneServe starts a gRPC server that is not managed by hashicorp.
 // The provided standalone.Args must have an Address set, or the function returns an error.
 // The function handles creating/cleaning up the standalone address file, and graceful GRPC server termination.
 // The function returns after the GRPC server has been terminated.
-func GracefulStandaloneServe(dsopts ServeOpts, info standalone.Args) error {
+func GracefulStandaloneServe(dsopts ServeOpts, info standalone.ServerSettings) error {
 	// We must have an address if we want to run the plugin in standalone mode
 	if info.Address == "" {
 		return fmt.Errorf("standalone address must be specified")
 	}
 
-	// Write the address to the local file
+	// Write the address and PID to local files
 	if info.Debugger {
 		log.DefaultLogger.Info("Creating standalone address and pid files")
-		if err := standalone.CreateStandaloneAddressFile(info); err != nil {
+		if err := standalone.CreateStandaloneAddressFile(info.Address, info.Dir); err != nil {
 			return fmt.Errorf("create standalone address file: %w", err)
 		}
-		if err := standalone.CreateStandalonePIDFile(info); err != nil {
+		if err := standalone.CreateStandalonePIDFile(os.Getpid(), info.Dir); err != nil {
 			return fmt.Errorf("create standalone pid file: %w", err)
 		}
 
@@ -154,7 +154,7 @@ func GracefulStandaloneServe(dsopts ServeOpts, info standalone.Args) error {
 			standalone.FindAndKillCurrentPlugin(info.Dir)
 		}()
 
-		// When debugging, be sure to kill the running instances, so we reconnect
+		// When debugging, be sure to kill the running instances, so that we can reconnect
 		standalone.FindAndKillCurrentPlugin(info.Dir)
 	}
 
@@ -242,21 +242,15 @@ func Manage(pluginID string, serveOpts ServeOpts) error {
 		}
 	}()
 
-	info, err := standalone.GetInfo(pluginID)
-	if err != nil {
-		return err
-	}
-
-	if info.Standalone {
+	if s, enabled := standalone.ServerModeEnabled(pluginID); enabled {
 		// Run the standalone GRPC server
-		return GracefulStandaloneServe(serveOpts, info)
+		return GracefulStandaloneServe(serveOpts, s)
 	}
 
-	if info.Address != "" && standalone.CheckPIDIsRunning(info.PID) {
-		// Grafana is trying to run the dummy plugin locator to connect to the standalone
-		// GRPC server (separate process)
-		Logger.Debug("Running dummy plugin locator", "addr", info.Address, "pid", strconv.Itoa(info.PID))
-		standalone.RunDummyPluginLocator(info.Address)
+	if s, enabled := standalone.ClientModeEnabled(pluginID); enabled {
+		// Grafana is trying to run the dummy plugin locator to connect to the standalone GRPC server (separate process)
+		Logger.Debug("Running dummy plugin locator", "addr", s.TargetAddress, "pid", strconv.Itoa(s.TargetPID))
+		standalone.RunDummyPluginLocator(s.TargetAddress)
 		return nil
 	}
 

--- a/backend/serve.go
+++ b/backend/serve.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -108,15 +109,6 @@ func Serve(opts ServeOpts) error {
 	return grpcplugin.Serve(pluginOpts)
 }
 
-// StandaloneServe starts a gRPC server that is not managed by hashicorp.
-// Deprecated: use GracefulStandaloneServe instead.
-func StandaloneServe(dsopts ServeOpts, address string) error {
-	// GracefulStandaloneServe has a new signature, this function keeps the old
-	// signature for existing plugins for backwards compatibility.
-	// Create a new standalone.Args and disable all the standalone-file-related features.
-	return GracefulStandaloneServe(dsopts, standalone.NewServerSettings(address))
-}
-
 // GracefulStandaloneServe starts a gRPC server that is not managed by hashicorp.
 // The provided standalone.Args must have an Address set, or the function returns an error.
 // The function handles creating/cleaning up the standalone address file, and graceful GRPC server termination.
@@ -124,39 +116,41 @@ func StandaloneServe(dsopts ServeOpts, address string) error {
 func GracefulStandaloneServe(dsopts ServeOpts, info standalone.ServerSettings) error {
 	// We must have an address if we want to run the plugin in standalone mode
 	if info.Address == "" {
-		return fmt.Errorf("standalone address must be specified")
+		return errors.New("standalone address must be specified")
+	}
+
+	if info.Dir == "" {
+		return errors.New("directory must be specified")
 	}
 
 	// Write the address and PID to local files
-	if info.Debugger {
-		log.DefaultLogger.Info("Creating standalone address and pid files")
-		if err := standalone.CreateStandaloneAddressFile(info.Address, info.Dir); err != nil {
-			return fmt.Errorf("create standalone address file: %w", err)
-		}
-		if err := standalone.CreateStandalonePIDFile(os.Getpid(), info.Dir); err != nil {
-			return fmt.Errorf("create standalone pid file: %w", err)
-		}
-
-		// sadly vs-code can not listen to shutdown events
-		// https://github.com/golang/vscode-go/issues/120
-
-		// Cleanup function that deletes standalone.txt and pid.txt, if it exists. Fails silently.
-		// This is so the address file is deleted when the plugin shuts down gracefully, if possible.
-		defer func() {
-			log.DefaultLogger.Info("Cleaning up standalone address and pid files")
-			if err := standalone.CleanupStandaloneAddressFile(info); err != nil {
-				log.DefaultLogger.Error("Error while cleaning up standalone address file", "error", err)
-			}
-			if err := standalone.CleanupStandalonePIDFile(info); err != nil {
-				log.DefaultLogger.Error("Error while cleaning up standalone pid file", "error", err)
-			}
-			// Kill the dummy locator so Grafana reloads the plugin
-			standalone.FindAndKillCurrentPlugin(info.Dir)
-		}()
-
-		// When debugging, be sure to kill the running instances, so that we can reconnect
-		standalone.FindAndKillCurrentPlugin(info.Dir)
+	log.DefaultLogger.Info("Creating standalone address and pid files", "dir", info.Dir)
+	if err := standalone.CreateStandaloneAddressFile(info.Address, info.Dir); err != nil {
+		return fmt.Errorf("create standalone address file: %w", err)
 	}
+	if err := standalone.CreateStandalonePIDFile(os.Getpid(), info.Dir); err != nil {
+		return fmt.Errorf("create standalone pid file: %w", err)
+	}
+
+	// sadly vs-code can not listen to shutdown events
+	// https://github.com/golang/vscode-go/issues/120
+
+	// Cleanup function that deletes standalone.txt and pid.txt, if it exists. Fails silently.
+	// This is so the address file is deleted when the plugin shuts down gracefully, if possible.
+	defer func() {
+		log.DefaultLogger.Info("Cleaning up standalone address and pid files")
+		if err := standalone.CleanupStandaloneAddressFile(info); err != nil {
+			log.DefaultLogger.Error("Error while cleaning up standalone address file", "error", err)
+		}
+		if err := standalone.CleanupStandalonePIDFile(info); err != nil {
+			log.DefaultLogger.Error("Error while cleaning up standalone pid file", "error", err)
+		}
+		// Kill the dummy locator so Grafana reloads the plugin
+		standalone.FindAndKillCurrentPlugin(info.Dir)
+	}()
+
+	// When debugging, be sure to kill the running instances, so that we can reconnect
+	standalone.FindAndKillCurrentPlugin(info.Dir)
 
 	// Start GRPC server
 	pluginOpts := asGRPCServeOpts(dsopts)

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -58,6 +58,7 @@ func ServerModeEnabled(pluginID string) (ServerSettings, bool) {
 func ClientModeEnabled(pluginID string) (ClientSettings, bool) {
 	s, err := clientSettings(pluginID)
 	if err != nil {
+		log.Printf("Error: %s", err.Error())
 		return ClientSettings{}, false
 	}
 
@@ -111,7 +112,7 @@ func clientSettings(pluginID string) (ClientSettings, error) {
 	}
 
 	if standaloneAddress == "" {
-		return ClientSettings{}, fmt.Errorf("address is empty")
+		return ClientSettings{}, errors.New("address is empty")
 	}
 
 	standalonePID, err := getStandalonePID(dir)

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -168,8 +168,7 @@ func findPluginRootDir(exe string) (string, error) {
 		}
 	}
 
-	log.Printf("Can not find plugin.json in: %v", check)
-	return "", nil
+	return "", fmt.Errorf("can not find plugin.json in: %v", check)
 }
 
 // debuggedEnabled returns true if the plugin should run in debug mode.

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -245,7 +245,7 @@ func getStandalonePID(dir string) (int, error) {
 		}
 
 		if !checkPIDIsRunning(pid) {
-			return 0, errors.New("standlone pid is not running")
+			return 0, errors.New("standalone server is not running")
 		}
 
 		return pid, nil
@@ -372,7 +372,7 @@ func checkPIDIsRunning(pid int) bool {
 	//   process group ID.
 	//
 	// So we send try to send a 0 signal to the process instead to test if it exists.
-	if err := process.Signal(syscall.Signal(0)); err != nil {
+	if err = process.Signal(syscall.Signal(0)); err != nil {
 		return false
 	}
 	return true

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -146,18 +146,18 @@ func currentProcPath() (string, error) {
 	return filepath.Dir(curProcPath), nil
 }
 
-// findPluginRootDir will attempt to find the dist plugin.json file based on the executing process's file-system path.
-func findPluginRootDir(exe string) (string, error) {
+// findPluginRootDir will attempt to find a plugin directory based on the executing process's file-system path.
+func findPluginRootDir(curProcPath string) (string, error) {
 	cwd, _ := os.Getwd()
 	if filepath.Base(cwd) == "pkg" {
 		cwd = filepath.Join(cwd, "..")
 	}
 
 	check := []string{
-		filepath.Join(exe, "plugin.json"),
-		filepath.Join(exe, "dist", "plugin.json"),
-		filepath.Join(filepath.Dir(exe), "plugin.json"),
-		filepath.Join(filepath.Dir(exe), "..", "dist", "plugin.json"),
+		filepath.Join(curProcPath, "plugin.json"),
+		filepath.Join(curProcPath, "dist", "plugin.json"),
+		filepath.Join(filepath.Dir(curProcPath), "plugin.json"),
+		filepath.Join(filepath.Dir(curProcPath), "..", "dist", "plugin.json"),
 		filepath.Join(cwd, "dist", "plugin.json"),
 		filepath.Join(cwd, "plugin.json"),
 	}

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -189,9 +189,8 @@ func debuggerEnabled(curProcPath string) bool {
 }
 
 func getStandaloneAddress(pluginID string, dir string) (string, error) {
-	addressEnvVar := "GF_PLUGIN_GRPC_ADDRESS_" + strings.ReplaceAll(strings.ToUpper(pluginID), "-", "_")
-	if v, ok := os.LookupEnv(addressEnvVar); ok {
-		return v, nil
+	if addressEnvVar, exists := standaloneAddressFromEnv(pluginID); exists {
+		return addressEnvVar, nil
 	}
 
 	// Check the local file for address
@@ -208,9 +207,8 @@ func getStandaloneAddress(pluginID string, dir string) (string, error) {
 }
 
 func createStandaloneAddress(pluginID string) (string, error) {
-	addressEnvVar := "GF_PLUGIN_GRPC_ADDRESS_" + strings.ReplaceAll(strings.ToUpper(pluginID), "-", "_")
-	if v, ok := os.LookupEnv(addressEnvVar); ok {
-		return v, nil
+	if addressEnvVar, exists := standaloneAddressFromEnv(pluginID); exists {
+		return addressEnvVar, nil
 	}
 
 	port, err := getFreePort()
@@ -218,6 +216,14 @@ func createStandaloneAddress(pluginID string) (string, error) {
 		return "", fmt.Errorf("get free port: %w", err)
 	}
 	return fmt.Sprintf(":%d", port), nil
+}
+
+func standaloneAddressFromEnv(pluginID string) (string, bool) {
+	addressEnvVar := "GF_PLUGIN_GRPC_ADDRESS_" + strings.ReplaceAll(strings.ToUpper(pluginID), "-", "_")
+	if v, ok := os.LookupEnv(addressEnvVar); ok {
+		return v, true
+	}
+	return "", false
 }
 
 func getStandalonePID(dir string) (int, error) {

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -2,6 +2,7 @@ package standalone
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -17,81 +18,144 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/internal"
 )
 
-type Args struct {
-	Address    string
-	PID        int
-	Standalone bool
-	Dir        string
-	Debugger   bool
+var (
+	standaloneEnabled = flag.Bool("standalone", false, "should this run standalone")
+	debugEnabled      = flag.Bool("debug", false, "run in debug mode")
+)
+
+func NewServerSettings(address string) ServerSettings {
+	return ServerSettings{
+		Address: address,
+	}
 }
 
-// StandaloneAddressFilePath returns the path to the standalone.txt file, which contains the standalone GRPC address
-func (a Args) StandaloneAddressFilePath() string {
-	return filepath.Join(a.Dir, "standalone.txt")
+type ServerSettings struct {
+	Address  string
+	Dir      string
+	Debugger bool
 }
 
-// StandalonePIDFilePath returns the path to the pid.txt file, which contains the standalone GRPC's server PID
-func (a Args) StandalonePIDFilePath() string {
-	return filepath.Join(a.Dir, "pid.txt")
+type ClientSettings struct {
+	TargetAddress string
+	TargetPID     int
 }
 
-func getInfo(id string, executable string, standalone, debug bool) (Args, error) {
-	var info Args
-	info.Standalone = standalone
+// ServerModeEnabled returns true if the plugin should run in standalone server mode.
+// It will first check for an environment variable GF_PLUGIN_GRPC_STANDALONE_<PLUGIN_ID>, and then the -standalone flag.
+func ServerModeEnabled(pluginID string) (ServerSettings, bool) {
+	flag.Parse() // Parse the flags so that we can check values for -standalone and -debug
 
-	// VsCode names the file "__debug_bin"
-	vsCodeDebug := strings.HasPrefix(filepath.Base(executable), "__debug_bin")
-	// GoLand places it in:
-	//  Linux: /tmp/GoLand/___%d%(CONFIGNAME)s_pkg
-	//  Mac OS X: /private/var/folders/lx/XXX/T/GoLand/___%d%(CONFIGNAME)s_pkg
-	//  Windows: C:\Users\USER\AppData\Local\Temp\GoLand\___%d%(CONFIGNAME)s_pkg.exe
-	goLandDebug := strings.Contains(executable, filepath.Join("GoLand", "___"))
-	if standalone && (vsCodeDebug || goLandDebug || debug) {
-		info.Debugger = true
-		js, err := findPluginJSON(executable)
+	var enabled bool
+	standaloneEnvVar := "GF_PLUGIN_GRPC_STANDALONE_" + strings.ReplaceAll(strings.ToUpper(pluginID), "-", "_")
+	if v, ok := os.LookupEnv(standaloneEnvVar); ok && v == "true" {
+		enabled = true
+	}
+
+	enabled = enabled || *standaloneEnabled
+
+	if enabled {
+		s, err := serverSettings(pluginID)
 		if err != nil {
-			return info, err
+			log.Printf("Error: %s", err.Error())
+			return ServerSettings{}, false
 		}
-		executable = js
+		return s, true
 	}
-	info.Dir = filepath.Dir(executable)
-
-	// Determine standalone address + PID
-	var err error
-	info.Address, err = getStandaloneAddress(id, info)
-	if err != nil {
-		return info, err
-	}
-	info.PID, err = getStandalonePID(info)
-	if err != nil {
-		return info, err
-	}
-	return info, nil
+	return ServerSettings{}, false
 }
 
-func GetInfo(id string) (Args, error) {
-	var standalone, debug bool
-	flag.BoolVar(&standalone, "standalone", false, "should this run standalone")
-	flag.BoolVar(&debug, "debug", false, "run in debug mode")
-	flag.Parse()
-
-	// standalone path
-	ex, err := os.Executable()
+// ClientModeEnabled returns standalone server connection settings if a standalone server is running and can be reached.
+func ClientModeEnabled(pluginID string) (ClientSettings, bool) {
+	s, err := clientSettings(pluginID)
 	if err != nil {
-		return Args{}, err
+		return ClientSettings{}, false
 	}
 
-	return getInfo(id, ex, standalone, debug)
+	return s, true
 }
 
-// will check a few options to find the dist plugin json file
-func findPluginJSON(exe string) (string, error) {
+// RunDummyPluginLocator runs the standalone server locator that Grafana uses to connect to the standalone GRPC server.
+func RunDummyPluginLocator(address string) {
+	fmt.Printf("1|2|tcp|%s|grpc\n", address)
+	t := time.NewTicker(time.Second * 10)
+
+	for ts := range t.C {
+		fmt.Printf("[%s] using address: %s\n", ts.Format("2006-01-02 15:04:05"), address)
+	}
+}
+
+func serverSettings(pluginID string) (ServerSettings, error) {
+	dir, err := currentProcPath()
+	if err != nil {
+		return ServerSettings{}, err
+	}
+
+	debug := debuggerEnabled(dir)
+	if debug {
+		pluginDir, err := findPluginRootDir(dir)
+		if err != nil {
+			return ServerSettings{}, err
+		}
+		dir = pluginDir
+	}
+
+	address, err := createStandaloneAddress(pluginID)
+	if err != nil {
+		return ServerSettings{}, err
+	}
+	return ServerSettings{
+		Address:  address,
+		Dir:      dir,
+		Debugger: debug,
+	}, nil
+}
+
+// clientSettings will attempt to find a standalone server's address and PID.
+func clientSettings(pluginID string) (ClientSettings, error) {
+	dir, err := currentProcPath()
+	if err != nil {
+		return ClientSettings{}, err
+	}
+
+	// Determine running standalone address + PID
+	standaloneAddress, err := getStandaloneAddress(pluginID, dir)
+	if err != nil {
+		return ClientSettings{}, err
+	}
+
+	if standaloneAddress == "" {
+		return ClientSettings{}, fmt.Errorf("address is empty")
+	}
+
+	standalonePID, err := getStandalonePID(dir)
+	if err != nil {
+		return ClientSettings{}, err
+	}
+
+	return ClientSettings{
+		TargetAddress: standaloneAddress,
+		TargetPID:     standalonePID,
+	}, nil
+}
+
+func currentProcPath() (string, error) {
+	curProcPath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(curProcPath), nil
+}
+
+// findPluginRootDir will attempt to find the dist plugin.json file based on the executing process's file-system path.
+func findPluginRootDir(exe string) (string, error) {
 	cwd, _ := os.Getwd()
 	if filepath.Base(cwd) == "pkg" {
 		cwd = filepath.Join(cwd, "..")
 	}
 
 	check := []string{
+		filepath.Join(exe, "plugin.json"),
+		filepath.Join(exe, "dist", "plugin.json"),
 		filepath.Join(filepath.Dir(exe), "plugin.json"),
 		filepath.Join(filepath.Dir(exe), "..", "dist", "plugin.json"),
 		filepath.Join(cwd, "dist", "plugin.json"),
@@ -100,30 +164,39 @@ func findPluginJSON(exe string) (string, error) {
 
 	for _, path := range check {
 		if _, err := os.Stat(path); err == nil {
-			return path, nil
+			return filepath.Dir(path), nil
 		}
 	}
 
-	return exe, fmt.Errorf("can not find plugin.json in: %v", check)
+	log.Printf("Can not find plugin.json in: %v", check)
+	return "", nil
 }
 
-func getStandaloneAddress(pluginID string, info Args) (string, error) {
-	if info.Debugger {
-		port, err := getFreePort()
-		if err != nil {
-			return "", fmt.Errorf("get free port: %w", err)
-		}
-		return fmt.Sprintf(":%d", port), nil
-	}
+// debuggedEnabled returns true if the plugin should run in debug mode.
+// It will first check the -debug flag and the name of the running process.
+func debuggerEnabled(curProcPath string) bool {
+	flag.Parse()
 
-	// Address from environment variable
-	envvar := "GF_PLUGIN_GRPC_ADDRESS_" + strings.ReplaceAll(strings.ToUpper(pluginID), "-", "_")
-	if v, ok := os.LookupEnv(envvar); ok {
+	// VsCode names the file "__debug_bin"
+	vsCodeDebug := strings.HasPrefix(filepath.Base(curProcPath), "__debug_bin")
+	// GoLand places it in:
+	//  Linux: /tmp/GoLand/___%d%(CONFIGNAME)s_pkg
+	//  Mac OS X: /private/var/folders/lx/XXX/T/GoLand/___%d%(CONFIGNAME)s_pkg
+	//  Windows: C:\Users\USER\AppData\Local\Temp\GoLand\___%d%(CONFIGNAME)s_pkg.exe
+	// Note: We also want to confirm we're not running a Go test binary
+	goLandDebug := strings.Contains(curProcPath, filepath.Join("GoLand", "___")) && filepath.Ext(curProcPath) != ".test"
+	df := *debugEnabled
+	return df || vsCodeDebug || goLandDebug
+}
+
+func getStandaloneAddress(pluginID string, dir string) (string, error) {
+	addressEnvVar := "GF_PLUGIN_GRPC_ADDRESS_" + strings.ReplaceAll(strings.ToUpper(pluginID), "-", "_")
+	if v, ok := os.LookupEnv(addressEnvVar); ok {
 		return v, nil
 	}
 
 	// Check the local file for address
-	fb, err := os.ReadFile(info.StandaloneAddressFilePath())
+	fb, err := os.ReadFile(standaloneAddressFilePath(dir))
 	addressFileContent := string(bytes.TrimSpace(fb))
 	switch {
 	case err != nil && !os.IsNotExist(err):
@@ -135,9 +208,22 @@ func getStandaloneAddress(pluginID string, info Args) (string, error) {
 	return addressFileContent, nil
 }
 
-func getStandalonePID(info Args) (int, error) {
+func createStandaloneAddress(pluginID string) (string, error) {
+	addressEnvVar := "GF_PLUGIN_GRPC_ADDRESS_" + strings.ReplaceAll(strings.ToUpper(pluginID), "-", "_")
+	if v, ok := os.LookupEnv(addressEnvVar); ok {
+		return v, nil
+	}
+
+	port, err := getFreePort()
+	if err != nil {
+		return "", fmt.Errorf("get free port: %w", err)
+	}
+	return fmt.Sprintf(":%d", port), nil
+}
+
+func getStandalonePID(dir string) (int, error) {
 	// Read PID (optional, as it was introduced later on)
-	fb, err := os.ReadFile(info.StandalonePIDFilePath())
+	fb, err := os.ReadFile(standalonePIDFilePath(dir))
 	pidFileContent := string(bytes.TrimSpace(fb))
 	switch {
 	case err != nil && !os.IsNotExist(err):
@@ -152,19 +238,16 @@ func getStandalonePID(info Args) (int, error) {
 		if err != nil {
 			return 0, fmt.Errorf("could not parse pid: %w", err)
 		}
-		return pid, err
+
+		if !checkPIDIsRunning(pid) {
+			return 0, errors.New("standlone pid is not running")
+		}
+
+		return pid, nil
 	}
 }
 
-func RunDummyPluginLocator(address string) {
-	fmt.Printf("1|2|tcp|%s|grpc\n", address)
-	t := time.NewTicker(time.Second * 10)
-
-	for ts := range t.C {
-		fmt.Printf("[%s] using address: %s\n", ts.Format("2006-01-02 15:04:05"), address)
-	}
-}
-
+// getFreePort returns a free port number on localhost.
 func getFreePort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {
@@ -179,46 +262,8 @@ func getFreePort() (int, error) {
 	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
-// CreateStandaloneAddressFile creates the standalone.txt file containing the address of the GRPC server
-func CreateStandaloneAddressFile(info Args) error {
-	return os.WriteFile(
-		info.StandaloneAddressFilePath(),
-		[]byte(info.Address),
-		0600,
-	)
-}
-
-// CreateStandalonePIDFile creates the pid.txt file containing the PID of the GRPC server process
-func CreateStandalonePIDFile(info Args) error {
-	return os.WriteFile(
-		info.StandalonePIDFilePath(),
-		[]byte(strconv.Itoa(os.Getpid())),
-		0600,
-	)
-}
-
-func cleanupStandaloneFile(fileName string) error {
-	err := os.Remove(fileName)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return nil
-}
-
-// CleanupStandaloneAddressFile attempts to delete standalone.txt from the specified folder.
-// If the file does not exist, the function returns nil.
-func CleanupStandaloneAddressFile(info Args) error {
-	return cleanupStandaloneFile(info.StandaloneAddressFilePath())
-}
-
-// CleanupStandalonePIDFile attempts to delete pid.txt from the specified folder.
-// If the file does not exist, the function returns nil.
-func CleanupStandalonePIDFile(info Args) error {
-	return cleanupStandaloneFile(info.StandalonePIDFilePath())
-}
-
-// FindAndKillCurrentPlugin kills the currently registered plugin, causing grafana to restart it
-// this time pointing to our new host.
+// FindAndKillCurrentPlugin kills the currently registered plugin, causing Grafana to restart it
+// and connect to our new host.
 func FindAndKillCurrentPlugin(dir string) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -226,15 +271,15 @@ func FindAndKillCurrentPlugin(dir string) {
 		}
 	}()
 
-	exeprefix, err := internal.GetExecutableFromPluginJSON(dir)
+	executablePath, err := internal.GetExecutableFromPluginJSON(dir)
 	if err != nil {
 		fmt.Printf("missing executable in plugin.json (standalone)")
 		return
 	}
 
-	out, err := exec.Command("pgrep", "-f", exeprefix).Output()
+	out, err := exec.Command("pgrep", "-f", executablePath).Output()
 	if err != nil {
-		fmt.Printf("error running pgrep: %s (%s)", err.Error(), exeprefix)
+		fmt.Printf("error running pgrep: %s (%s)", err.Error(), executablePath)
 		return
 	}
 	currentPID := os.Getpid()
@@ -256,8 +301,57 @@ func FindAndKillCurrentPlugin(dir string) {
 	}
 }
 
-// CheckPIDIsRunning returns true if there's a process with the specified PID
-func CheckPIDIsRunning(pid int) bool {
+// CreateStandaloneAddressFile creates the standalone.txt file containing the address of the GRPC server
+func CreateStandaloneAddressFile(address, dir string) error {
+	return os.WriteFile(
+		standaloneAddressFilePath(dir),
+		[]byte(address),
+		0600,
+	)
+}
+
+// CreateStandalonePIDFile creates the pid.txt file containing the PID of the GRPC server process
+func CreateStandalonePIDFile(pid int, dir string) error {
+	return os.WriteFile(
+		standalonePIDFilePath(dir),
+		[]byte(strconv.Itoa(pid)),
+		0600,
+	)
+}
+
+// CleanupStandaloneAddressFile attempts to delete standalone.txt from the specified folder.
+// If the file does not exist, the function returns nil.
+func CleanupStandaloneAddressFile(info ServerSettings) error {
+	return deleteFile(standaloneAddressFilePath(info.Dir))
+}
+
+// CleanupStandalonePIDFile attempts to delete pid.txt from the specified folder.
+// If the file does not exist, the function returns nil.
+func CleanupStandalonePIDFile(info ServerSettings) error {
+	return deleteFile(standalonePIDFilePath(info.Dir))
+}
+
+// deleteFile attempts to delete the specified file.
+func deleteFile(fileName string) error {
+	err := os.Remove(fileName)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// standaloneAddressFilePath returns the path to the standalone.txt file, which contains the standalone GRPC address
+func standaloneAddressFilePath(dir string) string {
+	return filepath.Join(dir, "standalone.txt")
+}
+
+// standalonePIDFilePath returns the path to the pid.txt file, which contains the standalone GRPC's server PID
+func standalonePIDFilePath(dir string) string {
+	return filepath.Join(dir, "pid.txt")
+}
+
+// checkPIDIsRunning returns true if there's a process with the specified PID
+func checkPIDIsRunning(pid int) bool {
 	if pid == 0 {
 		return false
 	}

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -45,15 +45,7 @@ type ClientSettings struct {
 func ServerModeEnabled(pluginID string) (ServerSettings, bool) {
 	flag.Parse() // Parse the flags so that we can check values for -standalone and -debug
 
-	var enabled bool
-	standaloneEnvVar := "GF_PLUGIN_GRPC_STANDALONE_" + strings.ReplaceAll(strings.ToUpper(pluginID), "-", "_")
-	if v, ok := os.LookupEnv(standaloneEnvVar); ok && v == "true" {
-		enabled = true
-	}
-
-	enabled = enabled || *standaloneEnabled
-
-	if enabled {
+	if *standaloneEnabled {
 		s, err := serverSettings(pluginID)
 		if err != nil {
 			log.Printf("Error: %s", err.Error())
@@ -187,7 +179,8 @@ func debuggerEnabled(curProcPath string) bool {
 	//  Linux: /tmp/GoLand/___%d%(CONFIGNAME)s_pkg
 	//  Mac OS X: /private/var/folders/lx/XXX/T/GoLand/___%d%(CONFIGNAME)s_pkg
 	//  Windows: C:\Users\USER\AppData\Local\Temp\GoLand\___%d%(CONFIGNAME)s_pkg.exe
-	// Note: We also want to confirm we're not running a Go test binary
+	// We also want to confirm we're not running a test through Goland, as that could lead to a false positive
+	// since all processes will match the below pattern.
 	goLandDebug := strings.Contains(curProcPath, filepath.Join("GoLand", "___")) && filepath.Ext(curProcPath) != ".test"
 	df := *debugEnabled
 	return df || vsCodeDebug || goLandDebug

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -85,14 +85,17 @@ func RunDummyPluginLocator(address string) {
 }
 
 func serverSettings(pluginID string) (ServerSettings, error) {
-	dir, err := currentProcPath()
+	curProcPath, err := currentProcPath()
 	if err != nil {
 		return ServerSettings{}, err
 	}
 
-	debug := debuggerEnabled(dir)
+	dir := filepath.Dir(curProcPath) // Default to current directory
+
+	debug := debuggerEnabled(curProcPath)
 	if debug {
-		pluginDir, err := findPluginRootDir(dir)
+		// If debug is enabled, we need to find the plugin root directory
+		pluginDir, err := findPluginRootDir(curProcPath)
 		if err != nil {
 			return ServerSettings{}, err
 		}
@@ -112,10 +115,12 @@ func serverSettings(pluginID string) (ServerSettings, error) {
 
 // clientSettings will attempt to find a standalone server's address and PID.
 func clientSettings(pluginID string) (ClientSettings, error) {
-	dir, err := currentProcPath()
+	procPath, err := currentProcPath()
 	if err != nil {
 		return ClientSettings{}, err
 	}
+
+	dir := filepath.Dir(procPath)
 
 	// Determine running standalone address + PID
 	standaloneAddress, err := getStandaloneAddress(pluginID, dir)
@@ -143,7 +148,7 @@ func currentProcPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Dir(curProcPath), nil
+	return curProcPath, nil
 }
 
 // findPluginRootDir will attempt to find a plugin directory based on the executing process's file-system path.

--- a/internal/standalone/standalone_test.go
+++ b/internal/standalone/standalone_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const pluginID = "grafana-test-datasource"
+const (
+	pluginID = "grafana-test-datasource"
+	addr     = "localhost:1234"
+)
 
 func TestServerModeEnabled(t *testing.T) {
 	t.Run("Disabled by default", func(t *testing.T) {
@@ -84,7 +87,6 @@ func TestClientModeEnabled(t *testing.T) {
 	})
 
 	t.Run("Enabled by env var", func(t *testing.T) {
-		addr := "localhost:1234"
 		t.Setenv("GF_PLUGIN_GRPC_ADDRESS_GRAFANA_TEST_DATASOURCE", addr)
 
 		settings, enabled := ClientModeEnabled(pluginID)
@@ -94,8 +96,6 @@ func TestClientModeEnabled(t *testing.T) {
 	})
 
 	t.Run("Enabled by standalone.txt file with valid address", func(t *testing.T) {
-		addr := "localhost:1234"
-
 		curProcPath, err := os.Executable()
 		require.NoError(t, err)
 
@@ -136,7 +136,6 @@ func TestClientModeEnabled(t *testing.T) {
 	})
 
 	t.Run("Enabled if pid.txt exists, but is empty", func(t *testing.T) {
-		addr := "localhost:1234"
 		t.Setenv("GF_PLUGIN_GRPC_ADDRESS_GRAFANA_TEST_DATASOURCE", addr)
 
 		curProcPath, err := os.Executable()
@@ -157,7 +156,6 @@ func TestClientModeEnabled(t *testing.T) {
 	})
 
 	t.Run("Disabled if pid.txt exists, but has invalid pid", func(t *testing.T) {
-		addr := "localhost:1234"
 		t.Setenv("GF_PLUGIN_GRPC_ADDRESS_GRAFANA_TEST_DATASOURCE", addr)
 
 		curProcPath, err := os.Executable()

--- a/internal/standalone/standalone_test.go
+++ b/internal/standalone/standalone_test.go
@@ -20,16 +20,6 @@ func TestServerModeEnabled(t *testing.T) {
 		require.Empty(t, settings)
 	})
 
-	t.Run("Enabled by env var", func(t *testing.T) {
-		t.Setenv("GF_PLUGIN_GRPC_STANDALONE_GRAFANA_TEST_DATASOURCE", "true")
-
-		settings, enabled := ServerModeEnabled(pluginID)
-		require.True(t, enabled)
-		require.False(t, settings.Debugger)
-		require.NotEmpty(t, settings.Address)
-		require.NotEmpty(t, settings.Dir)
-	})
-
 	t.Run("Enabled by flag", func(t *testing.T) {
 		before := standaloneEnabled
 		t.Cleanup(func() {
@@ -70,7 +60,12 @@ func TestServerModeEnabled(t *testing.T) {
 				require.NoError(t, err)
 			})
 
-			t.Setenv("GF_PLUGIN_GRPC_STANDALONE_GRAFANA_TEST_DATASOURCE", "true")
+			before = standaloneEnabled
+			t.Cleanup(func() {
+				standaloneEnabled = before
+			})
+			standaloneEnabled = &truthy
+
 			settings, enabled = ServerModeEnabled(pluginID)
 			require.True(t, enabled)
 			require.True(t, settings.Debugger)

--- a/internal/standalone/standalone_test.go
+++ b/internal/standalone/standalone_test.go
@@ -1,68 +1,97 @@
 package standalone
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetInfo(t *testing.T) {
-	t.Run("normal", func(t *testing.T) {
-		info, err := getInfo("plugin", "testdata/plugin/gpx_plugin", false, false)
-		require.NoError(t, err)
-		require.False(t, info.Standalone)
-		require.False(t, info.Debugger)
+const pluginID = "grafana-test-datasource"
+
+func TestServerModeEnabled(t *testing.T) {
+	t.Run("Disabled by default", func(t *testing.T) {
+		settings, enabled := ServerModeEnabled(pluginID)
+		require.False(t, enabled)
+		require.Empty(t, settings)
 	})
 
-	t.Run("standalone", func(t *testing.T) {
-		t.Run("without debug flag", func(t *testing.T) {
-			info, err := getInfo("plugin", "testdata/plugin/gpx_plugin", true, false)
-			require.NoError(t, err)
-			require.True(t, info.Standalone)
-			require.False(t, info.Debugger)
-			// No random free port, must be read from standalone.txt
-			require.Empty(t, info.Address)
-		})
+	t.Run("Enabled by env var", func(t *testing.T) {
+		t.Setenv("GF_PLUGIN_GRPC_STANDALONE_GRAFANA_TEST_DATASOURCE", "true")
 
-		t.Run("with debug flag", func(t *testing.T) {
-			info, err := getInfo("plugin", "testdata/plugin/gpx_plugin", true, true)
-			require.NoError(t, err)
-			require.True(t, info.Standalone)
-			require.True(t, info.Debugger)
-			// Should have a random free port
-			require.NotEmpty(t, info.Address)
-		})
+		settings, enabled := ServerModeEnabled(pluginID)
+		require.True(t, enabled)
+		require.False(t, settings.Debugger)
+		require.NotEmpty(t, settings.Address)
+		require.NotEmpty(t, settings.Dir)
+	})
 
-		t.Run("with debug executable", func(t *testing.T) {
-			for _, fn := range []string{
-				// VsCode
-				"testdata/plugin/__debug_bin",
-				"testdata/plugin/__debug_bin.exe",
-				// GoLand: Default run config name
-				"testdata/GoLand/___XXgo_build_github_com_PACKAGENAME_pkg",
-				"testdata/GoLand/___XXgo_build_github_com_PACKAGENAME_pkg.exe",
-				// GoLand: Different run config name
-				"testdata/GoLand/___1PLUGIN",
-				"testdata/GoLand/___1PLUGIN.exe",
-			} {
-				t.Run(fn, func(t *testing.T) {
-					info, err := getInfo("plugin", fn, true, false)
-					require.NoError(t, err)
-					require.True(t, info.Standalone)
-					require.True(t, info.Debugger)
-					// Should have a random free port
-					require.NotEmpty(t, info.Address)
-				})
-			}
+	t.Run("Enabled by flag", func(t *testing.T) {
+		before := standaloneEnabled
+		t.Cleanup(func() {
+			standaloneEnabled = before
 		})
+		truthy := true
+		standaloneEnabled = &truthy
 
-		t.Run("no debug with standalone.txt file", func(t *testing.T) {
-			info, err := getInfo("plugin", "testdata/standalone-txt/gpx_plugin", true, false)
+		settings, enabled := ServerModeEnabled(pluginID)
+		require.True(t, enabled)
+		require.False(t, settings.Debugger)
+		require.NotEmpty(t, settings.Address)
+		require.NotEmpty(t, settings.Dir)
+	})
+
+	t.Run("Debug enabled by flag, but only when standalone is enabled and process has access to a plugin.json file",
+		func(t *testing.T) {
+			before := debugEnabled
+			t.Cleanup(func() {
+				debugEnabled = before
+			})
+			truthy := true
+			debugEnabled = &truthy
+
+			settings, enabled := ServerModeEnabled(pluginID)
+			require.False(t, enabled)
+			require.Empty(t, settings)
+
+			curProcPath, err := os.Executable()
 			require.NoError(t, err)
-			require.True(t, info.Standalone)
-			require.False(t, info.Debugger)
-			// Read from standalone.txt
-			require.Equal(t, ":1234", info.Address)
+
+			dir := filepath.Dir(curProcPath)
+
+			file, err := os.Create(filepath.Join(dir, "plugin.json"))
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				err = os.Remove(file.Name())
+				require.NoError(t, err)
+			})
+
+			t.Setenv("GF_PLUGIN_GRPC_STANDALONE_GRAFANA_TEST_DATASOURCE", "true")
+			settings, enabled = ServerModeEnabled(pluginID)
+			require.True(t, enabled)
+			require.True(t, settings.Debugger)
+			require.NotEmpty(t, settings.Address)
+			require.Equal(t, dir, settings.Dir)
 		})
+}
+
+func Test_debuggerEnabled(t *testing.T) {
+	t.Run("debug paths", func(t *testing.T) {
+		for _, processPaths := range []string{
+			// VsCode
+			"testdata/plugin/__debug_bin",
+			"testdata/plugin/__debug_bin.exe",
+			// GoLand: Default run config name
+			"testdata/GoLand/___XXgo_build_github_com_PACKAGENAME_pkg",
+			"testdata/GoLand/___XXgo_build_github_com_PACKAGENAME_pkg.exe",
+			// GoLand: Different run config name
+			"testdata/GoLand/___1PLUGIN",
+			"testdata/GoLand/___1PLUGIN.exe",
+		} {
+			t.Run(processPaths, func(t *testing.T) {
+				require.True(t, debuggerEnabled(processPaths))
+			})
+		}
 	})
 }

--- a/internal/tenant/tenanttest/tenant_test.go
+++ b/internal/tenant/tenanttest/tenant_test.go
@@ -53,9 +53,7 @@ func TestTenantWithPluginInstanceManagement(t *testing.T) {
 			CallResourceHandler: handler,
 			StreamHandler:       handler,
 			CheckHealthHandler:  handler,
-		}, standalone.Args{
-			Address: addr,
-		})
+		}, standalone.NewServerSettings(addr))
 		require.NoError(t, err)
 	}()
 

--- a/internal/tenant/tenanttest/tenant_test.go
+++ b/internal/tenant/tenanttest/tenant_test.go
@@ -53,7 +53,7 @@ func TestTenantWithPluginInstanceManagement(t *testing.T) {
 			CallResourceHandler: handler,
 			StreamHandler:       handler,
 			CheckHealthHandler:  handler,
-		}, standalone.NewServerSettings(addr))
+		}, standalone.NewServerSettings(addr, t.TempDir()))
 		require.NoError(t, err)
 	}()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR attempts to simplify how the standalone package works by refactor into a client/server pattern. I found it quite difficult to navigate as we historically have combined both standalone and locator functionality in the same code path, which makes it tricky to know what information is needed and where.

Compatibility changes:
```
# github.com/grafana/grafana-plugin-sdk-go/backend
## incompatible changes
GracefulStandaloneServe: changed from func(ServeOpts, github.com/grafana/grafana-plugin-sdk-go/internal/standalone.Args) error to func(ServeOpts, github.com/grafana/grafana-plugin-sdk-go/internal/standalone.ServerSettings) error
StandaloneServe: removed
```

**Special notes for your reviewer**:
- This PR removes the need for a `-debug` flag as standalone/server mode will now always generate a `standalone.txt` and `pid.txt`.
- `GF_PLUGIN_GRPC_ADDRESS_<PLUGIN_ID>` is an existing env var, but now both client and server will use this as the primary source of truth for creating or connecting to the standalone server. The pre-existing generation of the address and reading from file still exists, but are treated as fallbacks in their respective modes.