### PR TITLE
WIP: add plugin-specific LLM/OpenAI helper function

### DIFF
--- a/experimental/llm/openai.go
+++ b/experimental/llm/openai.go
@@ -1,0 +1,70 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	llm "github.com/grafana/grafana-llm-app/llmclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/oauthtokenretriever"
+	"github.com/sashabaranov/go-openai"
+)
+
+type openAIUsingToken struct {
+	httpClient     *http.Client
+	grafanaURL     string
+	tokenRetriever oauthtokenretriever.TokenRetriever
+}
+
+func NewOpenAIForPlugin(ctx context.Context) (llm.OpenAI, error) {
+	cfg := backend.GrafanaConfigFromContext(ctx)
+	grafanaAppURL := strings.TrimRight(cfg.Get("GF_APP_URL"), "/")
+	if grafanaAppURL == "" {
+		// For debugging purposes only
+		grafanaAppURL = "http://localhost:3000"
+	}
+	client := &http.Client{}
+	tokenRetriever, err := oauthtokenretriever.New()
+	if err != nil {
+		return nil, fmt.Errorf("create token retriever: %w", err)
+	}
+	return &openAIUsingToken{
+		httpClient:     client,
+		tokenRetriever: tokenRetriever,
+		grafanaURL:     grafanaAppURL,
+	}, nil
+}
+
+func (o *openAIUsingToken) openAIClient(ctx context.Context) (llm.OpenAI, error) {
+	token, err := o.tokenRetriever.Self(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get token: %w", err)
+	}
+	return llm.NewOpenAIWithClient(o.grafanaURL, token, o.httpClient), nil
+}
+
+func (o *openAIUsingToken) Enabled(ctx context.Context) (bool, error) {
+	client, err := o.openAIClient(ctx)
+	if err != nil {
+		return false, err
+	}
+	return client.Enabled(ctx)
+}
+
+func (o *openAIUsingToken) ChatCompletions(ctx context.Context, req openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+	client, err := o.openAIClient(ctx)
+	if err != nil {
+		return openai.ChatCompletionResponse{}, err
+	}
+	return client.ChatCompletions(ctx, req)
+}
+
+func (o *openAIUsingToken) ChatCompletionsStream(ctx context.Context, req openai.ChatCompletionRequest) (*openai.ChatCompletionStream, error) {
+	client, err := o.openAIClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return client.ChatCompletionsStream(ctx, req)
+}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/prometheus/common v0.42.0
 	github.com/stretchr/testify v1.8.3
 	golang.org/x/sys v0.10.0
-	google.golang.org/grpc v1.57.0
+	google.golang.org/grpc v1.58.1
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
@@ -33,6 +33,8 @@ require (
 	github.com/getkin/kin-openapi v0.112.0
 	github.com/go-jose/go-jose/v3 v3.0.0
 	github.com/google/uuid v1.3.0
+	github.com/grafana/grafana-llm-app/llmclient v0.0.0-20230922072756-d4ccf8288c53
+	github.com/sashabaranov/go-openai v1.15.3
 	github.com/unknwon/bra v0.0.0-20200517080246-1e3013ecaff8
 	github.com/urfave/cli v1.22.12
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -52,7 +52,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/envoyproxy/protoc-gen-validate v0.10.1 h1:c0g45+xCJhdgFGw7a5QAfdS4byAbud7miNWJ1WwEVf8=
+github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
@@ -127,6 +127,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/grafana/grafana-llm-app/llmclient v0.0.0-20230922072756-d4ccf8288c53 h1:c9MxTshB180vX9/38q9yuN707p8jInYarlyOMrhq23o=
+github.com/grafana/grafana-llm-app/llmclient v0.0.0-20230922072756-d4ccf8288c53/go.mod h1:4hfupZhd1fwSS6sB8/m5QmAzj7XOoBHE2P8gkQAvjfU=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
@@ -226,6 +228,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
+github.com/sashabaranov/go-openai v1.15.3 h1:rzoNK9n+Cak+PM6OQ9puxDmFllxfnVea9StlmhglXqA=
+github.com/sashabaranov/go-openai v1.15.3/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 h1:Jpy1PXuP99tXNrhbq2BaPz9B+jNAvH1JPQQpG/9GCXY=
@@ -430,8 +434,8 @@ google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTp
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
-google.golang.org/grpc v1.57.0 h1:kfzNeI/klCGD2YPMUlaGNT3pxvYfga7smW3Vth8Zsiw=
-google.golang.org/grpc v1.57.0/go.mod h1:Sd+9RMTACXwmub0zcNY2c4arhtrbBYD1AUHI/dt16Mo=
+google.golang.org/grpc v1.58.1 h1:OL+Vz23DTtrrldqHK49FUOPHyY75rvFqJfXC84NYW58=
+google.golang.org/grpc v1.58.1/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
**What this PR does / why we need it**:

This is an alternative to #740 which builds off https://github.com/grafana/grafana-llm-app/pull/59, leaving the main client logic in the github.com/grafana/grafana-llm-app/pkg/client library, and just providing a helper to handle auth for plugins which are making use of the externalServiceAuth feature of Grafana.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-llm-app/issues/19

**Special notes for your reviewer**:

TODO:

- [ ] docs
- [ ] use proper plugin version, once we've released it
