### PR TITLE
Instrument secure socks dialer

### DIFF
--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -281,11 +281,12 @@ func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr strin
 	c, err := dialer.DialContext(ctx, n, addr)
 
 	var code string
-	var socksErr *net.OpError
+	var oppErr *net.OpError
 
-	if err == nil {
+	switch {
+	case err == nil:
 		code = "0"
-	} else if errors.As(err, &socksErr) && strings.Contains(socksErr.Op, "socks") {
+	case errors.As(err, &oppErr):
 		// Socks errors defined here: https://cs.opensource.google/go/x/net/+/refs/tags/v0.15.0:internal/socks/socks.go;l=40-63
 
 		unknownCode := socksUnknownError.FindStringSubmatch(err.Error())
@@ -312,8 +313,7 @@ func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr strin
 		default:
 			code = "socks_unknown_error"
 		}
-
-	} else {
+	default:
 		code = "dial_error"
 	}
 

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -42,11 +42,11 @@ var (
 )
 
 var (
-	socksUnknownError              = regexp.MustCompile(`unknown code: (\d+)`)
-	secureSocksConnectionsDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	socksUnknownError           = regexp.MustCompile(`unknown code: (\d+)`)
+	secureSocksRequestsDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "grafana",
-		Name:      "secure_socks_connections_duration",
-		Help:      "Duration of establishing a connection to a secure socks proxy",
+		Name:      "secure_socks_requests_duration",
+		Help:      "Duration of requests to the secure socks proxy",
 	}, []string{"code"})
 )
 
@@ -317,6 +317,6 @@ func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr strin
 		code = "dial_error"
 	}
 
-	secureSocksConnectionsDuration.WithLabelValues(code).Observe(time.Since(start).Seconds())
+	secureSocksRequestsDuration.WithLabelValues(code).Observe(time.Since(start).Seconds())
 	return c, err
 }

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -281,11 +281,11 @@ func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr strin
 	c, err := dialer.DialContext(ctx, n, addr)
 
 	var code string
-	var e *net.OpError
+	var socksErr *net.OpError
 
 	if err == nil {
 		code = "0"
-	} else if errors.As(err, &e) && strings.Contains(err.(*net.OpError).Op, "socks") {
+	} else if errors.As(err, &socksErr) && strings.Contains(socksErr.Op, "socks") {
 		// Socks errors defined here: https://cs.opensource.google/go/x/net/+/refs/tags/v0.15.0:internal/socks/socks.go;l=40-63
 
 		unknownCode := socksUnknownError.FindStringSubmatch(err.Error())


### PR DESCRIPTION
**What this PR does / why we need it**:
Instrument the secure socks proxy dialer.

**Special notes for your reviewer**:

The go socks client doesn't return the response codes directly. Those have to be parsed from the response error.