### PR TITLE
fix: error source middleware - don't return a pointer

### DIFF
--- a/experimental/errorsource/error_source_middleware.go
+++ b/experimental/errorsource/error_source_middleware.go
@@ -18,7 +18,7 @@ func Middleware(plugin string) httpclient.Middleware {
 				if err == nil {
 					err = errors.New(res.Status)
 				}
-				return nil, &Error{source: errorSource, err: err}
+				return nil, Error{source: errorSource, err: err}
 			}
 			return res, err
 		})


### PR DESCRIPTION
returning a pointer is causing errors.As to fail
