### PR TITLE
Adds a NopLogger to the backend/log package.

### DIFF
--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -44,6 +44,20 @@ func NewWithLevel(level Level) Logger {
 	}
 }
 
+type NopLogger struct{}
+
+func (n *NopLogger) Debug(msg string, args ...interface{}) {}
+
+func (n *NopLogger) Info(msg string, args ...interface{}) {}
+
+func (n *NopLogger) Warn(msg string, args ...interface{}) {}
+
+func (n *NopLogger) Error(msg string, args ...interface{}) {}
+
+func (n *NopLogger) Level() Level {
+	return NoLevel
+}
+
 type hclogWrapper struct {
 	logger hclog.Logger
 }


### PR DESCRIPTION
This is useful in testing and occasionally in other scenarios for plugin authors.


**What this PR does / why we need it**:
Adds a NopLogger to the backend/log package. This is useful in testing and occasionally in other scenarios for plugin authors.

**Which issue(s) this PR fixes**:

Fixes #708 