### PR TITLE
Return empty Grafana config from context if is nil

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -15,10 +15,15 @@ type configKey struct{}
 func GrafanaConfigFromContext(ctx context.Context) *GrafanaCfg {
 	v := ctx.Value(configKey{})
 	if v == nil {
-		return NewGrafanaCfg(make(map[string]string))
+		return NewGrafanaCfg(nil)
 	}
 
-	return v.(*GrafanaCfg)
+	cfg := v.(*GrafanaCfg)
+	if cfg == nil {
+		return NewGrafanaCfg(nil)
+	}
+
+	return cfg
 }
 
 // WithGrafanaConfig injects supplied Grafana config into context.
@@ -32,9 +37,6 @@ type GrafanaCfg struct {
 }
 
 func NewGrafanaCfg(cfg map[string]string) *GrafanaCfg {
-	if cfg == nil {
-		cfg = make(map[string]string)
-	}
 	return &GrafanaCfg{config: cfg}
 }
 
@@ -44,7 +46,7 @@ func (c *GrafanaCfg) Get(key string) string {
 
 func (c *GrafanaCfg) FeatureToggles() FeatureToggles {
 	features, exists := c.config[featuretoggles.EnabledFeatures]
-	if !exists {
+	if !exists || features == "" {
 		return FeatureToggles{}
 	}
 

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -1,0 +1,121 @@
+package backend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/featuretoggles"
+)
+
+func TestConfig(t *testing.T) {
+	t.Run("GrafanaConfigFromContext", func(t *testing.T) {
+		tcs := []struct {
+			name                   string
+			cfg                    *GrafanaCfg
+			expectedFeatureToggles FeatureToggles
+			expectedProxy          Proxy
+		}{
+			{
+				name:                   "nil config",
+				cfg:                    nil,
+				expectedFeatureToggles: FeatureToggles{},
+				expectedProxy:          Proxy{},
+			},
+			{
+				name:                   "empty config",
+				cfg:                    &GrafanaCfg{},
+				expectedFeatureToggles: FeatureToggles{},
+				expectedProxy:          Proxy{},
+			},
+			{
+				name:                   "nil config map",
+				cfg:                    NewGrafanaCfg(nil),
+				expectedFeatureToggles: FeatureToggles{},
+				expectedProxy:          Proxy{},
+			},
+			{
+				name:                   "empty config map",
+				cfg:                    NewGrafanaCfg(make(map[string]string)),
+				expectedFeatureToggles: FeatureToggles{},
+				expectedProxy:          Proxy{},
+			},
+			{
+				name: "feature toggles and proxy enabled",
+				cfg: NewGrafanaCfg(map[string]string{
+					featuretoggles.EnabledFeatures:           "TestFeature",
+					proxy.PluginSecureSocksProxyEnabled:      "true",
+					proxy.PluginSecureSocksProxyProxyAddress: "localhost:1234",
+					proxy.PluginSecureSocksProxyServerName:   "localhost",
+					proxy.PluginSecureSocksProxyClientKey:    "clientKey",
+					proxy.PluginSecureSocksProxyClientCert:   "clientCert",
+					proxy.PluginSecureSocksProxyRootCACert:   "rootCACert",
+				}),
+				expectedFeatureToggles: FeatureToggles{
+					enabled: map[string]struct{}{
+						"TestFeature": {},
+					},
+				},
+				expectedProxy: Proxy{
+					clientCfg: &proxy.ClientCfg{
+						ClientCert:   "clientCert",
+						ClientKey:    "clientKey",
+						RootCA:       "rootCACert",
+						ProxyAddress: "localhost:1234",
+						ServerName:   "localhost",
+					},
+				},
+			},
+			{
+				name: "feature toggles enabled and proxy disabled",
+				cfg: NewGrafanaCfg(map[string]string{
+					featuretoggles.EnabledFeatures:           "TestFeature",
+					proxy.PluginSecureSocksProxyEnabled:      "false",
+					proxy.PluginSecureSocksProxyProxyAddress: "localhost:1234",
+					proxy.PluginSecureSocksProxyServerName:   "localhost",
+					proxy.PluginSecureSocksProxyClientKey:    "clientKey",
+					proxy.PluginSecureSocksProxyClientCert:   "clientCert",
+					proxy.PluginSecureSocksProxyRootCACert:   "rootCACert",
+				}),
+				expectedFeatureToggles: FeatureToggles{
+					enabled: map[string]struct{}{
+						"TestFeature": {},
+					},
+				},
+				expectedProxy: Proxy{},
+			},
+			{
+				name: "feature toggles disabled and proxy enabled",
+				cfg: NewGrafanaCfg(map[string]string{
+					featuretoggles.EnabledFeatures:           "",
+					proxy.PluginSecureSocksProxyEnabled:      "true",
+					proxy.PluginSecureSocksProxyProxyAddress: "localhost:1234",
+					proxy.PluginSecureSocksProxyServerName:   "localhost",
+					proxy.PluginSecureSocksProxyClientKey:    "clientKey",
+					proxy.PluginSecureSocksProxyClientCert:   "clientCert",
+					proxy.PluginSecureSocksProxyRootCACert:   "rootCACert",
+				}),
+				expectedFeatureToggles: FeatureToggles{},
+				expectedProxy: Proxy{
+					clientCfg: &proxy.ClientCfg{
+						ClientCert:   "clientCert",
+						ClientKey:    "clientKey",
+						RootCA:       "rootCACert",
+						ProxyAddress: "localhost:1234",
+						ServerName:   "localhost",
+					},
+				},
+			},
+		}
+
+		for _, tc := range tcs {
+			ctx := WithGrafanaConfig(context.Background(), tc.cfg)
+			cfg := GrafanaConfigFromContext(ctx)
+
+			require.Equal(t, tc.expectedFeatureToggles, cfg.FeatureToggles())
+			require.Equal(t, tc.expectedProxy, cfg.proxy())
+		}
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
If we try to retrieve a `*GrafanaCfg` from context when it does not exist, it will currently return nil. Therefore any subsequent calls on this nil struct will panic. This ensures that we will return an empty struct in this case. 
<!--
**Which issue(s) this PR fixes**:



* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"


Fixes #
-->
**Special notes for your reviewer**:
This also undos the changes made in https://github.com/grafana/grafana-plugin-sdk-go/releases/tag/v0.183.0 as we don't actually need to create an empty map in these cases - this was incorrectly identified as the culprit of the original bug.