### PR TITLE
Add contextual logger (log.FromContext)

### DIFF
--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -8,6 +8,13 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 )
 
+const (
+	endpointCallResource   = "callResource"
+	endpointCheckHealth    = "checkHealth"
+	endpointCollectMetrics = "collectMetrics"
+	endpointQueryData      = "queryData"
+)
+
 // dataSDKAdapter adapter between low level plugin protocol and SDK interfaces.
 type dataSDKAdapter struct {
 	queryDataHandler QueryDataHandler
@@ -48,6 +55,8 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(req.PluginContext.GrafanaConfig))
 	parsedRequest := FromProto().QueryDataRequest(req)
 	ctx = withHeaderMiddleware(ctx, parsedRequest.GetHTTPHeaders())
+	// TODO: needs to be done for all other methods instead
+	ctx = withContextualLogger(ctx, parsedRequest.PluginContext, endpointQueryData)
 	resp, err := a.queryDataHandler.QueryData(ctx, parsedRequest)
 	if err != nil {
 		return nil, err

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -8,13 +8,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 )
 
-const (
-	endpointCallResource   = "callResource"
-	endpointCheckHealth    = "checkHealth"
-	endpointCollectMetrics = "collectMetrics"
-	endpointQueryData      = "queryData"
-)
-
 // dataSDKAdapter adapter between low level plugin protocol and SDK interfaces.
 type dataSDKAdapter struct {
 	queryDataHandler QueryDataHandler
@@ -55,7 +48,6 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(req.PluginContext.GrafanaConfig))
 	parsedRequest := FromProto().QueryDataRequest(req)
 	ctx = withHeaderMiddleware(ctx, parsedRequest.GetHTTPHeaders())
-	// TODO: needs to be done for all other methods instead
 	ctx = withContextualLogger(ctx, parsedRequest.PluginContext, endpointQueryData)
 	resp, err := a.queryDataHandler.QueryData(ctx, parsedRequest)
 	if err != nil {

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -48,7 +48,7 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(req.PluginContext.GrafanaConfig))
 	parsedRequest := FromProto().QueryDataRequest(req)
 	ctx = withHeaderMiddleware(ctx, parsedRequest.GetHTTPHeaders())
