### PR TITLE
Fix tracing middleware data race when no tracer is provided

### DIFF
--- a/backend/httpclient/tracing_middleware.go
+++ b/backend/httpclient/tracing_middleware.go
@@ -25,12 +25,12 @@ const (
 // code as span attributes. If tracer is nil, it will use tracing.DefaultTracer().
 func TracingMiddleware(tracer trace.Tracer) Middleware {
 	return NamedMiddlewareFunc(TracingMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
-		tracer := tracer
-		if tracer == nil {
-			tracer = tracing.DefaultTracer()
+		t := tracer
+		if t == nil {
+			t = tracing.DefaultTracer()
 		}
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			ctx, span := tracer.Start(req.Context(), "HTTP Outgoing Request", trace.WithSpanKind(trace.SpanKindClient))
+			ctx, span := t.Start(req.Context(), "HTTP Outgoing Request", trace.WithSpanKind(trace.SpanKindClient))
 			defer span.End()
 
 			ctx = httptrace.WithClientTrace(

--- a/backend/httpclient/tracing_middleware.go
+++ b/backend/httpclient/tracing_middleware.go
@@ -25,6 +25,7 @@ const (
 // code as span attributes. If tracer is nil, it will use tracing.DefaultTracer().
 func TracingMiddleware(tracer trace.Tracer) Middleware {
 	return NamedMiddlewareFunc(TracingMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
+		tracer := tracer
 		if tracer == nil {
 			tracer = tracing.DefaultTracer()
 		}

--- a/backend/httpclient/tracing_middleware_test.go
+++ b/backend/httpclient/tracing_middleware_test.go
@@ -116,7 +116,6 @@ func (*mockSpan) TracerProvider() trace.TracerProvider { return mockTracerProvid
 
 func TestTracingMiddlewareWithDefaultTracerDataRace(t *testing.T) {
 	var tracer trace.Tracer
-	tracer = nil
 
 	mw := httpclient.TracingMiddleware(tracer)
 	done := make(chan struct{})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Fixes a potential data race in the `TracingMiddleware` when no tracer is provided.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #752

**Special notes for your reviewer**:

To test this:

- Remove the variable shadowing in `tracing_middleware.go` line 28
```
diff --git a/backend/httpclient/tracing_middleware.go b/backend/httpclient/tracing_middleware.go
index 336da37..2152955 100644
--- a/backend/httpclient/tracing_middleware.go
+++ b/backend/httpclient/tracing_middleware.go
@@ -25,7 +25,7 @@ const (
 // code as span attributes. If tracer is nil, it will use tracing.DefaultTracer().
 func TracingMiddleware(tracer trace.Tracer) Middleware {
        return NamedMiddlewareFunc(TracingMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
-               tracer := tracer
+               // tracer := tracer
                if tracer == nil {
                        tracer = tracing.DefaultTracer()
                }
```

- Run tests with race detector:
```bash
╰─❯ go test -short -race ./backend/httpclient
==================
WARNING: DATA RACE
Read at 0x00c000055b10 by goroutine 65:
  github.com/grafana/grafana-plugin-sdk-go/backend/httpclient_test.TestTracingMiddlewareWithDefaultTracerDataRace.TracingMiddleware.func2()
      /home/giuseppe/grafana/grafana-plugin-sdk-go/backend/httpclient/tracing_middleware.go:29 +0x44
  github.com/grafana/grafana-plugin-sdk-go/backend/httpclient.MiddlewareFunc.CreateMiddleware()
      /home/giuseppe/grafana/grafana-plugin-sdk-go/backend/httpclient/http_client.go:189 +0x84
  github.com/grafana/grafana-plugin-sdk-go/backend/httpclient.(*namedMiddleware).CreateMiddleware()
      /home/giuseppe/grafana/grafana-plugin-sdk-go/backend/httpclient/http_client.go:252 +0xc7
  github.com/grafana/grafana-plugin-sdk-go/backend/httpclient_test.TestTracingMiddlewareWithDefaultTracerDataRace.func1()
      /home/giuseppe/grafana/grafana-plugin-sdk-go/backend/httpclient/tracing_middleware_test.go:125 +0x89

Previous write at 0x00c000055b10 by goroutine 64:
  github.com/grafana/grafana-plugin-sdk-go/backend/httpclient_test.TestTracingMiddlewareWithDefaultTracerDataRace.TracingMiddleware.func2()
      /home/giuseppe/grafana/grafana-plugin-sdk-go/backend/httpclient/tracing_middleware.go:30 +0x68
  github.com/grafana/grafana-plugin-sdk-go/backend/httpclient.MiddlewareFunc.CreateMiddleware()
      /home/giuseppe/grafana/grafana-plugin-sdk-go/backend/httpclient/http_client.go:189 +0x84
  github.com/grafana/grafana-plugin-sdk-go/backend/httpclient.(*namedMiddleware).CreateMiddleware()
      /home/giuseppe/grafana/grafana-plugin-sdk-go/backend/httpclient/http_client.go:252 +0xc7
  github.com/grafana/grafana-plugin-sdk-go/backend/httpclient_test.TestTracingMiddlewareWithDefaultTracerDataRace.func1()
      /home/giuseppe/grafana/grafana-plugin-sdk-go/backend/httpclient/tracing_middleware_test.go:125 +0x89

Goroutine 65 (running) created at:
  github.com/grafana/grafana-plugin-sdk-go/backend/httpclient_test.TestTracingMiddlewareWithDefaultTracerDataRace()
      /home/giuseppe/grafana/grafana-plugin-sdk-go/backend/httpclient/tracing_middleware_test.go:124 +0x16d
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1595 +0x238
  testing.(*T).Run.func1()
      /usr/lib/go/src/testing/testing.go:1648 +0x44

Goroutine 64 (finished) created at:
  github.com/grafana/grafana-plugin-sdk-go/backend/httpclient_test.TestTracingMiddlewareWithDefaultTracerDataRace()
      /home/giuseppe/grafana/grafana-plugin-sdk-go/backend/httpclient/tracing_middleware_test.go:124 +0x16d
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1595 +0x238
  testing.(*T).Run.func1()
      /usr/lib/go/src/testing/testing.go:1648 +0x44
==================
--- FAIL: TestTracingMiddlewareWithDefaultTracerDataRace (0.00s)
    testing.go:1465: race detected during execution of test
FAIL
FAIL    github.com/grafana/grafana-plugin-sdk-go/backend/httpclient     0.324s
FAIL
```

- Undo the changes:
```bash
git checkout -- ./backend/httpclient
```
- Re-run the tests, no more race:
```
╰─❯ go test -race ./backend/httpclient
ok      github.com/grafana/grafana-plugin-sdk-go/backend/httpclient     1.323s
```
