### PR TITLE
build: perform one-by-one build

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -223,7 +223,7 @@ func (Build) Backend() error {
 // BuildAll builds production executables for all supported platforms.
 func BuildAll() { //revive:disable-line
 	b := Build{}
-	mg.Deps(b.Linux, b.Windows, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM, b.GenerateManifestFile)
+	mg.SerialDeps(b.Linux, b.Windows, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM, b.GenerateManifestFile)
 }
 
 //go:embed tmpl/*


### PR DESCRIPTION
**What this PR does / why we need it**:

1) avoid duplicate package requests to `${GOPROXY}` and `${GOSUMDB}` - first binary target fetches all required packages and further binary builds reuse them.

2) respect `${GOMAXPROCS}` (if any).