### PR TITLE
supported multiple result sets in *sql.Rows result from db.QueryContext

### DIFF
--- a/data/sqlutil/dynamic_frame.go
+++ b/data/sqlutil/dynamic_frame.go
@@ -25,63 +25,67 @@ func findDataTypes(rows Rows, rowLimit int64, types []*sql.ColumnType) ([]Field,
 
 	var returnData [][]interface{}
 
-	for rows.Next() {
+	for {
 		if i == rowLimit {
 			break
 		}
-
-		row := make([]interface{}, len(types))
-		for i := range row {
-			row[i] = new(interface{})
-		}
-		err := rows.Scan(row)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		returnData = append(returnData, row)
-
-		if len(fields) == len(types) {
-			// found all data types.  keep looping to load all the return data
-			continue
-		}
-
-		for colIdx, col := range row {
-			val := *col.(*interface{})
-			var field Field
-			colType := types[colIdx]
-			switch val.(type) {
-			case time.Time, *time.Time:
-				field.converter = &TimeToNullableTime
-				field.kind = "time"
-				field.name = colType.Name()
-			case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-				field.converter = &IntOrFloatToNullableFloat64
-				field.kind = "float64"
-				field.name = colType.Name()
-			case string:
-				field.converter = &converters.AnyToNullableString
-				field.kind = STRING
-				field.name = colType.Name()
-			case []uint8:
-				field.converter = &converters.Uint8ArrayToNullableString
-				field.kind = STRING
-				field.name = colType.Name()
-			case nil:
-				continue
-			default:
-				field.converter = &converters.AnyToNullableString
-				field.kind = STRING
-				field.name = colType.Name()
+		for rows.Next() {
+			row := make([]interface{}, len(types))
+			for i := range row {
+				row[i] = new(interface{})
+			}
+			err := rows.Scan(row)
+			if err != nil {
+				return nil, nil, err
 			}
 
-			fields[colIdx] = field
-		}
+			returnData = append(returnData, row)
 
-		i++
+			if len(fields) == len(types) {
+				// found all data types.  keep looping to load all the return data
+				continue
+			}
+
+			for colIdx, col := range row {
+				val := *col.(*interface{})
+				var field Field
+				colType := types[colIdx]
+				switch val.(type) {
+				case time.Time, *time.Time:
+					field.converter = &TimeToNullableTime
+					field.kind = "time"
+					field.name = colType.Name()
+				case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+					field.converter = &IntOrFloatToNullableFloat64
+					field.kind = "float64"
+					field.name = colType.Name()
+				case string:
+					field.converter = &converters.AnyToNullableString
+					field.kind = STRING
+					field.name = colType.Name()
+				case []uint8:
+					field.converter = &converters.Uint8ArrayToNullableString
+					field.kind = STRING
+					field.name = colType.Name()
+				case nil:
+					continue
+				default:
+					field.converter = &converters.AnyToNullableString
+					field.kind = STRING
+					field.name = colType.Name()
+				}
+
+				fields[colIdx] = field
+			}
+
+			i++
+		}
+		if !rows.NextResultSet() {
+			break
+		}
 	}
 
-	fieldList := []Field{}
+	fieldList := make([]Field, len(types))
 	for colIdx, col := range types {
 		field, ok := fields[colIdx]
 		field.name = col.Name()
@@ -92,7 +96,7 @@ func findDataTypes(rows Rows, rowLimit int64, types []*sql.ColumnType) ([]Field,
 				name:      col.Name(),
 			}
 		}
-		fieldList = append(fieldList, field)
+		fieldList[colIdx] = field
 	}
 
 	return fieldList, returnData, nil
@@ -172,6 +176,10 @@ type Field struct {
 	kind      string
 }
 
+type ResultSetIterator interface {
+	NextResultSet() bool
+}
+
 type RowIterator interface {
 	Next() bool
 	Scan(dest ...interface{}) error
@@ -179,6 +187,13 @@ type RowIterator interface {
 
 type Rows struct {
 	itr RowIterator
+}
+
+func (rs Rows) NextResultSet() bool {
+	if itr, has := rs.itr.(ResultSetIterator); has {
+		return itr.NextResultSet()
+	}
+	return false
 }
 
 func (rs Rows) Next() bool {

--- a/data/sqlutil/dynamic_frame.go
+++ b/data/sqlutil/dynamic_frame.go
@@ -26,10 +26,10 @@ func findDataTypes(rows Rows, rowLimit int64, types []*sql.ColumnType) ([]Field,
 	var returnData [][]interface{}
 
 	for {
-		if i == rowLimit {
-			break
-		}
 		for rows.Next() {
+			if i == rowLimit {
+				break
+			}
 			row := make([]interface{}, len(types))
 			for i := range row {
 				row[i] = new(interface{})
@@ -80,7 +80,7 @@ func findDataTypes(rows Rows, rowLimit int64, types []*sql.ColumnType) ([]Field,
 
 			i++
 		}
-		if !rows.NextResultSet() {
+		if i == rowLimit || !rows.NextResultSet() {
 			break
 		}
 	}

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -65,7 +65,7 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 
 			i++
 		}
-		if !rows.NextResultSet() {
+		if i == rowLimit || !rows.NextResultSet() {
 			break
 		}
 	}

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -43,25 +43,27 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 	frame := NewFrame(names, scanRow.Converters...)
 
 	var i int64
-	for rows.Next() {
-		if i == rowLimit {
-			frame.AppendNotices(data.Notice{
-				Severity: data.NoticeSeverityWarning,
-				Text:     fmt.Sprintf("Results have been limited to %v because the SQL row limit was reached", rowLimit),
-			})
-			break
-		}
+	for rows.NextResultSet() {
+		for rows.Next() {
+			if i == rowLimit {
+				frame.AppendNotices(data.Notice{
+					Severity: data.NoticeSeverityWarning,
+					Text:     fmt.Sprintf("Results have been limited to %v because the SQL row limit was reached", rowLimit),
+				})
+				break
+			}
 
-		r := scanRow.NewScannableRow()
-		if err := rows.Scan(r...); err != nil {
-			return nil, err
-		}
+			r := scanRow.NewScannableRow()
+			if err := rows.Scan(r...); err != nil {
+				return nil, err
+			}
 
-		if err := Append(frame, r, scanRow.Converters...); err != nil {
-			return nil, err
-		}
+			if err := Append(frame, r, scanRow.Converters...); err != nil {
+				return nil, err
+			}
 
-		i++
+			i++
+		}
 	}
 
 	if err := rows.Err(); err != nil {

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -43,7 +43,8 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 	frame := NewFrame(names, scanRow.Converters...)
 
 	var i int64
-	for rows.NextResultSet() {
+	for {
+		// first iterate over rows may be nop if not switched result set to next
 		for rows.Next() {
 			if i == rowLimit {
 				frame.AppendNotices(data.Notice{
@@ -63,6 +64,9 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 			}
 
 			i++
+		}
+		if !rows.NextResultSet() {
+			break
 		}
 	}
 

--- a/data/sqlutil/sql_test.go
+++ b/data/sqlutil/sql_test.go
@@ -1,1 +1,284 @@
-package sqlutil_test
+package sqlutil
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+type fakeDB struct {
+	rows driver.Rows
+}
+
+type baseRows struct {
+	columnNames []string
+}
+
+func (rows *baseRows) Columns() []string {
+	return rows.columnNames
+}
+
+func (*baseRows) Close() error {
+	return nil
+}
+
+type singleResultSet struct {
+	baseRows
+
+	rows       [][]interface{}
+	currentRow int
+}
+
+func (rows *singleResultSet) Next(dest []driver.Value) error {
+	rows.currentRow++
+	if rows.currentRow >= len(rows.rows) {
+		return io.EOF
+	}
+	data := rows.rows[rows.currentRow]
+	for i := range dest {
+		dest[i] = data[i]
+	}
+	return nil
+}
+
+type multipleResultSets struct {
+	baseRows
+
+	resultSets       [][][]interface{}
+	currentResultSet int
+	currentRow       int
+	once             sync.Once
+}
+
+func (rows *multipleResultSets) Next(dest []driver.Value) error {
+	rows.once.Do(func() {
+		rows.currentResultSet++
+	})
+	rows.currentRow++
+	if rows.currentRow >= len(rows.resultSets[rows.currentResultSet]) {
+		return io.EOF
+	}
+	data := rows.resultSets[rows.currentResultSet][rows.currentRow]
+	for i := range dest {
+		dest[i] = data[i]
+	}
+	return nil
+}
+
+func (rows *multipleResultSets) HasNextResultSet() bool {
+	return rows.currentResultSet < len(rows.resultSets)
+}
+
+func (rows *multipleResultSets) NextResultSet() error {
+	rows.once.Do(func() {})
+	rows.currentResultSet++
+	rows.currentRow = -1
+	if rows.currentResultSet >= len(rows.resultSets) {
+		return io.EOF
+	}
+	return nil
+}
+
+func (db *fakeDB) LastInsertId() (int64, error) {
+	return 0, errors.New("not implemented for fakeDB")
+}
+
+func (db *fakeDB) RowsAffected() (int64, error) {
+	return 0, errors.New("not implemented for fakeDB")
+}
+
+func (db *fakeDB) NumInput() int {
+	return 0
+}
+
+func (db *fakeDB) Exec([]driver.Value) (driver.Result, error) {
+	return nil, errors.New("not implemented for fakeDB")
+}
+
+func (db *fakeDB) Query([]driver.Value) (driver.Rows, error) {
+	return db.rows, nil
+}
+
+func (db *fakeDB) Prepare(string) (driver.Stmt, error) {
+	return db, nil
+}
+
+func (db *fakeDB) Close() error {
+	return nil
+}
+
+func (db *fakeDB) Begin() (driver.Tx, error) {
+	return nil, errors.New("not implemented for fakeDB")
+}
+
+func (db *fakeDB) Open(string) (driver.Conn, error) {
+	return nil, errors.New("not implemented for fakeDB")
+}
+
+func (db *fakeDB) Connect(context.Context) (driver.Conn, error) {
+	return db, nil
+}
+
+func (db *fakeDB) Driver() driver.Driver {
+	return db
+}
+
+func makeSingleResultSet(
+	columnNames []string,
+	data ...[]interface{},
+) *sql.Rows {
+	rows, _ := sql.OpenDB(&fakeDB{
+		rows: &singleResultSet{
+			baseRows: baseRows{
+				columnNames: columnNames,
+			},
+			rows:       data,
+			currentRow: -1,
+		},
+	}).Query("")
+	return rows
+}
+
+func makeMultipleResultSets(
+	columnNames []string,
+	resultSets ...[][]interface{},
+) *sql.Rows {
+	rows, _ := sql.OpenDB(&fakeDB{
+		rows: &multipleResultSets{
+			baseRows: baseRows{
+				columnNames: columnNames,
+			},
+			resultSets:       resultSets,
+			currentResultSet: -1,
+			currentRow:       -1,
+		},
+	}).Query("")
+	return rows
+}
+
+func ptr(s string) *string {
+	return &s
+}
+
+func TestFrameFromRows(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		rows       *sql.Rows
+		rowLimit   int64
+		converters []Converter
+		frame      *data.Frame
+		err        bool
+	}{
+		{
+			name: "rows not implements driver.RowsNextResultSet",
+			rows: makeSingleResultSet( //nolint:rowserrcheck
+				[]string{
+					"a",
+					"b",
+					"c",
+				},
+				[]interface{}{
+					1, 2, 3,
+				},
+				[]interface{}{
+					4, 5, 6,
+				},
+				[]interface{}{
+					7, 8, 9,
+				},
+			),
+			rowLimit:   100,
+			converters: nil,
+			frame: &data.Frame{
+				Fields: []*data.Field{
+					data.NewField("a", nil, []*string{ptr("1"), ptr("4"), ptr("7")}),
+					data.NewField("b", nil, []*string{ptr("2"), ptr("5"), ptr("8")}),
+					data.NewField("c", nil, []*string{ptr("3"), ptr("6"), ptr("9")}),
+				},
+			},
+			err: false,
+		},
+		{
+			name: "rows implements driver.RowsNextResultSet, but contains only one result set",
+			rows: makeMultipleResultSets( //nolint:rowserrcheck
+				[]string{
+					"a",
+					"b",
+					"c",
+				},
+				[][]interface{}{
+					{
+						1, 2, 3,
+					},
+					{
+						4, 5, 6,
+					},
+					{
+						7, 8, 9,
+					},
+				},
+			),
+			rowLimit:   100,
+			converters: nil,
+			frame: &data.Frame{
+				Fields: []*data.Field{
+					data.NewField("a", nil, []*string{ptr("1"), ptr("4"), ptr("7")}),
+					data.NewField("b", nil, []*string{ptr("2"), ptr("5"), ptr("8")}),
+					data.NewField("c", nil, []*string{ptr("3"), ptr("6"), ptr("9")}),
+				},
+			},
+			err: false,
+		},
+		{
+			name: "rows implements driver.RowsNextResultSet, but contains more then one result set",
+			rows: makeMultipleResultSets( //nolint:rowserrcheck
+				[]string{
+					"a",
+					"b",
+					"c",
+				},
+				[][]interface{}{
+					{
+						1, 2, 3,
+					},
+					{
+						4, 5, 6,
+					},
+				},
+				[][]interface{}{
+					{
+						7, 8, 9,
+					},
+				},
+			),
+			rowLimit:   100,
+			converters: nil,
+			frame: &data.Frame{
+				Fields: []*data.Field{
+					data.NewField("a", nil, []*string{ptr("1"), ptr("4"), ptr("7")}),
+					data.NewField("b", nil, []*string{ptr("2"), ptr("5"), ptr("8")}),
+					data.NewField("c", nil, []*string{ptr("3"), ptr("6"), ptr("9")}),
+				},
+			},
+			err: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			frame, err := FrameFromRows(tt.rows, tt.rowLimit, tt.converters...)
+			if tt.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.frame, frame)
+			}
+		})
+	}
+}

--- a/data/sqlutil/sql_test.go
+++ b/data/sqlutil/sql_test.go
@@ -1,4 +1,4 @@
-package sqlutil
+package sqlutil_test
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 )
 
 type fakeDB struct {
@@ -173,7 +174,7 @@ func TestFrameFromRows(t *testing.T) {
 		name       string
 		rows       *sql.Rows
 		rowLimit   int64
-		converters []Converter
+		converters []sqlutil.Converter
 		frame      *data.Frame
 		err        bool
 	}{
@@ -272,7 +273,7 @@ func TestFrameFromRows(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			frame, err := FrameFromRows(tt.rows, tt.rowLimit, tt.converters...)
+			frame, err := sqlutil.FrameFromRows(tt.rows, tt.rowLimit, tt.converters...)
 			if tt.err {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
Since `go1.8` `*sql.Rows` supports multiple result sets. But `grafana-plugin-sdk-go` doesn't take this into.
This PR improved `grafana-plugin-sdk-go` for supporting multiple result sets in `db.QueryContext` result

**Which issue(s) this PR fixes**:
Some databases (like [YDB](https://ydb.tech)) have stream protocol inside. Because designed for large data sets. This fact determines stream API for getting result from server. Multiple result sets is normal for iterate between result batches

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
