### PR TITLE
Chore: CI: Bump grafana-plugin-ci image to 1.9.5

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,6 +29,9 @@ steps:
   image: grafana/grafana-plugin-ci:1.9.5
   commands:
   - mage -v testRace
+  environment:
+    # -race requires cgo
+    CGO_ENABLED: "1"
 ---
 kind: pipeline
 type: docker
@@ -57,9 +60,12 @@ steps:
   image: grafana/grafana-plugin-ci:1.9.5
   commands:
   - mage -v testRace
+  environment:
+    # -race requires cgo
+    CGO_ENABLED: "1"
 
 ---
 kind: signature
-hmac: b7ab5d7df4753837c999e7502e27ed73fc23448500960a34e3ed68f3776cc067
+hmac: b148443a2ef693d80a4291b253e935c6bb337abd347e35e1524f65f611dca864
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -28,11 +28,11 @@ steps:
 - name: test
   image: grafana/grafana-plugin-ci:1.9.5
   commands:
+  # -race requires cgo + a C compiler
   - apt update
   - apt install -y gcc
   - mage -v testRace
   environment:
-    # -race requires cgo
     CGO_ENABLED: "1"
 ---
 kind: pipeline
@@ -61,15 +61,15 @@ steps:
 - name: test
   image: grafana/grafana-plugin-ci:1.9.5
   commands:
+  # -race requires cgo + a C compiler
   - apt update
   - apt install -y gcc
   - mage -v testRace
   environment:
-    # -race requires cgo
     CGO_ENABLED: "1"
 
 ---
 kind: signature
-hmac: 1bf1d193ce89ab19332b69fe807b1087a8c3808f459456c71ede5eb3da1ce50e
+hmac: cee688a6f8ed3ecb1ddd384e349a6556d28b23b298057d8fa02da37ab50b0ba7
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -28,6 +28,8 @@ steps:
 - name: test
   image: grafana/grafana-plugin-ci:1.9.5
   commands:
+  - apt update
+  - apt install -y gcc
   - mage -v testRace
   environment:
     # -race requires cgo
@@ -59,6 +61,8 @@ steps:
 - name: test
   image: grafana/grafana-plugin-ci:1.9.5
   commands:
+  - apt update
+  - apt install -y gcc
   - mage -v testRace
   environment:
     # -race requires cgo
@@ -66,6 +70,6 @@ steps:
 
 ---
 kind: signature
-hmac: b148443a2ef693d80a4291b253e935c6bb337abd347e35e1524f65f611dca864
+hmac: 1bf1d193ce89ab19332b69fe807b1087a8c3808f459456c71ede5eb3da1ce50e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,17 +16,17 @@ trigger:
 
 steps:
 - name: build
-  image: grafana/grafana-plugin-ci:1.8.1-alpine
+  image: grafana/grafana-plugin-ci:1.9.5
   commands:
   - mage -v build
 
 - name: lint
-  image: grafana/grafana-plugin-ci:1.8.1-alpine
+  image: grafana/grafana-plugin-ci:1.9.5
   commands:
   - mage -v lint
 
 - name: test
-  image: grafana/grafana-plugin-ci:1.8.1-alpine
+  image: grafana/grafana-plugin-ci:1.9.5
   commands:
   - mage -v testRace
 ---
@@ -44,22 +44,22 @@ trigger:
 
 steps:
 - name: build
-  image: grafana/grafana-plugin-ci:1.8.1-alpine
+  image: grafana/grafana-plugin-ci:1.9.5
   commands:
   - mage -v build
 
 - name: lint
-  image: grafana/grafana-plugin-ci:1.8.1-alpine
+  image: grafana/grafana-plugin-ci:1.9.5
   commands:
   - mage -v lint
 
 - name: test
-  image: grafana/grafana-plugin-ci:1.8.1-alpine
+  image: grafana/grafana-plugin-ci:1.9.5
   commands:
   - mage -v testRace
 
 ---
 kind: signature
-hmac: 6f03e7026ce25ca829f7969c38628da6ee4ccdf0f5898b592f95c71f9090a093
+hmac: b7ab5d7df4753837c999e7502e27ed73fc23448500960a34e3ed68f3776cc067
 
 ...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-plugin-sdk-go
 
-go 1.20
+go 1.21
 
 require (
 	github.com/cheekybits/genny v1.0.0


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Bumps the image used to run CI steps. Brings the following changes:

- Go 1.21 is used (instead of 1.20)
- The latest version of `golangci-lint` is used

Previously, we used Alpine-based images. Since `1.9.0` of the image, we stopped building them:

https://hub.docker.com/r/grafana/grafana-plugin-ci/tags

So we are using Debian-based images now.

`go test -race` requires CGO and a C compiler, for this reason we have to install gcc and enable CGO in the test step.

Long term I say we should probably stop using those `grafana-plugin-ci` images and use the Go image + mage, and golangci-lint separately, similar to what we do for example in the plugin runner:

https://github.com/grafana/grafana-plugin-runner/blob/main/.drone.yml

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
