### PR TITLE
Tracing: Set service version tracer attribute from compile-set build info

### DIFF
--- a/backend/setup.go
+++ b/backend/setup.go
@@ -107,10 +107,10 @@ func getTracerCustomAttributes(pluginID string) []attribute.KeyValue {
 			pluginVersion = pv
 		}
 	}
-	if pluginVersion != "" {
-		customAttributes = append([]attribute.KeyValue{semconv.ServiceVersionKey.String(pluginVersion)}, customAttributes...)
+	customAttributes = []attribute.KeyValue{
+		semconv.ServiceNameKey.String(pluginID),
+		semconv.ServiceVersionKey.String(pluginVersion),
 	}
-	customAttributes = append([]attribute.KeyValue{semconv.ServiceNameKey.String(pluginID)}, customAttributes...)
 	return customAttributes
 }
 

--- a/backend/setup.go
+++ b/backend/setup.go
@@ -11,6 +11,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
+	"github.com/grafana/grafana-plugin-sdk-go/build"
 	"github.com/grafana/grafana-plugin-sdk-go/internal/tracerprovider"
 )
 
@@ -33,6 +34,7 @@ var (
 	PluginTracingOpenTelemetryOTLPPropagationEnv = "GF_INSTANCE_OTLP_PROPAGATION"
 
 	// PluginVersionEnv is a constant for the GF_PLUGIN_VERSION environment variable containing the plugin's version.
+	// Deprecated: Use build.GetBuildInfo().Version instead.
 	PluginVersionEnv = "GF_PLUGIN_VERSION"
 )
 
@@ -88,16 +90,37 @@ func setupProfiler(pluginID string) {
 	}
 }
 
+func getTracerCustomAttributes(pluginID string) []attribute.KeyValue {
+	var customAttributes []attribute.KeyValue
+	// Add plugin id and version to custom attributes
+	// Try to get plugin version from build info
+	// If not available, fallback to environment variable
+	var pluginVersion string
+	buildInfo, err := build.GetBuildInfo()
+	if err != nil {
+		Logger.Debug("Failed to get build info", "error", err)
+	} else {
+		pluginVersion = buildInfo.Version
+	}
+	if pluginVersion == "" {
+		if pv, ok := os.LookupEnv(PluginVersionEnv); ok {
+			pluginVersion = pv
+		}
+	}
+	if pluginVersion != "" {
+		customAttributes = append([]attribute.KeyValue{semconv.ServiceVersionKey.String(pluginVersion)}, customAttributes...)
+	}
+	customAttributes = append([]attribute.KeyValue{semconv.ServiceNameKey.String(pluginID)}, customAttributes...)
+	return customAttributes
+}
+
 // SetupTracer sets up the global OTEL trace provider and tracer.
 func SetupTracer(pluginID string, tracingOpts tracing.Opts) error {
 	// Set up tracing
 	tracingCfg := getTracingConfig()
 	if tracingCfg.IsEnabled() {
-		// Default attributes from instance management (plugin id and version)
-		if pv, ok := os.LookupEnv(PluginVersionEnv); ok {
-			tracingOpts.CustomAttributes = append([]attribute.KeyValue{semconv.ServiceVersionKey.String(pv)}, tracingOpts.CustomAttributes...)
-		}
-		tracingOpts.CustomAttributes = append([]attribute.KeyValue{semconv.ServiceNameKey.String(pluginID)}, tracingOpts.CustomAttributes...)
+		// Append custom attributes to the default ones
+		tracingOpts.CustomAttributes = append(getTracerCustomAttributes(pluginID), tracingOpts.CustomAttributes...)
 
 		// Initialize global tracer provider
 		tp, err := tracerprovider.NewTracerProvider(tracingCfg.Address, tracingOpts)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

- Sets the service version tracer attribute from compiler-set build info rather than env vars, which is still used as a fallback. This removes usage of an environment variables, which we want to avoid going forward as they do not play well with remote plugins.
- Deprecates the `GF_PLUGIN_VERSION` env var

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

- The plugin has to be re-compiled (via `mage`) every time the version is bumped, even if there are no backend code changes. I believe this is the case our plugins (and all plugins that are built on CI). Not doing so will result in the wrong (older) version being set in the tracer. To enforce this check, it may be a good idea add a check in the plugin-validator
