### PR TITLE
Secure socks proxy: Modify how proxy options can be set

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -231,14 +231,9 @@ func (s *DataSourceInstanceSettings) ProxyOptions() (*proxy.Options, error) {
 		}
 	}
 
-	// the proxy defaults to disabled
-	if res, exists := dat["enableSecureSocksProxy"]; exists {
-		if val, ok := res.(bool); !ok || !val {
-			return opts, nil
-		}
-		opts.Enabled = true
-	} else {
-		return opts, nil
+	opts.Enabled = proxy.SecureSocksProxyEnabledOnDS(dat)
+	if !opts.Enabled {
+		return nil, nil
 	}
 
 	opts.Auth = &proxy.AuthOptions{}

--- a/backend/common.go
+++ b/backend/common.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"github.com/grafana/grafana-plugin-sdk-go/internal/tenant"
 )
 
@@ -119,6 +120,17 @@ func (s *DataSourceInstanceSettings) HTTPClientOptions() (httpclient.Options, er
 	opts.Labels["datasource_name"] = s.Name
 	opts.Labels["datasource_uid"] = s.UID
 	opts.Labels["datasource_type"] = s.Type
+
+	if opts.ProxyOptions != nil {
+		// default username is the datasource uid, this can be updated
+		// by setting `secureSocksProxyUsername` in the datasource json
+		if opts.ProxyOptions.Auth == nil {
+			opts.ProxyOptions.Auth = &proxy.AuthOptions{}
+		}
+		if opts.ProxyOptions.Auth.Username == "" {
+			opts.ProxyOptions.Auth.Username = opts.Labels["datasource_uid"]
+		}
+	}
 
 	setCustomOptionsFromHTTPSettings(&opts, httpSettings)
 

--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -265,11 +265,11 @@ func TestProxyOptions(t *testing.T) {
 	t.Run("ProxyOptions() should translate settings as expected", func(t *testing.T) {
 		tcs := []struct {
 			instanceSettings      *DataSourceInstanceSettings
-			expectedClientOptions proxy.Options
+			expectedClientOptions *proxy.Options
 		}{
 			{
 				instanceSettings:      &DataSourceInstanceSettings{},
-				expectedClientOptions: proxy.Options{},
+				expectedClientOptions: nil,
 			},
 			{
 				instanceSettings: &DataSourceInstanceSettings{
@@ -281,7 +281,7 @@ func TestProxyOptions(t *testing.T) {
 					BasicAuthEnabled: true,
 					BasicAuthUser:    "buser",
 				},
-				expectedClientOptions: proxy.Options{},
+				expectedClientOptions: nil,
 			},
 			{
 				instanceSettings: &DataSourceInstanceSettings{
@@ -293,7 +293,7 @@ func TestProxyOptions(t *testing.T) {
 					BasicAuthEnabled: true,
 					BasicAuthUser:    "buser",
 				},
-				expectedClientOptions: proxy.Options{
+				expectedClientOptions: &proxy.Options{
 					Enabled: true,
 					Auth: &proxy.AuthOptions{
 						Username: "uid1",
@@ -314,7 +314,7 @@ func TestProxyOptions(t *testing.T) {
 						"secureSocksProxyPassword": "pswd",
 					},
 				},
-				expectedClientOptions: proxy.Options{
+				expectedClientOptions: &proxy.Options{
 					Enabled: true,
 					Auth: &proxy.AuthOptions{
 						Username: "username",
@@ -333,7 +333,7 @@ func TestProxyOptions(t *testing.T) {
 					BasicAuthEnabled: true,
 					BasicAuthUser:    "buser",
 				},
-				expectedClientOptions: proxy.Options{
+				expectedClientOptions: &proxy.Options{
 					Enabled: true,
 					Auth: &proxy.AuthOptions{
 						Username: "uid1",
@@ -349,9 +349,7 @@ func TestProxyOptions(t *testing.T) {
 		for _, tc := range tcs {
 			opts, err := tc.instanceSettings.ProxyOptions()
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedClientOptions.Enabled, opts.Enabled)
-			assert.Equal(t, tc.expectedClientOptions.Auth, opts.Auth)
-			assert.Equal(t, tc.expectedClientOptions.Timeouts, opts.Timeouts)
+			assert.Equal(t, tc.expectedClientOptions, opts)
 		}
 	})
 }

--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -160,6 +161,27 @@ func TestDataSourceInstanceSettings(t *testing.T) {
 						secureDataCustomOptionsKey: map[string]string{
 							"sKey": "sValue",
 						},
+					},
+				},
+			},
+			{
+				instanceSettings: &DataSourceInstanceSettings{
+					UID:                     "uid1",
+					JSONData:                []byte("{ \"enableSecureSocksProxy\": true }"),
+					DecryptedSecureJSONData: map[string]string{},
+				},
+				expectedClientOptions: httpclient.Options{
+					ProxyOptions: &proxy.Options{
+						Enabled: true,
+						Auth: &proxy.AuthOptions{
+							Username: "uid1",
+						},
+					},
+					CustomOptions: map[string]interface{}{
+						dataCustomOptionsKey: map[string]interface{}{
+							"enableSecureSocksProxy": true,
+						},
+						secureDataCustomOptionsKey: map[string]string{},
 					},
 				},
 			},

--- a/backend/http_settings.go
+++ b/backend/http_settings.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 )
 
 // HTTPSettings is a convenient struct for holding decoded HTTP settings from
@@ -45,10 +44,6 @@ type HTTPSettings struct {
 	SigV4Profile       string
 	SigV4AccessKey     string
 	SigV4SecretKey     string
-
-	SecureSocksProxyEnabled  bool
-	SecureSocksProxyUsername string
-	SecureSocksProxyPass     string
 
 	JSONData       map[string]interface{}
 	SecureJSONData map[string]string
@@ -100,20 +95,6 @@ func (s *HTTPSettings) HTTPClientOptions() httpclient.Options {
 			AssumeRoleARN: s.SigV4AssumeRoleARN,
 			ExternalID:    s.SigV4ExternalID,
 			Region:        s.SigV4Region,
-		}
-	}
-
-	if s.SecureSocksProxyEnabled {
-		opts.ProxyOptions = &proxy.Options{
-			Enabled: s.SecureSocksProxyEnabled,
-			Timeouts: &proxy.TimeoutOptions{
-				Timeout:   s.Timeout,
-				KeepAlive: s.KeepAlive,
-			},
-			Auth: &proxy.AuthOptions{
-				Username: s.SecureSocksProxyUsername,
-				Password: s.SecureSocksProxyPass,
-			},
 		}
 	}
 
@@ -281,20 +262,6 @@ func parseHTTPSettings(jsonData json.RawMessage, secureJSONData map[string]strin
 		}
 		if v, exists := secureJSONData["sigV4SecretKey"]; exists {
 			s.SigV4SecretKey = v
-		}
-	}
-
-	// secure socks proxy
-	if v, exists := dat["enableSecureSocksProxy"]; exists {
-		s.SecureSocksProxyEnabled = v.(bool)
-	}
-
-	if s.SecureSocksProxyEnabled {
-		if v, exists := dat["secureSocksProxyUsername"]; exists {
-			s.SecureSocksProxyUsername = v.(string)
-		}
-		if v, exists := secureJSONData["secureSocksProxyPassword"]; exists {
-			s.SecureSocksProxyPass = v
 		}
 	}
 

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -159,17 +159,6 @@ func createOptions(providedOpts ...Options) Options {
 		opts.Middlewares = DefaultMiddlewares()
 	}
 
-	if proxy.SecureSocksProxyEnabled(opts.ProxyOptions) {
-		// default username is the datasource uid, this can be updated
-		// by setting `secureSocksProxyUsername` in the datasource json
-		if opts.ProxyOptions.Auth == nil {
-			opts.ProxyOptions.Auth = &proxy.AuthOptions{}
-		}
-		if opts.ProxyOptions.Auth.Username == "" {
-			opts.ProxyOptions.Auth.Username = opts.Labels["datasource_uid"]
-		}
-	}
-
 	return opts
 }
 

--- a/backend/proxy/options.go
+++ b/backend/proxy/options.go
@@ -28,7 +28,7 @@ var DefaultTimeoutOptions = TimeoutOptions{
 	KeepAlive: 30 * time.Second,
 }
 
-func createOptions(providedOpts *Options) Options {
+func setDefaults(providedOpts *Options) Options {
 	var opts Options
 	if providedOpts == nil {
 		return opts

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -114,7 +114,7 @@ func NewSecureSocksProxyContextDialer(opts *Options) (proxy.Dialer, error) {
 		return nil, err
 	}
 
-	clientOpts := createOptions(opts)
+	clientOpts := setDefaults(opts)
 
 	certPool := x509.NewCertPool()
 	for _, rootCAFile := range strings.Split(cfg.rootCA, " ") {

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -70,21 +70,6 @@ func SecureSocksProxyEnabled(opts *Options) bool {
 	return false
 }
 
-// SecureSocksProxyEnabledOnDS checks the datasource json data for `enableSecureSocksProxy`
-// to determine if the secure socks proxy should be enabled on it
-func SecureSocksProxyEnabledOnDS(jsonData map[string]interface{}) bool {
-	res, enabled := jsonData["enableSecureSocksProxy"]
-	if !enabled {
-		return false
-	}
-
-	if val, ok := res.(bool); ok {
-		return val
-	}
-
-	return false
-}
-
 // ConfigureSecureSocksHTTPProxy takes a http.DefaultTransport and wraps it in a socks5 proxy with TLS
 // if it is enabled on the datasource and the grafana instance
 func ConfigureSecureSocksHTTPProxy(transport *http.Transport, opts *Options) error {

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -70,6 +70,21 @@ func SecureSocksProxyEnabled(opts *Options) bool {
 	return false
 }
 
+// SecureSocksProxyEnabledOnDS checks the datasource json data for `enableSecureSocksProxy`
+// to determine if the secure socks proxy should be enabled on it
+func SecureSocksProxyEnabledOnDS(jsonData map[string]interface{}) bool {
+	res, enabled := jsonData["enableSecureSocksProxy"]
+	if !enabled {
+		return false
+	}
+
+	if val, ok := res.(bool); ok {
+		return val
+	}
+
+	return false
+}
+
 // ConfigureSecureSocksHTTPProxy takes a http.DefaultTransport and wraps it in a socks5 proxy with TLS
 // if it is enabled on the datasource and the grafana instance
 func ConfigureSecureSocksHTTPProxy(transport *http.Transport, opts *Options) error {

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -108,36 +108,6 @@ func TestSecureSocksProxyConfigEnv(t *testing.T) {
 	assert.Equal(t, &expected, actual)
 }
 
-func TestSecureSocksProxyEnabledOnDS(t *testing.T) {
-	t.Run("Secure socks proxy should only be enabled when the json data contains enableSecureSocksProxy=true", func(t *testing.T) {
-		tests := []struct {
-			jsonData map[string]interface{}
-			enabled  bool
-		}{
-			{
-				jsonData: map[string]interface{}{},
-				enabled:  false,
-			},
-			{
-				jsonData: map[string]interface{}{"enableSecureSocksProxy": "nonbool"},
-				enabled:  false,
-			},
-			{
-				jsonData: map[string]interface{}{"enableSecureSocksProxy": false},
-				enabled:  false,
-			},
-			{
-				jsonData: map[string]interface{}{"enableSecureSocksProxy": true},
-				enabled:  true,
-			},
-		}
-
-		for _, tt := range tests {
-			assert.Equal(t, tt.enabled, SecureSocksProxyEnabledOnDS(tt.jsonData))
-		}
-	})
-}
-
 func TestPreventInvalidRootCA(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv(PluginSecureSocksProxyClientCert, "client.crt")

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -108,6 +108,36 @@ func TestSecureSocksProxyConfigEnv(t *testing.T) {
 	assert.Equal(t, &expected, actual)
 }
 
+func TestSecureSocksProxyEnabledOnDS(t *testing.T) {
+	t.Run("Secure socks proxy should only be enabled when the json data contains enableSecureSocksProxy=true", func(t *testing.T) {
+		tests := []struct {
+			jsonData map[string]interface{}
+			enabled  bool
+		}{
+			{
+				jsonData: map[string]interface{}{},
+				enabled:  false,
+			},
+			{
+				jsonData: map[string]interface{}{"enableSecureSocksProxy": "nonbool"},
+				enabled:  false,
+			},
+			{
+				jsonData: map[string]interface{}{"enableSecureSocksProxy": false},
+				enabled:  false,
+			},
+			{
+				jsonData: map[string]interface{}{"enableSecureSocksProxy": true},
+				enabled:  true,
+			},
+		}
+
+		for _, tt := range tests {
+			assert.Equal(t, tt.enabled, SecureSocksProxyEnabledOnDS(tt.jsonData))
+		}
+	})
+}
+
 func TestPreventInvalidRootCA(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv(PluginSecureSocksProxyClientCert, "client.crt")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors how the proxy options are set. Perviously, it was set mainly in the `HTTPClientOptions()` function, but then the socks user was set in the client. This made it both harder to understand when and why things are being set, and prevented non-http clients from setting it up in a straightforward manner.

This PR extracts all the functionality into the function `ProxyOptions()`, which simplifies the code base and is non-http specific. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/hosted-grafana/issues/4030