### PR TITLE
SQLUtil IntOrFloatToNullableFloat64 float32 conversion fix

### DIFF
--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -398,7 +398,7 @@ var IntOrFloatToNullableFloat64 = data.FieldConverter{
 			return &val, nil
 		case float32:
 			fval := float64(val)
-			return fval, nil
+			return &fval, nil
 		case int:
 			fval := float64(val)
 			return &fval, nil


### PR DESCRIPTION
Supports https://github.com/grafana/support-escalations/issues/7279

There was a bug when dealing float32 when converting to nullablefloat64 since we were returning the float64 but not a pointer.

This PR addresses that