-	ctx = withContextualLogger(ctx, parsedRequest.PluginContext, endpointQueryData)
+	ctx = withContextualLogAttributes(ctx, parsedRequest.PluginContext, endpointQueryData)
 	resp, err := a.queryDataHandler.QueryData(ctx, parsedRequest)
 	if err != nil {
 		return nil, err

--- a/backend/diagnostics_adapter.go
+++ b/backend/diagnostics_adapter.go
@@ -50,6 +50,7 @@ func (a *diagnosticsSDKAdapter) CheckHealth(ctx context.Context, protoReq *plugi
 		ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 		parsedReq := FromProto().CheckHealthRequest(protoReq)
 		ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
+		ctx = withContextualLogger(ctx, parsedReq.PluginContext, endpointCheckHealth)
 		res, err := a.checkHealthHandler.CheckHealth(ctx, parsedReq)
 		if err != nil {
 			return nil, err

--- a/backend/diagnostics_adapter.go
+++ b/backend/diagnostics_adapter.go
@@ -50,7 +50,7 @@ func (a *diagnosticsSDKAdapter) CheckHealth(ctx context.Context, protoReq *plugi
 		ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 		parsedReq := FromProto().CheckHealthRequest(protoReq)
 		ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
-		ctx = withContextualLogger(ctx, parsedReq.PluginContext, endpointCheckHealth)
+		ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointCheckHealth)
 		res, err := a.checkHealthHandler.CheckHealth(ctx, parsedReq)
 		if err != nil {
 			return nil, err

--- a/backend/log.go
+++ b/backend/log.go
@@ -27,8 +27,7 @@ var NewLoggerWith = func(args ...interface{}) log.Logger {
 	return log.New().With(args...)
 }
 
-func withContextualLogger(ctx context.Context, pCtx PluginContext, endpoint string) context.Context {
-	logger := log.FromContext(ctx)
+func withContextualLogAttributes(ctx context.Context, pCtx PluginContext, endpoint string) context.Context {
 	args := []any{"pluginID", pCtx.PluginID, "endpoint", endpoint}
 	if tid := trace.SpanContextFromContext(ctx).TraceID(); tid.IsValid() {
 		args = append(args, "traceID", tid.String())
@@ -43,6 +42,6 @@ func withContextualLogger(ctx context.Context, pCtx PluginContext, endpoint stri
 			args = append(args, "uname", pCtx.User.Name)
 		}
 	}
-	ctx = log.WithContext(ctx, logger.With(args...))
+	ctx = log.WithContextualAttributes(ctx, args)
 	return ctx
 }

--- a/backend/log.go
+++ b/backend/log.go
@@ -1,6 +1,10 @@
 package backend
 
 import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
@@ -11,4 +15,23 @@ var Logger = log.DefaultLogger
 // NewLoggerWith creates a new logger with the given arguments.
 var NewLoggerWith = func(args ...interface{}) log.Logger {
 	return log.New().With(args...)
+}
+
+func withContextualLogger(ctx context.Context, pCtx PluginContext, endpoint string) context.Context {
+	logger := log.FromContext(ctx)
+	args := []any{"pluginID", pCtx.PluginID, "endpoint", endpoint}
+	if tid := trace.SpanContextFromContext(ctx).TraceID(); tid.IsValid() {
+		args = append(args, []any{"traceID", tid.String()})
+	}
+	if pCtx.DataSourceInstanceSettings != nil {
+		args = append(args, []any{
+			"dsName", pCtx.DataSourceInstanceSettings.Name,
+			"dsUID", pCtx.DataSourceInstanceSettings.UID,
+		})
+		if pCtx.User != nil {
+			args = append(args, []any{"uname", pCtx.User.Name})
+		}
+	}
+	ctx = log.WithContext(ctx, logger.With(args...))
+	return ctx
 }

--- a/backend/log.go
+++ b/backend/log.go
@@ -8,6 +8,16 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
+const (
+	endpointCallResource    = "callResource"
+	endpointCheckHealth     = "checkHealth"
+	endpointCollectMetrics  = "collectMetrics"
+	endpointQueryData       = "queryData"
+	endpointRunStream       = "runStream"
+	endpointSubscribeStream = "subscribeStream"
+	endpointPublishStream   = "publishStream"
+)
+
 // Logger is the default logger instance. This can be used directly to log from
 // your plugin to grafana-server with calls like backend.Logger.Debug(...).
 var Logger = log.DefaultLogger
@@ -21,15 +31,16 @@ func withContextualLogger(ctx context.Context, pCtx PluginContext, endpoint stri
 	logger := log.FromContext(ctx)
 	args := []any{"pluginID", pCtx.PluginID, "endpoint", endpoint}
 	if tid := trace.SpanContextFromContext(ctx).TraceID(); tid.IsValid() {
-		args = append(args, []any{"traceID", tid.String()})
+		args = append(args, "traceID", tid.String())
 	}
 	if pCtx.DataSourceInstanceSettings != nil {
-		args = append(args, []any{
+		args = append(
+			args,
 			"dsName", pCtx.DataSourceInstanceSettings.Name,
 			"dsUID", pCtx.DataSourceInstanceSettings.UID,
-		})
+		)
 		if pCtx.User != nil {
-			args = append(args, []any{"uname", pCtx.User.Name})
+			args = append(args, "uname", pCtx.User.Name)
 		}
 	}
 	ctx = log.WithContext(ctx, logger.With(args...))

--- a/backend/log/context.go
+++ b/backend/log/context.go
@@ -2,21 +2,25 @@ package log
 
 import "context"
 
-type loggerCtxKeyType struct{}
+type loggerParamsCtxKeyType struct{}
 
-var loggerCtxKey = loggerCtxKeyType{}
+var loggerParamsCtxKey = loggerParamsCtxKeyType{}
 
-// FromContext returns a logger from the context if one is set, otherwise it returns [DefaultLogger].
-func FromContext(ctx context.Context) Logger {
-	logger, ok := ctx.Value(loggerCtxKey).(Logger)
-	if !ok {
-		return DefaultLogger
+// WithContextualAttributes returns a new context with the given key/value log parameters appended to the existing ones.
+// It's possible to get a logger with those contextual parameters by using [FromContext].
+func WithContextualAttributes(ctx context.Context, logParams []any) context.Context {
+	p := logParams
+	if ctxParams := ctx.Value(loggerParamsCtxKey); ctxParams != nil {
+		p = append(ctxParams.([]any), logParams...)
 	}
-	return logger
+	return context.WithValue(ctx, loggerParamsCtxKey, p)
 }
 
-// WithContext returns a new context with the logger set to the provided value.
-// The logger can be retrieved later using [FromContext].
-func WithContext(ctx context.Context, logger Logger) context.Context {
-	return context.WithValue(ctx, loggerCtxKey, logger)
+// ContextualAttributesFromContext returns the contextual key/value log parameters from the given context.
+// If no contextual log parameters are set, it returns nil.
+func ContextualAttributesFromContext(ctx context.Context) []any {
+	if logParams := ctx.Value(loggerParamsCtxKey); logParams != nil {
+		return logParams.([]any)
+	}
+	return nil
 }

--- a/backend/log/context.go
+++ b/backend/log/context.go
@@ -1,0 +1,22 @@
+package log
+
+import "context"
+
+type loggerCtxKeyType struct{}
+
+var loggerCtxKey = loggerCtxKeyType{}
+
+// FromContext returns a logger from the context if one is set, otherwise it returns [DefaultLogger].
+func FromContext(ctx context.Context) Logger {
+	logger, ok := ctx.Value(loggerCtxKey).(Logger)
+	if !ok {
+		return DefaultLogger
+	}
+	return logger
+}
+
+// WithContext returns a new context with the logger set to the provided value.
+// The logger can be retrieved later using [FromContext].
+func WithContext(ctx context.Context, logger Logger) context.Context {
+	return context.WithValue(ctx, loggerCtxKey, logger)
+}

--- a/backend/log/context_test.go
+++ b/backend/log/context_test.go
@@ -1,0 +1,23 @@
+package log
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextualLogger(t *testing.T) {
+	t.Run("FromContext", func(t *testing.T) {
+		logger := New()
+		ctx := WithContext(context.Background(), logger)
+		ctxLogger := FromContext(ctx)
+		require.Equal(t, logger, ctxLogger)
+		require.NotEqual(t, DefaultLogger, ctxLogger)
+	})
+
+	t.Run("FromContext on empty context should return default logger", func(t *testing.T) {
+		ctxLogger := FromContext(context.Background())
+		require.Equal(t, DefaultLogger, ctxLogger)
+	})
+}

--- a/backend/log/context_test.go
+++ b/backend/log/context_test.go
@@ -8,16 +8,24 @@ import (
 )
 
 func TestContextualLogger(t *testing.T) {
-	t.Run("FromContext", func(t *testing.T) {
-		logger := New()
-		ctx := WithContext(context.Background(), logger)
-		ctxLogger := FromContext(ctx)
-		require.Equal(t, logger, ctxLogger)
-		require.NotEqual(t, DefaultLogger, ctxLogger)
+	t.Run("WithContextualAttributes", func(t *testing.T) {
+		t.Run("simple", func(t *testing.T) {
+			logParams := []any{"key", "value"}
+			ctx := WithContextualAttributes(context.Background(), logParams)
+			attrs := ContextualAttributesFromContext(ctx)
+			require.Equal(t, logParams, attrs)
+		})
+
+		t.Run("should append to existing value", func(t *testing.T) {
+			ctx := WithContextualAttributes(context.Background(), []any{"a", "b"})
+			ctx = WithContextualAttributes(ctx, []any{"c", "d"})
+			attrs := ContextualAttributesFromContext(ctx)
+			require.Equal(t, []any{"a", "b", "c", "d"}, attrs)
+		})
 	})
 
-	t.Run("FromContext on empty context should return default logger", func(t *testing.T) {
-		ctxLogger := FromContext(context.Background())
-		require.Equal(t, DefaultLogger, ctxLogger)
+	t.Run("ContextualAttributesFromContext on empty context should return empty slice", func(t *testing.T) {
+		attrs := ContextualAttributesFromContext(context.Background())
+		require.Empty(t, attrs)
 	})
 }

--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -2,6 +2,8 @@
 package log
 
 import (
+	"context"
+
 	hclog "github.com/hashicorp/go-hclog"
 )
 
@@ -24,6 +26,7 @@ type Logger interface {
 	Error(msg string, args ...interface{})
 	With(args ...interface{}) Logger
 	Level() Level
+	FromContext(ctx context.Context) Logger
 }
 
 // New creates a new logger.
@@ -88,6 +91,12 @@ func (l *hclogWrapper) With(args ...interface{}) Logger {
 	return &hclogWrapper{
 		logger: l.logger.With(args...),
 	}
+}
+
+// FromContext creates a sub-logger with the contextual log parameters from the given context.
+// The contextual log parameters can be set using [WithContextualAttributes].
+func (l *hclogWrapper) FromContext(ctx context.Context) Logger {
+	return l.With(ContextualAttributesFromContext(ctx)...)
 }
 
 // DefaultLogger is the default logger.

--- a/backend/log/log_test.go
+++ b/backend/log/log_test.go
@@ -1,20 +1,46 @@
-package log_test
+package log
 
 import (
+	"context"
 	"testing"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLogLevel(t *testing.T) {
-	logger := log.New()
+	logger := New()
 	level := logger.Level()
-	assert.Equal(t, level, log.Debug)
+	assert.Equal(t, level, Debug)
 }
 
 func TestLogLevelWarn(t *testing.T) {
-	logger := log.NewWithLevel(log.Warn)
+	logger := NewWithLevel(Warn)
 	level := logger.Level()
-	assert.Equal(t, level, log.Warn)
+	assert.Equal(t, level, Warn)
+}
+
+func TestLogFromContext(t *testing.T) {
+	t.Run("should return a new empty logger with empty context", func(t *testing.T) {
+		ctx := context.Background()
+		logger := New()
+		ctxLogger := logger.FromContext(ctx)
+		require.NotEqual(t, logger, ctxLogger)
+		require.Empty(t, ctxLogger.(*hclogWrapper).logger.ImpliedArgs())
+	})
+
+	t.Run("should return logger with contextual params when set in context", func(t *testing.T) {
+		ctx := WithContextualAttributes(context.Background(), []any{"key", "value"})
+		logger := New()
+		ctxLogger := logger.FromContext(ctx)
+		require.NotEqual(t, logger, ctxLogger)
+		require.Equal(t, []any{"key", "value"}, ctxLogger.(*hclogWrapper).logger.ImpliedArgs())
+	})
+
+	t.Run("params set in the logger should be kept in the contextual logger", func(t *testing.T) {
+		logger := New().With("service", "myservice")
+		ctxLogger := logger.FromContext(WithContextualAttributes(context.Background(), []any{"key", "value"}))
+		require.NotEqual(t, logger, ctxLogger)
+		require.Equal(t, []any{"key", "value", "service", "myservice"}, ctxLogger.(*hclogWrapper).logger.ImpliedArgs())
+	})
 }

--- a/backend/log_test.go
+++ b/backend/log_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 )
 
-func checkCtxLogger(t *testing.T, ctx context.Context) {
+func checkCtxLogger(ctx context.Context, t *testing.T) {
+	t.Helper()
 	// Make sure we have a ctx logger and that it's different from the DefaultLogger
 	ctxLogger := log.FromContext(ctx)
 	require.NotEqual(t, log.DefaultLogger, ctxLogger)
@@ -22,7 +23,7 @@ func TestContextualLogger(t *testing.T) {
 	t.Run("DataSDKAdapter", func(t *testing.T) {
 		run := make(chan struct{}, 1)
 		a := newDataSDKAdapter(QueryDataHandlerFunc(func(ctx context.Context, req *QueryDataRequest) (*QueryDataResponse, error) {
-			checkCtxLogger(t, ctx)
+			checkCtxLogger(ctx, t)
 			run <- struct{}{}
 			return NewQueryDataResponse(), nil
 		}))
@@ -36,7 +37,7 @@ func TestContextualLogger(t *testing.T) {
 	t.Run("DiagnosticsSDKAdapter", func(t *testing.T) {
 		run := make(chan struct{}, 1)
 		a := newDiagnosticsSDKAdapter(prometheus.DefaultGatherer, CheckHealthHandlerFunc(func(ctx context.Context, req *CheckHealthRequest) (*CheckHealthResult, error) {
-			checkCtxLogger(t, ctx)
+			checkCtxLogger(ctx, t)
 			run <- struct{}{}
 			return &CheckHealthResult{}, nil
 		}))
@@ -50,7 +51,7 @@ func TestContextualLogger(t *testing.T) {
 	t.Run("ResourceSDKAdapter", func(t *testing.T) {
 		run := make(chan struct{}, 1)
 		a := newResourceSDKAdapter(CallResourceHandlerFunc(func(ctx context.Context, req *CallResourceRequest, sender CallResourceResponseSender) error {
-			checkCtxLogger(t, ctx)
+			checkCtxLogger(ctx, t)
 			run <- struct{}{}
 			return nil
 		}))
@@ -67,17 +68,17 @@ func TestContextualLogger(t *testing.T) {
 		runStreamRun := make(chan struct{}, 1)
 		a := newStreamSDKAdapter(&streamAdapter{
 			subscribeStreamFunc: func(ctx context.Context, request *SubscribeStreamRequest) (*SubscribeStreamResponse, error) {
-				checkCtxLogger(t, ctx)
+				checkCtxLogger(ctx, t)
 				subscribeStreamRun <- struct{}{}
 				return &SubscribeStreamResponse{}, nil
 			},
 			publishStreamFunc: func(ctx context.Context, request *PublishStreamRequest) (*PublishStreamResponse, error) {
-				checkCtxLogger(t, ctx)
+				checkCtxLogger(ctx, t)
 				publishStreamRun <- struct{}{}
 				return &PublishStreamResponse{}, nil
 			},
 			runStreamFunc: func(ctx context.Context, request *RunStreamRequest, sender *StreamSender) error {
-				checkCtxLogger(t, ctx)
+				checkCtxLogger(ctx, t)
 				runStreamRun <- struct{}{}
 				return nil
 			},

--- a/backend/log_test.go
+++ b/backend/log_test.go
@@ -1,0 +1,110 @@
+package backend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
+)
+
+func checkCtxLogger(t *testing.T, ctx context.Context) {
+	// Make sure we have a ctx logger and that it's different from the DefaultLogger
+	ctxLogger := log.FromContext(ctx)
+	require.NotEqual(t, log.DefaultLogger, ctxLogger)
+	require.NotNil(t, ctxLogger)
+}
+
+func TestContextualLogger(t *testing.T) {
+	t.Run("DataSDKAdapter", func(t *testing.T) {
+		run := make(chan struct{}, 1)
+		a := newDataSDKAdapter(QueryDataHandlerFunc(func(ctx context.Context, req *QueryDataRequest) (*QueryDataResponse, error) {
+			checkCtxLogger(t, ctx)
+			run <- struct{}{}
+			return NewQueryDataResponse(), nil
+		}))
+		_, err := a.QueryData(context.Background(), &pluginv2.QueryDataRequest{
+			PluginContext: &pluginv2.PluginContext{},
+		})
+		require.NoError(t, err)
+		<-run
+	})
+
+	t.Run("DiagnosticsSDKAdapter", func(t *testing.T) {
+		run := make(chan struct{}, 1)
+		a := newDiagnosticsSDKAdapter(prometheus.DefaultGatherer, CheckHealthHandlerFunc(func(ctx context.Context, req *CheckHealthRequest) (*CheckHealthResult, error) {
+			checkCtxLogger(t, ctx)
+			run <- struct{}{}
+			return &CheckHealthResult{}, nil
+		}))
+		_, err := a.CheckHealth(context.Background(), &pluginv2.CheckHealthRequest{
+			PluginContext: &pluginv2.PluginContext{},
+		})
+		require.NoError(t, err)
+		<-run
+	})
+
+	t.Run("ResourceSDKAdapter", func(t *testing.T) {
+		run := make(chan struct{}, 1)
+		a := newResourceSDKAdapter(CallResourceHandlerFunc(func(ctx context.Context, req *CallResourceRequest, sender CallResourceResponseSender) error {
+			checkCtxLogger(t, ctx)
+			run <- struct{}{}
+			return nil
+		}))
+		err := a.CallResource(&pluginv2.CallResourceRequest{
+			PluginContext: &pluginv2.PluginContext{},
+		}, newTestCallResourceServer())
+		require.NoError(t, err)
+		<-run
+	})
+
+	t.Run("StreamHandler", func(t *testing.T) {
+		subscribeStreamRun := make(chan struct{}, 1)
+		publishStreamRun := make(chan struct{}, 1)
+		runStreamRun := make(chan struct{}, 1)
+		a := newStreamSDKAdapter(&streamAdapter{
+			subscribeStreamFunc: func(ctx context.Context, request *SubscribeStreamRequest) (*SubscribeStreamResponse, error) {
+				checkCtxLogger(t, ctx)
+				subscribeStreamRun <- struct{}{}
+				return &SubscribeStreamResponse{}, nil
+			},
+			publishStreamFunc: func(ctx context.Context, request *PublishStreamRequest) (*PublishStreamResponse, error) {
+				checkCtxLogger(t, ctx)
+				publishStreamRun <- struct{}{}
+				return &PublishStreamResponse{}, nil
+			},
+			runStreamFunc: func(ctx context.Context, request *RunStreamRequest, sender *StreamSender) error {
+				checkCtxLogger(t, ctx)
+				runStreamRun <- struct{}{}
+				return nil
+			},
+		})
+
+		t.Run("SubscribeStream", func(t *testing.T) {
+			_, err := a.SubscribeStream(context.Background(), &pluginv2.SubscribeStreamRequest{
+				PluginContext: &pluginv2.PluginContext{},
+			})
+			require.NoError(t, err)
+			<-subscribeStreamRun
+		})
+
+		t.Run("PublishStream", func(t *testing.T) {
+			_, err := a.PublishStream(context.Background(), &pluginv2.PublishStreamRequest{
+				PluginContext: &pluginv2.PluginContext{},
+			})
+			require.NoError(t, err)
+			<-publishStreamRun
+		})
+
+		t.Run("RunStream", func(t *testing.T) {
+			err := a.RunStream(&pluginv2.RunStreamRequest{
+				PluginContext: &pluginv2.PluginContext{},
+			}, newTestRunStreamServer())
+			require.NoError(t, err)
+			<-runStreamRun
+		})
+	})
+}

--- a/backend/resource_adapter.go
+++ b/backend/resource_adapter.go
@@ -39,5 +39,6 @@ func (a *resourceSDKAdapter) CallResource(protoReq *pluginv2.CallResourceRequest
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().CallResourceRequest(protoReq)
 	ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
+	ctx = withContextualLogger(ctx, parsedReq.PluginContext, endpointCallResource)
 	return a.callResourceHandler.CallResource(ctx, parsedReq, fn)
 }

--- a/backend/resource_adapter.go
+++ b/backend/resource_adapter.go
@@ -39,6 +39,6 @@ func (a *resourceSDKAdapter) CallResource(protoReq *pluginv2.CallResourceRequest
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().CallResourceRequest(protoReq)
 	ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
-	ctx = withContextualLogger(ctx, parsedReq.PluginContext, endpointCallResource)
+	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointCallResource)
 	return a.callResourceHandler.CallResource(ctx, parsedReq, fn)
 }

--- a/backend/stream_adapter.go
+++ b/backend/stream_adapter.go
@@ -27,7 +27,7 @@ func (a *streamSDKAdapter) SubscribeStream(ctx context.Context, protoReq *plugin
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().SubscribeStreamRequest(protoReq)
-	ctx = withContextualLogger(ctx, parsedReq.PluginContext, endpointSubscribeStream)
+	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointSubscribeStream)
 	resp, err := a.streamHandler.SubscribeStream(ctx, parsedReq)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (a *streamSDKAdapter) PublishStream(ctx context.Context, protoReq *pluginv2
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().PublishStreamRequest(protoReq)
-	ctx = withContextualLogger(ctx, parsedReq.PluginContext, endpointPublishStream)
+	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointPublishStream)
 	resp, err := a.streamHandler.PublishStream(ctx, parsedReq)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (a *streamSDKAdapter) RunStream(protoReq *pluginv2.RunStreamRequest, protoS
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().RunStreamRequest(protoReq)
-	ctx = withContextualLogger(ctx, parsedReq.PluginContext, endpointRunStream)
+	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointRunStream)
 	sender := NewStreamSender(&runStreamServer{protoSrv: protoSrv})
 	return a.streamHandler.RunStream(ctx, parsedReq, sender)
 }

--- a/backend/stream_adapter.go
+++ b/backend/stream_adapter.go
@@ -26,7 +26,9 @@ func (a *streamSDKAdapter) SubscribeStream(ctx context.Context, protoReq *plugin
 	}
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
-	resp, err := a.streamHandler.SubscribeStream(ctx, FromProto().SubscribeStreamRequest(protoReq))
+	parsedReq := FromProto().SubscribeStreamRequest(protoReq)
+	ctx = withContextualLogger(ctx, parsedReq.PluginContext, endpointSubscribeStream)
+	resp, err := a.streamHandler.SubscribeStream(ctx, parsedReq)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +41,9 @@ func (a *streamSDKAdapter) PublishStream(ctx context.Context, protoReq *pluginv2
 	}
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
-	resp, err := a.streamHandler.PublishStream(ctx, FromProto().PublishStreamRequest(protoReq))
+	parsedReq := FromProto().PublishStreamRequest(protoReq)
+	ctx = withContextualLogger(ctx, parsedReq.PluginContext, endpointPublishStream)
+	resp, err := a.streamHandler.PublishStream(ctx, parsedReq)
 	if err != nil {
 		return nil, err
 	}
@@ -61,6 +65,8 @@ func (a *streamSDKAdapter) RunStream(protoReq *pluginv2.RunStreamRequest, protoS
 	ctx := protoSrv.Context()
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
+	parsedReq := FromProto().RunStreamRequest(protoReq)
+	ctx = withContextualLogger(ctx, parsedReq.PluginContext, endpointRunStream)
 	sender := NewStreamSender(&runStreamServer{protoSrv: protoSrv})
-	return a.streamHandler.RunStream(ctx, FromProto().RunStreamRequest(protoReq), sender)
+	return a.streamHandler.RunStream(ctx, parsedReq, sender)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Adds a contextual logger, retrievable with `log.FromContext(ctx)`

This is a logger that's similar to `log.DefaultLogger`, but it's pre-populated with some contextual parameters:

- `pluginID`
- `endpoint`
- `traceID` (if available)
- `dsName` (if available)
- `dsUID` (if available)
- `uname` (if available)

Those are the same attributes logged in Grafana core's contextual logger:

https://github.com/grafana/grafana/blob/50504ba00803a291ea24e8a4a48b14494b97c744/pkg/services/pluginsintegration/clientmiddleware/contextual_logger_middleware.go#L27-L37

For this reason, this is especially useful for decoupling core plugins (replacing contextual logger with plugin sdk contextual logger).

This logger is added to the `context.Context` by the sdk adapter. This is a similar pattern to what happens in Grafana core (logging middleware).

Usage example:

```go
func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
	log.DefaultLogger.Info("no context", "a", "b")
	log.FromContext(ctx).Info("with context", "a", "b")
	// ...
```

```
INFO [10-17|17:23:56] no context                               logger=plugin.grafana-datasourcehttpbackend-datasource a=b
INFO [10-17|17:23:56] with context                             logger=plugin.grafana-datasourcehttpbackend-datasource endpoint=queryData uname=admin a=b dsName="Datasource Http Backend" dsUID=a7e_d3pVk pluginID=grafana-datasourcehttpbackend-datasource
```

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #755

**Special notes for your reviewer**:
