### PR TITLE
Chore: Fix lint warnings with golangci-lint version 1.54.2

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -14,6 +14,12 @@ ignore-generated-header = false
 [linters-settings.misspell]
 ignore-words = ["unknwon"]
 
+[linters-settings.depguard.rules.main]
+allow = [] # allow all
+deny = [
+  { pkg = "io/ioutil", desc = "Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details." },
+]
+
 [linters]
 disable-all = true
 enable = [

--- a/backend/setup.go
+++ b/backend/setup.go
@@ -22,13 +22,13 @@ var (
 	PluginProfilingEnabledEnv = "GF_PLUGIN_PROFILING_ENABLED"
 
 	// PluginProfilerPortEnvDeprecated is a constant for the GF_PLUGINS_PROFILER_PORT environment variable use to specify a pprof port (default 6060).
-	PluginProfilerPortEnvDeprecated = "GF_PLUGINS_PROFILER_PORT"
+	PluginProfilerPortEnvDeprecated = "GF_PLUGINS_PROFILER_PORT" // nolint:gosec
 	// PluginProfilingPortEnv is a constant for the GF_PLUGIN_PROFILING_PORT environment variable use to specify a pprof port (default 6060).
-	PluginProfilingPortEnv = "GF_PLUGIN_PROFILING_PORT"
+	PluginProfilingPortEnv = "GF_PLUGIN_PROFILING_PORT" // nolint:gosec
 
 	// PluginTracingOpenTelemetryOTLPAddressEnv is a constant for the GF_INSTANCE_OTLP_ADDRESS
 	// environment variable used to specify the OTLP Address.
-	PluginTracingOpenTelemetryOTLPAddressEnv = "GF_INSTANCE_OTLP_ADDRESS"
+	PluginTracingOpenTelemetryOTLPAddressEnv = "GF_INSTANCE_OTLP_ADDRESS" // nolint:gosec
 	// PluginTracingOpenTelemetryOTLPPropagationEnv is a constant for the GF_INSTANCE_OTLP_PROPAGATION
 	// environment variable used to specify the OTLP propagation format.
 	PluginTracingOpenTelemetryOTLPPropagationEnv = "GF_INSTANCE_OTLP_PROPAGATION"

--- a/build/utils/copy.go
+++ b/build/utils/copy.go
@@ -11,15 +11,14 @@ import (
 // CopyFile copies a file from src to dst. If src and dst files exist, and are
 // the same, then return success. Otherise, attempt to create a hard link
 // between the two files. If that fail, copy the file contents from src to dst.
-func CopyFile(src, dst string) (err error) {
+func CopyFile(src, dst string) error {
 	absSrc, err := filepath.Abs(src)
 	if err != nil {
 		return fmt.Errorf("failed to get absolute path of source file %q: %w", src, err)
 	}
 	sfi, err := os.Stat(src)
 	if err != nil {
-		err = fmt.Errorf("couldn't stat source file %q: %w", absSrc, err)
-		return
+		return fmt.Errorf("couldn't stat source file %q: %w", absSrc, err)
 	}
 	if !sfi.Mode().IsRegular() {
 		// Cannot copy non-regular files (e.g., directories, symlinks, devices, etc.)
@@ -31,27 +30,26 @@ func CopyFile(src, dst string) (err error) {
 		return err
 	}
 	if !exists {
-		err = fmt.Errorf("destination directory doesn't exist: %q", dpath)
-		return
+		return fmt.Errorf("destination directory doesn't exist: %q", dpath)
 	}
 
 	var dfi os.FileInfo
 	dfi, err = os.Stat(dst)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return
+			return err
 		}
 	} else {
 		if !(dfi.Mode().IsRegular()) {
 			return fmt.Errorf("non-regular destination file %s (%q)", dfi.Name(), dfi.Mode().String())
 		}
 		if os.SameFile(sfi, dfi) {
-			return
+			return err
 		}
 	}
 
 	if err = os.Link(src, dst); err == nil {
-		return
+		return err
 	}
 
 	err = copyFileContents(src, dst)

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -63,16 +63,17 @@ func (t TimeSeriesType) String() string {
 // TimeSeriesSchema returns the TimeSeriesSchema of the frame. The TimeSeriesSchema's Type
 // value will be TimeSeriesNot if it is not a time series.
 // Deprecated
-func (f *Frame) TimeSeriesSchema() (tsSchema TimeSeriesSchema) {
+func (f *Frame) TimeSeriesSchema() TimeSeriesSchema {
+	var tsSchema TimeSeriesSchema
 	tsSchema.Type = TimeSeriesTypeNot
 	if f.Fields == nil || len(f.Fields) == 0 {
-		return
+		return tsSchema
 	}
 
 	nonValueIndices := make(map[int]struct{})
 	timeIndices := f.TypeIndices(FieldTypeTime, FieldTypeNullableTime)
 	if len(timeIndices) == 0 {
-		return
+		return tsSchema
 	}
 	tsSchema.TimeIndex = timeIndices[0]
 	nonValueIndices[tsSchema.TimeIndex] = struct{}{}
@@ -92,12 +93,12 @@ func (f *Frame) TimeSeriesSchema() (tsSchema TimeSeriesSchema) {
 	}
 
 	if len(tsSchema.ValueIndices) == 0 {
-		return
+		return tsSchema
 	}
 
 	if len(tsSchema.FactorIndices) == 0 {
 		tsSchema.Type = TimeSeriesTypeWide
-		return
+		return tsSchema
 	}
 	tsSchema.Type = TimeSeriesTypeLong
 	return tsSchema


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Fixes golangci-lint issues with its latest version (v1.54.2):

```
internal/buildinfo/buildinfo.go:9:2: import 'github.com/grafana/grafana-plugin-sdk-go/build' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/build"  
       ^  
backend/log/log.go:7:2: import 'github.com/hashicorp/go-hclog' is not allowed from list 'Main' (depguard)  
       hclog "github.com/hashicorp/go-hclog"  
       ^  
backend/log/context_test.go:7:2: import 'github.com/stretchr/testify/require' is not allowed from list 'Main' (depguard)  
       "github.com/stretchr/testify/require"  
       ^  
backend/log/log_test.go:7:2: import 'github.com/stretchr/testify/assert' is not allowed from list 'Main' (depguard)  
       "github.com/stretchr/testify/assert"  
       ^  
backend/log/log_test.go:8:2: import 'github.com/stretchr/testify/require' is not allowed from list 'Main' (depguard)  
       "github.com/stretchr/testify/require"  
       ^  
experimental/macros/macros_test.go:7:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend"  
       ^  
experimental/macros/macros_test.go:8:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/macros' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/macros"  
       ^  
experimental/macros/macros_test.go:9:2: import 'github.com/stretchr/testify/assert' is not allowed from list 'Main' (depguard)  
       "github.com/stretchr/testify/assert"  
       ^  
experimental/macros/macros_test.go:10:2: import 'github.com/stretchr/testify/require' is not allowed from list 'Main' (depguard)  
       "github.com/stretchr/testify/require"  
       ^  
experimental/macros/time_macros_test.go:7:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend"  
       ^  
experimental/macros/time_macros_test.go:8:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/macros' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/macros"  
       ^  
experimental/macros/time_macros_test.go:9:2: import 'github.com/stretchr/testify/assert' is not allowed from list 'Main' (depguard)  
       "github.com/stretchr/testify/assert"  
       ^  
experimental/e2e/proxy.go:10:2: import 'github.com/elazarl/goproxy' is not allowed from list 'Main' (depguard)  
       "github.com/elazarl/goproxy"  
       ^  
experimental/e2e/proxy.go:12:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/certificate_authority' is not allowed from list 'Main' (depguard)  
       ca "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/certificate_authority"  
       ^  
experimental/e2e/proxy.go:13:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/config' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/config"  
       ^  
experimental/e2e/proxy.go:14:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/fixture' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/fixture"  
       ^  
experimental/e2e/proxy.go:15:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/utils' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/utils"  
       ^  
experimental/datasourcetest/client.go:13:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend"  
       ^  
experimental/datasourcetest/client.go:14:2: import 'github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"  
       ^  
experimental/datasourcetest/manage.go:5:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend/datasource' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend/datasource"  
       ^  
experimental/datasourcetest/manage.go:6:2: import 'github.com/grafana/grafana-plugin-sdk-go/internal/automanagement' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/internal/automanagement"  
       ^  
backend/httpclient/contextual_middleware_example_test.go:8:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend/httpclient' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"  
       ^  
backend/httpclient/http_client_example_test.go:8:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend/httpclient' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"  
       ^  
backend/httpclient/provider_example_test.go:8:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend/httpclient' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"  
       ^  
backend/httpclient/tracing_middleware_test.go:16:2: import 'github.com/grafana/grafana-plugin-sdk-go/internal/tracerprovider' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/internal/tracerprovider"  
       ^  
data/converters/converters_test.go:9:2: import 'github.com/grafana/grafana-plugin-sdk-go/data/converters' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/data/converters"  
       ^  
experimental/authclient/authclient_test.go:16:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/authclient' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/authclient"  
       ^  
experimental/e2e/proxy_test.go:13:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e"  
       ^  
experimental/e2e/proxy_test.go:14:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/config' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/config"  
       ^  
experimental/e2e/proxy_test.go:15:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/fixture' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/fixture"  
       ^  
experimental/e2e/proxy_test.go:16:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/storage' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/storage"  
       ^  
experimental/e2e/certificate_authority/ca_test.go:9:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/certificate_authority' is not allowed from list 'Main' (depguard)  
       ca "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/certificate_authority"  
       ^  
experimental/http_logger/http_logger_test.go:14:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/storage' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/storage"  
       ^  
experimental/http_logger/http_logger_test.go:15:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/http_logger' is not allowed from list 'Main' (depguard)  
       httplogger "github.com/grafana/grafana-plugin-sdk-go/experimental/http_logger"  
       ^  
backend/datasource/query_type_mux_example_test.go:7:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend/datasource' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend/datasource"  
       ^  
backend/datasource/serve_example_test.go:9:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend/datasource' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend/datasource"  
       ^  
backend/datasource/serve_example_test.go:11:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"  
       ^  
backend/datasource/serve_example_test.go:12:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"  
       ^  
backend/httpclient/http_client.go:10:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend/proxy' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"  
       ^  
backend/httpclient/options.go:8:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend/proxy' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"  
       ^  
backend/httpclient/tracing_middleware.go:16:2: import 'github.com/grafana/grafana-plugin-sdk-go/backend/tracing' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/backend/tracing"  
       ^  
build/common.go:13:2: import 'github.com/grafana/grafana-plugin-sdk-go/build/utils' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/build/utils"  
       ^  
build/common.go:14:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e"  
       ^  
build/common.go:15:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/certificate_authority' is not allowed from list 'Main' (depguard)  
       ca "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/certificate_authority"  
       ^  
build/common.go:16:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/config' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/config"  
       ^  
build/common.go:17:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/fixture' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/fixture"  
       ^  
build/common.go:18:2: import 'github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/storage' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/storage"  
       ^  
build/common.go:19:2: import 'github.com/grafana/grafana-plugin-sdk-go/internal' is not allowed from list 'Main' (depguard)  
       "github.com/grafana/grafana-plugin-sdk-go/internal"  
       ^  
build/common.go:20:2: import 'github.com/magefile/mage/mg' is not allowed from list 'Main' (depguard)  
       "github.com/magefile/mage/mg"  
       ^  
build/common.go:21:2: import 'github.com/magefile/mage/sh' is not allowed from list 'Main' (depguard)  
       "github.com/magefile/mage/sh"  
       ^  
backend/setup.go:25:2: G101: Potential hardcoded credentials (gosec)  
       PluginProfilerPortEnvDeprecated = "GF_PLUGINS_PROFILER_PORT"  
       ^  
backend/setup.go:27:2: G101: Potential hardcoded credentials (gosec)  
       PluginProfilingPortEnv = "GF_PLUGIN_PROFILING_PORT"  
       ^  
backend/setup.go:31:2: G101: Potential hardcoded credentials (gosec)  
       PluginTracingOpenTelemetryOTLPAddressEnv = "GF_INSTANCE_OTLP_ADDRESS"  
       ^  
build/utils/copy.go:22:3: naked return in func `CopyFile` with 46 lines of code (nakedret)  
               return  
               ^  
build/utils/copy.go:35:3: naked return in func `CopyFile` with 46 lines of code (nakedret)  
               return  
               ^  
build/utils/copy.go:42:4: naked return in func `CopyFile` with 46 lines of code (nakedret)  
                       return  
                       ^  
data/time_series.go:69:3: naked return in func `TimeSeriesSchema` with 38 lines of code (nakedret)  
               return  
               ^  
data/time_series.go:75:3: naked return in func `TimeSeriesSchema` with 38 lines of code (nakedret)  
               return  
               ^  
data/time_series.go:95:3: naked return in func `TimeSeriesSchema` with 38 lines of code (nakedret)  
               return  
               ^  
Error: running "golangci-lint run ./..." failed with exit code 1
```

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #689 

**Special notes for your reviewer**:
