### PR TITLE
Use random port in TestTenantWithPluginInstanceManagement

### DIFF
--- a/internal/tenant/tenanttest/tenant_test.go
+++ b/internal/tenant/tenanttest/tenant_test.go
@@ -130,7 +130,7 @@ func (s *testCallResourceResponseSender) Send(_ *backend.CallResourceResponse) e
 }
 
 // getFreePort returns a random free port listening on 127.0.0.1.
-func getFreePort() (port int, err error) {
+func getFreePort() (int, error) {
 	a, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {
 		return 0, fmt.Errorf("resolve tcp addr: %w", err)
@@ -139,11 +139,9 @@ func getFreePort() (port int, err error) {
 	if err != nil {
 		return 0, fmt.Errorf("listen tcp: %w", err)
 	}
-	defer func() {
-		closeErr := l.Close()
-		if err == nil && closeErr != nil {
-			err = fmt.Errorf("close: %w", closeErr)
-		}
-	}()
-	return l.Addr().(*net.TCPAddr).Port, nil
+	port := l.Addr().(*net.TCPAddr).Port
+	if err = l.Close(); err != nil {
+		return 0, fmt.Errorf("close: %w", err)
+	}
+	return port, nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

`TestTenantWithPluginInstanceManagement` fails if port 8000 is already in use:

```
{"@level":"info","@message":"Standalone plugin server","@timestamp":"2023-10-09T15:42:08.712515+02:00","capabilities":["diagnostics","resources","data","stream"]}
--- FAIL: TestTenantWithPluginInstanceManagement (0.00s)
    tenant_test.go:31: 
        	Error Trace:	/home/giuseppe/grafana/grafana-plugin-sdk-go/internal/tenant/tenanttest/tenant_test.go:31
        	Error:      	Received unexpected error:
        	            	listen tcp 127.0.0.1:8000: bind: address already in use
        	Test:       	TestTenantWithPluginInstanceManagement
FAIL
FAIL	github.com/grafana/grafana-plugin-sdk-go/internal/tenant/tenanttest	0.012s
```

This PR changes the test so it uses a random free port rather than 8000

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

To quickly spin up a server on port 8000 you can use:

```
python3 -m http.server 8000
```
