### PR TITLE
FrameMeta: add PreferredVisualizationPluginId field to API

### DIFF
--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -43,7 +43,7 @@ type FrameMeta struct {
 
 	// PreferredVisualizationPluginId sets the panel plugin id to use to render the data when using Explore. If
 	// the plugin cannot be found will fall back to PreferredVisualization.
-	PreferredVisualizationPluginId string `json:"preferredVisualisationPluginId,omitempty"`
+	PreferredVisualizationPluginID string `json:"preferredVisualisationPluginId,omitempty"`
 
 	// ExecutedQueryString is the raw query sent to the underlying system. All macros and templating
 	// have been applied.  When metadata contains this value, it will be shown in the query inspector.

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -41,6 +41,10 @@ type FrameMeta struct {
 	// PreferredVisualization is currently used to show results in Explore only in preferred visualisation option.
 	PreferredVisualization VisType `json:"preferredVisualisationType,omitempty"`
 
+	// PreferredVisualizationPluginId sets the panel plugin id to use to render the data when using Explore. If
+	// the plugin cannot be found will fall back to PreferredVisualization.
+	PreferredVisualizationPluginId string `json:"preferredVisualisationPluginId,omitempty"`
+
 	// ExecutedQueryString is the raw query sent to the underlying system. All macros and templating
 	// have been applied.  When metadata contains this value, it will be shown in the query inspector.
 	ExecutedQueryString string `json:"executedQueryString,omitempty"`


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
This will add the field '' to the FrameMeta type. This is linked to the PR I have open on grafana/grafana https://github.com/grafana/grafana/pull/66982.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
