### PR TITLE
PDC: Configure proxy with info from request

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -40,7 +40,7 @@ type AppInstanceSettings struct {
 }
 
 // HTTPClientOptions creates httpclient.Options based on settings.
-func (s *AppInstanceSettings) HTTPClientOptions() (httpclient.Options, error) {
+func (s *AppInstanceSettings) HTTPClientOptions(_ context.Context) (httpclient.Options, error) {
 	httpSettings, err := parseHTTPSettings(s.JSONData, s.DecryptedSecureJSONData)
 	if err != nil {
 		return httpclient.Options{}, err

--- a/backend/common.go
+++ b/backend/common.go
@@ -125,7 +125,7 @@ func (s *DataSourceInstanceSettings) HTTPClientOptions(ctx context.Context) (htt
 	setCustomOptionsFromHTTPSettings(&opts, httpSettings)
 
 	cfg := GrafanaConfigFromContext(ctx)
-	opts.ProxyOptions, err = s.ProxyOptions(cfg.Proxy().clientCfg)
+	opts.ProxyOptions, err = s.ProxyOptions(cfg.proxy().clientCfg)
 	if err != nil {
 		return opts, err
 	}

--- a/backend/common.go
+++ b/backend/common.go
@@ -100,10 +100,6 @@ type DataSourceInstanceSettings struct {
 	Updated time.Time
 }
 
-type DataSourceHTTPClientOpts struct {
-	ProxyClientCfg proxy.ClientCfg
-}
-
 // HTTPClientOptions creates httpclient.Options based on settings.
 func (s *DataSourceInstanceSettings) HTTPClientOptions(ctx context.Context) (httpclient.Options, error) {
 	httpSettings, err := parseHTTPSettings(s.JSONData, s.DecryptedSecureJSONData)
@@ -129,7 +125,7 @@ func (s *DataSourceInstanceSettings) HTTPClientOptions(ctx context.Context) (htt
 	setCustomOptionsFromHTTPSettings(&opts, httpSettings)
 
 	cfg := GrafanaConfigFromContext(ctx)
-	opts.ProxyOptions, err = s.ProxyOptions(cfg.Proxy().ClientConfig())
+	opts.ProxyOptions, err = s.ProxyOptions(cfg.Proxy().clientCfg)
 	if err != nil {
 		return opts, err
 	}
@@ -237,7 +233,7 @@ func propagateTenantIDIfPresent(ctx context.Context) context.Context {
 	return ctx
 }
 
-func (s *DataSourceInstanceSettings) ProxyOptions(clientCfg proxy.ClientCfg) (*proxy.Options, error) {
+func (s *DataSourceInstanceSettings) ProxyOptions(clientCfg *proxy.ClientCfg) (*proxy.Options, error) {
 	opts := &proxy.Options{}
 
 	var dat map[string]interface{}

--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -189,7 +190,7 @@ func TestDataSourceInstanceSettings(t *testing.T) {
 		}
 
 		for _, tc := range tcs {
-			opts, err := tc.instanceSettings.HTTPClientOptions()
+			opts, err := tc.instanceSettings.HTTPClientOptions(context.Background())
 			assert.NoError(t, err)
 			if tc.expectedClientOptions.BasicAuth != nil {
 				assert.Equal(t, tc.expectedClientOptions.BasicAuth, opts.BasicAuth)
@@ -265,6 +266,7 @@ func TestProxyOptions(t *testing.T) {
 	t.Run("ProxyOptions() should translate settings as expected", func(t *testing.T) {
 		tcs := []struct {
 			instanceSettings      *DataSourceInstanceSettings
+			proxyClientCfg        proxy.ClientCfg
 			expectedClientOptions *proxy.Options
 		}{
 			{
@@ -344,10 +346,45 @@ func TestProxyOptions(t *testing.T) {
 					},
 				},
 			},
+			{
+				instanceSettings: &DataSourceInstanceSettings{
+					Name:             "ds1",
+					UID:              "uid1",
+					User:             "user",
+					Type:             "example-datasource",
+					JSONData:         []byte("{ \"enableSecureSocksProxy\": true, \"timeout\": 10, \"keepAlive\": 15 }"),
+					BasicAuthEnabled: true,
+					BasicAuthUser:    "buser",
+				},
+				proxyClientCfg: proxy.ClientCfg{
+					ClientCert:   "<client-cert>",
+					ClientKey:    "123abc",
+					RootCA:       "<root-ca-cert>",
+					ProxyAddress: "10.1.2.3",
+					ServerName:   "grafana-server",
+				},
+				expectedClientOptions: &proxy.Options{
+					Enabled: true,
+					Auth: &proxy.AuthOptions{
+						Username: "uid1",
+					},
+					Timeouts: &proxy.TimeoutOptions{
+						KeepAlive: time.Second * 15,
+						Timeout:   time.Second * 10,
+					},
+					ClientCfg: proxy.ClientCfg{
+						ClientCert:   "<client-cert>",
+						ClientKey:    "123abc",
+						RootCA:       "<root-ca-cert>",
+						ProxyAddress: "10.1.2.3",
+						ServerName:   "grafana-server",
+					},
+				},
+			},
 		}
 
 		for _, tc := range tcs {
-			opts, err := tc.instanceSettings.ProxyOptions()
+			opts, err := tc.instanceSettings.ProxyOptions(tc.proxyClientCfg)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedClientOptions, opts)
 		}

--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -42,7 +42,7 @@ func TestAppInstanceSettings(t *testing.T) {
 		}
 
 		for _, tc := range tcs {
-			opts, err := tc.instanceSettings.HTTPClientOptions()
+			opts, err := tc.instanceSettings.HTTPClientOptions(context.Background())
 			assert.NoError(t, err)
 			if tc.expectedClientOptions.BasicAuth != nil {
 				assert.Equal(t, tc.expectedClientOptions.BasicAuth, opts.BasicAuth)

--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -266,7 +266,7 @@ func TestProxyOptions(t *testing.T) {
 	t.Run("ProxyOptions() should translate settings as expected", func(t *testing.T) {
 		tcs := []struct {
 			instanceSettings      *DataSourceInstanceSettings
-			proxyClientCfg        proxy.ClientCfg
+			proxyClientCfg        *proxy.ClientCfg
 			expectedClientOptions *proxy.Options
 		}{
 			{
@@ -356,7 +356,7 @@ func TestProxyOptions(t *testing.T) {
 					BasicAuthEnabled: true,
 					BasicAuthUser:    "buser",
 				},
-				proxyClientCfg: proxy.ClientCfg{
+				proxyClientCfg: &proxy.ClientCfg{
 					ClientCert:   "<client-cert>",
 					ClientKey:    "123abc",
 					RootCA:       "<root-ca-cert>",
@@ -372,7 +372,7 @@ func TestProxyOptions(t *testing.T) {
 						KeepAlive: time.Second * 15,
 						Timeout:   time.Second * 10,
 					},
-					ClientCfg: proxy.ClientCfg{
+					ClientCfg: &proxy.ClientCfg{
 						ClientCert:   "<client-cert>",
 						ClientKey:    "123abc",
 						RootCA:       "<root-ca-cert>",

--- a/backend/config.go
+++ b/backend/config.go
@@ -87,17 +87,13 @@ func (ft FeatureToggles) IsEnabled(f string) bool {
 }
 
 type Proxy struct {
-	clientCfg proxy.ClientCfg
-}
-
-func (pc Proxy) ClientConfig() proxy.ClientCfg {
-	return pc.clientCfg
+	clientCfg *proxy.ClientCfg
 }
 
 func (c *GrafanaCfg) Proxy() Proxy {
 	if v, exists := c.config[proxy.PluginSecureSocksProxyEnabled]; exists && v == strconv.FormatBool(true) {
 		return Proxy{
-			clientCfg: proxy.ClientCfg{
+			clientCfg: &proxy.ClientCfg{
 				ClientCert:   c.Get(proxy.PluginSecureSocksProxyClientCert),
 				ClientKey:    c.Get(proxy.PluginSecureSocksProxyClientKey),
 				RootCA:       c.Get(proxy.PluginSecureSocksProxyRootCACert),
@@ -106,5 +102,5 @@ func (c *GrafanaCfg) Proxy() Proxy {
 			},
 		}
 	}
-	return Proxy{clientCfg: proxy.ClientCfg{}}
+	return Proxy{}
 }

--- a/backend/config.go
+++ b/backend/config.go
@@ -90,7 +90,7 @@ type Proxy struct {
 	clientCfg *proxy.ClientCfg
 }
 
-func (c *GrafanaCfg) Proxy() Proxy {
+func (c *GrafanaCfg) proxy() Proxy {
 	if v, exists := c.config[proxy.PluginSecureSocksProxyEnabled]; exists && v == strconv.FormatBool(true) {
 		return Proxy{
 			clientCfg: &proxy.ClientCfg{

--- a/backend/config.go
+++ b/backend/config.go
@@ -98,7 +98,6 @@ func (c *GrafanaCfg) Proxy() Proxy {
 	if v, exists := c.config[proxy.PluginSecureSocksProxyEnabled]; exists && v == strconv.FormatBool(true) {
 		return Proxy{
 			clientCfg: proxy.ClientCfg{
-				Enabled:      true,
 				ClientCert:   c.Get(proxy.PluginSecureSocksProxyClientCert),
 				ClientKey:    c.Get(proxy.PluginSecureSocksProxyClientKey),
 				RootCA:       c.Get(proxy.PluginSecureSocksProxyRootCACert),

--- a/backend/config.go
+++ b/backend/config.go
@@ -21,8 +21,8 @@ func GrafanaConfigFromContext(ctx context.Context) *GrafanaCfg {
 	return v.(*GrafanaCfg)
 }
 
-// withGrafanaConfig injects supplied Grafana config into context.
-func withGrafanaConfig(ctx context.Context, cfg *GrafanaCfg) context.Context {
+// WithGrafanaConfig injects supplied Grafana config into context.
+func WithGrafanaConfig(ctx context.Context, cfg *GrafanaCfg) context.Context {
 	ctx = context.WithValue(ctx, configKey{}, cfg)
 	return ctx
 }

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -45,7 +45,7 @@ func withHeaderMiddleware(ctx context.Context, headers http.Header) context.Cont
 
 func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataRequest) (*pluginv2.QueryDataResponse, error) {
 	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = withGrafanaConfig(ctx, NewGrafanaCfg(req.PluginContext.GrafanaConfig))
+	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(req.PluginContext.GrafanaConfig))
 	parsedRequest := FromProto().QueryDataRequest(req)
 	ctx = withHeaderMiddleware(ctx, parsedRequest.GetHTTPHeaders())
 	resp, err := a.queryDataHandler.QueryData(ctx, parsedRequest)

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -25,7 +25,7 @@ type fakeDataHandlerWithOAuth struct {
 
 func newFakeDataHandlerWithOAuth() *fakeDataHandlerWithOAuth {
 	settings := DataSourceInstanceSettings{}
-	opts, err := settings.HTTPClientOptions()
+	opts, err := settings.HTTPClientOptions(context.Background())
 	if err != nil {
 		panic("http client options: " + err.Error())
 	}

--- a/backend/datasource/serve_example_test.go
+++ b/backend/datasource/serve_example_test.go
@@ -16,8 +16,8 @@ type testDataSourceInstanceSettings struct {
 	httpClient *http.Client
 }
 
-func newDataSourceInstance(_ context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-	opts, err := settings.HTTPClientOptions()
+func newDataSourceInstance(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+	opts, err := settings.HTTPClientOptions(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/diagnostics_adapter.go
+++ b/backend/diagnostics_adapter.go
@@ -47,7 +47,7 @@ func (a *diagnosticsSDKAdapter) CollectMetrics(_ context.Context, _ *pluginv2.Co
 func (a *diagnosticsSDKAdapter) CheckHealth(ctx context.Context, protoReq *pluginv2.CheckHealthRequest) (*pluginv2.CheckHealthResponse, error) {
 	if a.checkHealthHandler != nil {
 		ctx = propagateTenantIDIfPresent(ctx)
-		ctx = withGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
+		ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 		parsedReq := FromProto().CheckHealthRequest(protoReq)
 		ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
 		res, err := a.checkHealthHandler.CheckHealth(ctx, parsedReq)

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -86,7 +86,8 @@ func GetTransport(opts ...Options) (http.RoundTripper, error) {
 		clientOpts.Middlewares = clientOpts.ConfigureMiddleware(clientOpts, clientOpts.Middlewares)
 	}
 
-	err = proxy.Cli.ConfigureSecureSocksHTTPProxy(transport, clientOpts.ProxyOptions)
+	pc := proxy.New(clientOpts.ProxyOptions)
+	err = pc.ConfigureSecureSocksHTTPProxy(transport)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/httpclient/options.go
+++ b/backend/httpclient/options.go
@@ -28,8 +28,10 @@ type Options struct {
 	// BasicAuth basic authentication related options.
 	BasicAuth *BasicAuthOptions
 
-	// TLS TLS related options.
-	TLS   *TLSOptions
+	// TLS related options.
+	TLS *TLSOptions
+
+	// SigV4 related options.
 	SigV4 *SigV4Config
 
 	// Proxy related options.

--- a/backend/proxy/options.go
+++ b/backend/proxy/options.go
@@ -4,9 +4,10 @@ import "time"
 
 // Options defines per datasource options for creating the proxy dialer.
 type Options struct {
-	Enabled  bool
-	Auth     *AuthOptions
-	Timeouts *TimeoutOptions
+	Enabled   bool
+	Auth      *AuthOptions
+	Timeouts  *TimeoutOptions
+	ClientCfg ClientCfg
 }
 
 // AuthOptions socks5 username and password options.

--- a/backend/proxy/options.go
+++ b/backend/proxy/options.go
@@ -41,7 +41,11 @@ func setDefaults(providedOpts *Options) Options {
 	}
 
 	if opts.ClientCfg == nil {
-		opts.ClientCfg = getConfigFromEnv()
+		clientCfg := getConfigFromEnv()
+		if clientCfg == nil {
+			return opts
+		}
+		opts.ClientCfg = clientCfg
 	}
 
 	return opts

--- a/backend/proxy/options.go
+++ b/backend/proxy/options.go
@@ -30,6 +30,10 @@ var DefaultTimeoutOptions = TimeoutOptions{
 }
 
 func (o *Options) setDefaults() {
+	if o == nil {
+		return
+	}
+
 	if o.Timeouts == nil {
 		o.Timeouts = &DefaultTimeoutOptions
 	}

--- a/backend/proxy/options.go
+++ b/backend/proxy/options.go
@@ -29,24 +29,12 @@ var DefaultTimeoutOptions = TimeoutOptions{
 	KeepAlive: 30 * time.Second,
 }
 
-func setDefaults(providedOpts *Options) Options {
-	var opts Options
-	if providedOpts == nil {
-		return opts
+func (o *Options) setDefaults() {
+	if o.Timeouts == nil {
+		o.Timeouts = &DefaultTimeoutOptions
 	}
 
-	opts = *providedOpts
-	if opts.Timeouts == nil {
-		opts.Timeouts = &DefaultTimeoutOptions
+	if o.ClientCfg == nil {
+		o.ClientCfg = getConfigFromEnv()
 	}
-
-	if opts.ClientCfg == nil {
-		clientCfg := getConfigFromEnv()
-		if clientCfg == nil {
-			return opts
-		}
-		opts.ClientCfg = clientCfg
-	}
-
-	return opts
 }

--- a/backend/proxy/options.go
+++ b/backend/proxy/options.go
@@ -7,7 +7,7 @@ type Options struct {
 	Enabled   bool
 	Auth      *AuthOptions
 	Timeouts  *TimeoutOptions
-	ClientCfg ClientCfg
+	ClientCfg *ClientCfg
 }
 
 // AuthOptions socks5 username and password options.
@@ -38,6 +38,10 @@ func setDefaults(providedOpts *Options) Options {
 	opts = *providedOpts
 	if opts.Timeouts == nil {
 		opts.Timeouts = &DefaultTimeoutOptions
+	}
+
+	if opts.ClientCfg == nil {
+		opts.ClientCfg = getConfigFromEnv()
 	}
 
 	return opts

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -82,7 +82,7 @@ type cfgProxyWrapper struct {
 // and the datasource options specify to use the proxy
 func (p *cfgProxyWrapper) SecureSocksProxyEnabled() bool {
 	// it cannot be enabled if it's not enabled on Grafana
-	if p.opts == nil {
+	if p.opts == nil || p.opts.ClientCfg == nil {
 		return false
 	}
 

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -53,9 +52,9 @@ var (
 
 // Client is the main Proxy Client interface.
 type Client interface {
-	SecureSocksProxyEnabled(opts *Options) bool
-	ConfigureSecureSocksHTTPProxy(transport *http.Transport, opts *Options) error
-	NewSecureSocksProxyContextDialer(opts *Options) (proxy.Dialer, error)
+	SecureSocksProxyEnabled() bool
+	ConfigureSecureSocksHTTPProxy(transport *http.Transport) error
+	NewSecureSocksProxyContextDialer() (proxy.Dialer, error)
 }
 
 // ClientCfg contains the information needed to allow datasource connections to be
@@ -68,45 +67,37 @@ type ClientCfg struct {
 	ServerName   string
 }
 
-// Cli is the default Proxy Client.
-var Cli = New()
-
-// New creates a new proxy client from the environment variables set by the grafana-server in the plugin.
-func New() Client {
-	return NewWithCfg(getConfigFromEnv())
-}
-
-// NewWithCfg creates a new proxy client from a given config.
-func NewWithCfg(cfg *ClientCfg) Client {
+// New creates a new proxy client from a given config.
+func New(opts *Options) Client {
 	return &cfgProxyWrapper{
-		cfg: cfg,
+		opts: opts,
 	}
 }
 
 type cfgProxyWrapper struct {
-	cfg *ClientCfg
+	opts *Options
 }
 
 // SecureSocksProxyEnabled checks if the Grafana instance allows the secure socks proxy to be used
 // and the datasource options specify to use the proxy
-func (p *cfgProxyWrapper) SecureSocksProxyEnabled(opts *Options) bool {
+func (p *cfgProxyWrapper) SecureSocksProxyEnabled() bool {
 	// it cannot be enabled if it's not enabled on Grafana
-	if p.cfg == nil {
+	if p.opts == nil {
 		return false
 	}
 
 	// if it's enabled on Grafana, check if the datasource is using it
-	return (opts != nil) && opts.Enabled
+	return (p.opts != nil) && p.opts.Enabled
 }
 
 // ConfigureSecureSocksHTTPProxy takes a http.DefaultTransport and wraps it in a socks5 proxy with TLS
 // if it is enabled on the datasource and the grafana instance
-func (p *cfgProxyWrapper) ConfigureSecureSocksHTTPProxy(transport *http.Transport, opts *Options) error {
-	if !p.SecureSocksProxyEnabled(opts) {
+func (p *cfgProxyWrapper) ConfigureSecureSocksHTTPProxy(transport *http.Transport) error {
+	if !p.SecureSocksProxyEnabled() {
 		return nil
 	}
 
-	dialSocksProxy, err := p.NewSecureSocksProxyContextDialer(opts)
+	dialSocksProxy, err := p.NewSecureSocksProxyContextDialer()
 	if err != nil {
 		return err
 	}
@@ -121,15 +112,15 @@ func (p *cfgProxyWrapper) ConfigureSecureSocksHTTPProxy(transport *http.Transpor
 }
 
 // NewSecureSocksProxyContextDialer returns a proxy context dialer that can be used to allow datasource connections to go through a secure socks proxy
-func (p *cfgProxyWrapper) NewSecureSocksProxyContextDialer(opts *Options) (proxy.Dialer, error) {
-	if !p.SecureSocksProxyEnabled(opts) {
-		return nil, fmt.Errorf("proxy not enabled")
+func (p *cfgProxyWrapper) NewSecureSocksProxyContextDialer() (proxy.Dialer, error) {
+	if !p.SecureSocksProxyEnabled() {
+		return nil, errors.New("proxy not enabled")
 	}
 
-	clientOpts := setDefaults(opts)
+	clientOpts := setDefaults(p.opts)
 
 	certPool := x509.NewCertPool()
-	for _, rootCAFile := range strings.Split(p.cfg.RootCA, " ") {
+	for _, rootCAFile := range strings.Split(p.opts.ClientCfg.RootCA, " ") {
 		// nolint:gosec
 		// The gosec G304 warning can be ignored because `rootCAFile` comes from config ini
 		// and we check below if it's the right file type
@@ -148,7 +139,7 @@ func (p *cfgProxyWrapper) NewSecureSocksProxyContextDialer(opts *Options) (proxy
 		}
 	}
 
-	cert, err := tls.LoadX509KeyPair(p.cfg.ClientCert, p.cfg.ClientKey)
+	cert, err := tls.LoadX509KeyPair(p.opts.ClientCfg.ClientCert, p.opts.ClientCfg.ClientKey)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +147,7 @@ func (p *cfgProxyWrapper) NewSecureSocksProxyContextDialer(opts *Options) (proxy
 	tlsDialer := &tls.Dialer{
 		Config: &tls.Config{
 			Certificates: []tls.Certificate{cert},
-			ServerName:   p.cfg.ServerName,
+			ServerName:   p.opts.ClientCfg.ServerName,
 			RootCAs:      certPool,
 			MinVersion:   tls.VersionTLS13,
 		},
@@ -174,14 +165,12 @@ func (p *cfgProxyWrapper) NewSecureSocksProxyContextDialer(opts *Options) (proxy
 		}
 	}
 
-	dialSocksProxy, err := proxy.SOCKS5("tcp", p.cfg.ProxyAddress, auth, tlsDialer)
+	dialSocksProxy, err := proxy.SOCKS5("tcp", p.opts.ClientCfg.ProxyAddress, auth, tlsDialer)
 	if err != nil {
 		return nil, err
 	}
 
-	instrumentedSocksDialer := newInstrumentedSocksDialer(dialSocksProxy)
-
-	return instrumentedSocksDialer, nil
+	return newInstrumentedSocksDialer(dialSocksProxy), nil
 }
 
 // getConfigFromEnv gets the needed proxy information from the env variables that Grafana set with the values from the config ini

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -82,7 +82,7 @@ type cfgProxyWrapper struct {
 // and the datasource options specify to use the proxy
 func (p *cfgProxyWrapper) SecureSocksProxyEnabled() bool {
 	// it cannot be enabled if it's not enabled on Grafana
-	if p.opts == nil || p.opts.ClientCfg == nil {
+	if p.opts == nil {
 		return false
 	}
 
@@ -113,11 +113,11 @@ func (p *cfgProxyWrapper) ConfigureSecureSocksHTTPProxy(transport *http.Transpor
 
 // NewSecureSocksProxyContextDialer returns a proxy context dialer that can be used to allow datasource connections to go through a secure socks proxy
 func (p *cfgProxyWrapper) NewSecureSocksProxyContextDialer() (proxy.Dialer, error) {
+	p.opts.setDefaults()
+
 	if !p.SecureSocksProxyEnabled() {
 		return nil, errors.New("proxy not enabled")
 	}
-
-	p.opts.setDefaults()
 
 	certPool := x509.NewCertPool()
 	for _, rootCAFile := range strings.Split(p.opts.ClientCfg.RootCA, " ") {

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -61,7 +61,6 @@ type Client interface {
 // ClientCfg contains the information needed to allow datasource connections to be
 // proxied to a secure socks proxy.
 type ClientCfg struct {
-	Enabled      bool
 	ClientCert   string
 	ClientKey    string
 	RootCA       string
@@ -92,7 +91,7 @@ type cfgProxyWrapper struct {
 // and the datasource options specify to use the proxy
 func (p *cfgProxyWrapper) SecureSocksProxyEnabled(opts *Options) bool {
 	// it cannot be enabled if it's not enabled on Grafana
-	if p.cfg == nil || !p.cfg.Enabled {
+	if p.cfg == nil {
 		return false
 	}
 
@@ -230,7 +229,6 @@ func getConfigFromEnv() *ClientCfg {
 	}
 
 	return &ClientCfg{
-		Enabled:      true,
 		ClientCert:   clientCert,
 		ClientKey:    clientKey,
 		RootCA:       rootCA,

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -117,7 +117,7 @@ func (p *cfgProxyWrapper) NewSecureSocksProxyContextDialer() (proxy.Dialer, erro
 		return nil, errors.New("proxy not enabled")
 	}
 
-	clientOpts := setDefaults(p.opts)
+	p.opts.setDefaults()
 
 	certPool := x509.NewCertPool()
 	for _, rootCAFile := range strings.Split(p.opts.ClientCfg.RootCA, " ") {
@@ -152,16 +152,16 @@ func (p *cfgProxyWrapper) NewSecureSocksProxyContextDialer() (proxy.Dialer, erro
 			MinVersion:   tls.VersionTLS13,
 		},
 		NetDialer: &net.Dialer{
-			Timeout:   clientOpts.Timeouts.Timeout,
-			KeepAlive: clientOpts.Timeouts.KeepAlive,
+			Timeout:   p.opts.Timeouts.Timeout,
+			KeepAlive: p.opts.Timeouts.KeepAlive,
 		},
 	}
 
 	var auth *proxy.Auth
-	if clientOpts.Auth != nil {
+	if p.opts.Auth != nil {
 		auth = &proxy.Auth{
-			User:     clientOpts.Auth.Username,
-			Password: clientOpts.Auth.Password,
+			User:     p.opts.Auth.Username,
+			Password: p.opts.Auth.Password,
 		}
 	}
 

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -70,26 +70,25 @@ func TestNewSecureSocksProxy(t *testing.T) {
 
 func TestSecureSocksProxyEnabled(t *testing.T) {
 	t.Run("not enabled if not enabled on grafana instance", func(t *testing.T) {
-		cli := NewWithCfg(&ClientCfg{Enabled: false})
+		cli := NewWithCfg(nil)
 		assert.Equal(t, false, cli.SecureSocksProxyEnabled(&Options{Enabled: true}))
 	})
 	t.Run("not enabled if not enabled on datasource", func(t *testing.T) {
-		cli := NewWithCfg(&ClientCfg{Enabled: true})
+		cli := NewWithCfg(&ClientCfg{})
 		assert.Equal(t, false, cli.SecureSocksProxyEnabled(&Options{Enabled: false}))
 	})
 	t.Run("not enabled if not enabled on datasource", func(t *testing.T) {
-		cli := NewWithCfg(&ClientCfg{Enabled: true})
+		cli := NewWithCfg(&ClientCfg{})
 		assert.Equal(t, false, cli.SecureSocksProxyEnabled(nil))
 	})
 	t.Run("enabled, if enabled on grafana instance and datasource", func(t *testing.T) {
-		cli := NewWithCfg(&ClientCfg{Enabled: true})
+		cli := NewWithCfg(&ClientCfg{})
 		assert.Equal(t, true, cli.SecureSocksProxyEnabled(&Options{Enabled: true}))
 	})
 }
 
 func TestSecureSocksProxyConfig(t *testing.T) {
 	expected := ClientCfg{
-		Enabled:      true,
 		ClientCert:   "client.crt",
 		ClientKey:    "client.key",
 		RootCA:       "ca.crt",
@@ -147,7 +146,6 @@ func TestSecureSocksProxyEnabledOnDS(t *testing.T) {
 func TestPreventInvalidRootCA(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := &ClientCfg{
-		Enabled:      true,
 		ClientCert:   "client.crt",
 		ClientKey:    "client.key",
 		ProxyAddress: "localhost:8080",
@@ -253,7 +251,6 @@ func setupTestSecureSocksProxySettings(t *testing.T) *ClientCfg {
 	require.NoError(t, err)
 
 	cfg := &ClientCfg{
-		Enabled:      true,
 		ClientCert:   clientCert,
 		ClientKey:    clientKey,
 		RootCA:       rootCACert,

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -19,8 +19,13 @@ import (
 )
 
 func TestNewSecureSocksProxy(t *testing.T) {
-	cfg := setupTestSecureSocksProxySettings(t)
-	cli := NewWithCfg(cfg)
+	opts := &Options{
+		Enabled:   true,
+		Timeouts:  &TimeoutOptions{Timeout: time.Duration(30), KeepAlive: time.Duration(15)},
+		Auth:      &AuthOptions{Username: "user1"},
+		ClientCfg: setupTestSecureSocksProxySettings(t),
+	}
+	cli := New(opts)
 
 	// create empty file for testing invalid configs
 	tempDir := t.TempDir()
@@ -31,59 +36,55 @@ func TestNewSecureSocksProxy(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("New socks proxy should be properly configured when all settings are valid", func(t *testing.T) {
-		require.NoError(t, cli.ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Timeouts: &TimeoutOptions{Timeout: time.Duration(30), KeepAlive: time.Duration(15)}, Auth: &AuthOptions{Username: "user1"}}))
+		require.NoError(t, cli.ConfigureSecureSocksHTTPProxy(&http.Transport{}))
 	})
 
 	t.Run("Client cert must be valid", func(t *testing.T) {
-		clientCertBefore := cfg.ClientCert
-		cfg.ClientCert = tempEmptyFile
-		cli = NewWithCfg(cfg)
+		clientCertBefore := opts.ClientCfg.ClientCert
+		opts.ClientCfg.ClientCert = tempEmptyFile
+		cli = New(opts)
 		t.Cleanup(func() {
-			cfg.ClientCert = clientCertBefore
-			cli = NewWithCfg(cfg)
+			opts.ClientCfg.ClientCert = clientCertBefore
+			cli = New(opts)
 		})
-		require.Error(t, cli.ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Enabled: true}))
+		require.Error(t, cli.ConfigureSecureSocksHTTPProxy(&http.Transport{}))
 	})
 
 	t.Run("Client key must be valid", func(t *testing.T) {
-		clientKeyBefore := cfg.ClientKey
-		cfg.ClientKey = tempEmptyFile
-		cli = NewWithCfg(cfg)
+		clientKeyBefore := opts.ClientCfg.ClientKey
+		opts.ClientCfg.ClientKey = tempEmptyFile
+		cli = New(opts)
 		t.Cleanup(func() {
-			cfg.ClientKey = clientKeyBefore
-			cli = NewWithCfg(cfg)
+			opts.ClientCfg.ClientKey = clientKeyBefore
+			cli = New(opts)
 		})
-		require.Error(t, cli.ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Enabled: true}))
+		require.Error(t, cli.ConfigureSecureSocksHTTPProxy(&http.Transport{}))
 	})
 
 	t.Run("Root CA must be valid", func(t *testing.T) {
-		rootCABefore := cfg.RootCA
-		cfg.RootCA = tempEmptyFile
-		cli = NewWithCfg(cfg)
+		rootCABefore := opts.ClientCfg.RootCA
+		opts.ClientCfg.RootCA = tempEmptyFile
+		cli = New(opts)
 		t.Cleanup(func() {
-			cfg.RootCA = rootCABefore
-			cli = NewWithCfg(cfg)
+			opts.ClientCfg.RootCA = rootCABefore
+			cli = New(opts)
 		})
-		require.Error(t, cli.ConfigureSecureSocksHTTPProxy(&http.Transport{}, &Options{Enabled: true}))
+		require.Error(t, cli.ConfigureSecureSocksHTTPProxy(&http.Transport{}))
 	})
 }
 
 func TestSecureSocksProxyEnabled(t *testing.T) {
-	t.Run("not enabled if not enabled on grafana instance", func(t *testing.T) {
-		cli := NewWithCfg(nil)
-		assert.Equal(t, false, cli.SecureSocksProxyEnabled(&Options{Enabled: true}))
+	t.Run("not enabled if Enabled field is not true", func(t *testing.T) {
+		cli := New(&Options{Enabled: false})
+		assert.Equal(t, false, cli.SecureSocksProxyEnabled())
 	})
-	t.Run("not enabled if not enabled on datasource", func(t *testing.T) {
-		cli := NewWithCfg(&ClientCfg{})
-		assert.Equal(t, false, cli.SecureSocksProxyEnabled(&Options{Enabled: false}))
+	t.Run("not enabled if opts is nil", func(t *testing.T) {
+		cli := New(nil)
+		assert.Equal(t, false, cli.SecureSocksProxyEnabled())
 	})
-	t.Run("not enabled if not enabled on datasource", func(t *testing.T) {
-		cli := NewWithCfg(&ClientCfg{})
-		assert.Equal(t, false, cli.SecureSocksProxyEnabled(nil))
-	})
-	t.Run("enabled, if enabled on grafana instance and datasource", func(t *testing.T) {
-		cli := NewWithCfg(&ClientCfg{})
-		assert.Equal(t, true, cli.SecureSocksProxyEnabled(&Options{Enabled: true}))
+	t.Run("enabled, if Enabled field is true", func(t *testing.T) {
+		cli := New(&Options{Enabled: true})
+		assert.Equal(t, true, cli.SecureSocksProxyEnabled())
 	})
 }
 
@@ -145,11 +146,16 @@ func TestSecureSocksProxyEnabledOnDS(t *testing.T) {
 
 func TestPreventInvalidRootCA(t *testing.T) {
 	tempDir := t.TempDir()
-	cfg := &ClientCfg{
-		ClientCert:   "client.crt",
-		ClientKey:    "client.key",
-		ProxyAddress: "localhost:8080",
-		ServerName:   "testServer",
+	opts := &Options{
+		Enabled:  true,
+		Auth:     nil,
+		Timeouts: nil,
+		ClientCfg: &ClientCfg{
+			ClientCert:   "client.crt",
+			ClientKey:    "client.key",
+			ProxyAddress: "localhost:8080",
+			ServerName:   "testServer",
+		},
 	}
 
 	t.Run("root ca must be of the type CERTIFICATE", func(t *testing.T) {
@@ -161,18 +167,18 @@ func TestPreventInvalidRootCA(t *testing.T) {
 			Bytes: []byte("testing"),
 		})
 		require.NoError(t, err)
-		cfg.RootCA = rootCACert
-		cli := NewWithCfg(cfg)
-		_, err = cli.NewSecureSocksProxyContextDialer(&Options{Enabled: true})
+		opts.ClientCfg.RootCA = rootCACert
+		cli := New(opts)
+		_, err = cli.NewSecureSocksProxyContextDialer()
 		require.Contains(t, err.Error(), "root ca is invalid")
 	})
 	t.Run("root ca has to have valid content", func(t *testing.T) {
 		rootCACert := filepath.Join(tempDir, "ca.cert")
 		err := os.WriteFile(rootCACert, []byte("this is not a pem encoded file"), fs.ModeAppend)
 		require.NoError(t, err)
-		cfg.RootCA = rootCACert
-		cli := NewWithCfg(cfg)
-		_, err = cli.NewSecureSocksProxyContextDialer(&Options{Enabled: true})
+		opts.ClientCfg.RootCA = rootCACert
+		cli := New(opts)
+		_, err = cli.NewSecureSocksProxyContextDialer()
 		require.Contains(t, err.Error(), "root ca is invalid")
 	})
 }

--- a/backend/resource_adapter.go
+++ b/backend/resource_adapter.go
@@ -36,7 +36,7 @@ func (a *resourceSDKAdapter) CallResource(protoReq *pluginv2.CallResourceRequest
 
 	ctx := protoSrv.Context()
 	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = withGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
+	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().CallResourceRequest(protoReq)
 	ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
 	return a.callResourceHandler.CallResource(ctx, parsedReq, fn)

--- a/backend/stream_adapter.go
+++ b/backend/stream_adapter.go
@@ -25,7 +25,7 @@ func (a *streamSDKAdapter) SubscribeStream(ctx context.Context, protoReq *plugin
 		return nil, status.Error(codes.Unimplemented, "not implemented")
 	}
 	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = withGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
+	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	resp, err := a.streamHandler.SubscribeStream(ctx, FromProto().SubscribeStreamRequest(protoReq))
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func (a *streamSDKAdapter) PublishStream(ctx context.Context, protoReq *pluginv2
 		return nil, status.Error(codes.Unimplemented, "not implemented")
 	}
 	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = withGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
+	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	resp, err := a.streamHandler.PublishStream(ctx, FromProto().PublishStreamRequest(protoReq))
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func (a *streamSDKAdapter) RunStream(protoReq *pluginv2.RunStreamRequest, protoS
 	}
 	ctx := protoSrv.Context()
 	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = withGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
+	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	sender := NewStreamSender(&runStreamServer{protoSrv: protoSrv})
 	return a.streamHandler.RunStream(ctx, FromProto().RunStreamRequest(protoReq), sender)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Now reads proxy client configuration from the request, whilst maintaining a fallback to env vars.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/5861

**Special notes for your reviewer**:

See corresponding Grafana changes here - https://github.com/grafana/grafana/pull/76036

Changelog:
```
# github.com/grafana/grafana-plugin-sdk-go/backend
## incompatible changes
(*AppInstanceSettings).HTTPClientOptions: changed from func() (github.com/grafana/grafana-plugin-sdk-go/backend/httpclient.Options, error) to func(context.Context) (github.com/grafana/grafana-plugin-sdk-go/backend/httpclient.Options, error)
(*DataSourceInstanceSettings).HTTPClientOptions: changed from func() (github.com/grafana/grafana-plugin-sdk-go/backend/httpclient.Options, error) to func(context.Context) (github.com/grafana/grafana-plugin-sdk-go/backend/httpclient.Options, error)
(*DataSourceInstanceSettings).ProxyOptions: changed from func() (*github.com/grafana/grafana-plugin-sdk-go/backend/proxy.Options, error) to func(*github.com/grafana/grafana-plugin-sdk-go/backend/proxy.ClientCfg) (*github.com/grafana/grafana-plugin-sdk-go/backend/proxy.Options, error)
(*GrafanaCfg).Proxy: removed
ErrorSourceFromHTTPStatus: removed
Proxy.ClientConfig: removed
## compatible changes
WithGrafanaConfig: added

# github.com/grafana/grafana-plugin-sdk-go/backend/proxy
## incompatible changes
Cli: removed
Client.ConfigureSecureSocksHTTPProxy: changed from func(*net/http.Transport, *Options) error to func(*net/http.Transport) error
Client.NewSecureSocksProxyContextDialer: changed from func(*Options) (golang.org/x/net/proxy.Dialer, error) to func() (golang.org/x/net/proxy.Dialer, error)
Client.SecureSocksProxyEnabled: changed from func(*Options) bool to func() bool
ClientCfg.Enabled: removed
New: changed from func() Client to func(*Options) Client
NewWithCfg: removed
## compatible changes
Options.ClientCfg: added

# github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource
## incompatible changes
package removed

# summary
v0.182.0 is a valid semantic version for this release.
```