### PR TITLE
Fix ErrorSource not being set in protobuf QueryDataRespone

### DIFF
--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -182,6 +182,7 @@ func (t ConvertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.
 		} else if status == 0 {
 			pDR.Status = int32(StatusOK)
 		}
+		pDR.ErrorSource = string(dr.ErrorSource)
 
 		pQDR.Responses[refID] = &pDR
 	}

--- a/backend/convert_to_protobuf_test.go
+++ b/backend/convert_to_protobuf_test.go
@@ -65,7 +65,7 @@ func TestConvertToProtobufQueryDataResponse(t *testing.T) {
 			err:                 errors.New("oh no"),
 			status:              StatusBadGateway,
 			errorSource:         ErrorSourceDownstream,
-			expectedStatus:      502,
+			expectedStatus:      int32(StatusBadGateway),
 			expectedErrorSource: "downstream",
 		},
 	}

--- a/backend/convert_to_protobuf_test.go
+++ b/backend/convert_to_protobuf_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -16,10 +17,13 @@ import (
 func TestConvertToProtobufQueryDataResponse(t *testing.T) {
 	frames := data.Frames{data.NewFrame("test", data.NewField("test", nil, []int64{1}))}
 	tcs := []struct {
-		name           string
-		err            error
-		status         Status
-		expectedStatus int32
+		name        string
+		err         error
+		status      Status
+		errorSource ErrorSource
+
+		expectedStatus      int32
+		expectedErrorSource string
 	}{
 		{
 			name:           "If a HTTP Status code is used, use backend.Status equivalent status code",
@@ -56,15 +60,24 @@ func TestConvertToProtobufQueryDataResponse(t *testing.T) {
 			err:            fmt.Errorf("wrap 2: %w", fmt.Errorf("wrap 1: %w", os.ErrDeadlineExceeded)),
 			expectedStatus: int32(StatusTimeout),
 		},
+		{
+			name:                "ErrorSource is marshalled",
+			err:                 errors.New("oh no"),
+			status:              StatusBadGateway,
+			errorSource:         ErrorSourceDownstream,
+			expectedStatus:      502,
+			expectedErrorSource: "downstream",
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			protoRes := &QueryDataResponse{
 				Responses: map[string]DataResponse{
 					"A": {
-						Frames: frames,
-						Error:  tc.err,
-						Status: tc.status,
+						Frames:      frames,
+						Error:       tc.err,
+						Status:      tc.status,
+						ErrorSource: tc.errorSource,
 					},
 				},
 			}
@@ -72,8 +85,10 @@ func TestConvertToProtobufQueryDataResponse(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, qdr)
 			require.NotNil(t, qdr.Responses)
-			receivedStatus := qdr.Responses["A"].Status
+			resp := qdr.Responses["A"]
+			receivedStatus := resp.Status
 			require.Equal(t, tc.expectedStatus, receivedStatus)
+			require.Equal(t, tc.expectedErrorSource, resp.ErrorSource)
 		})
 	}
 }

--- a/backend/convert_to_protobuf_test.go
+++ b/backend/convert_to_protobuf_test.go
@@ -86,8 +86,7 @@ func TestConvertToProtobufQueryDataResponse(t *testing.T) {
 			require.NotNil(t, qdr)
 			require.NotNil(t, qdr.Responses)
 			resp := qdr.Responses["A"]
-			receivedStatus := resp.Status
-			require.Equal(t, tc.expectedStatus, receivedStatus)
+			require.Equal(t, tc.expectedStatus, resp.Status)
 			require.Equal(t, tc.expectedErrorSource, resp.ErrorSource)
 		})
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

The newly introduced `ErrorSource` field is not set when marshaling `DataResponse`s to protobuf. Due to this, the `ErrorSource` field is always empty when read back from Grafana.

The corresponding part in `convert_from_protobuf.go` is already present:

https://github.com/grafana/grafana-plugin-sdk-go/blob/1183d30fc74ade344272a53590c06c920393adab/backend/convert_from_protobuf.go#L159

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
