### PR TITLE
default bad request/400 to downstream error

### DIFF
--- a/backend/error_source.go
+++ b/backend/error_source.go
@@ -13,8 +13,7 @@ const (
 // ErrorSourceFromStatus returns an ErrorSource based on provided HTTP status code.
 func ErrorSourceFromHTTPStatus(statusCode int) ErrorSource {
 	switch statusCode {
-	case http.StatusBadRequest,
-		http.StatusMethodNotAllowed,
+	case http.StatusMethodNotAllowed,
 		http.StatusNotAcceptable,
 		http.StatusPreconditionFailed,
 		http.StatusRequestEntityTooLarge,


### PR DESCRIPTION
Makes a 400 a downstream error.

These are essentially opinionated defaults.  IMO, by the time a plugin is released, it's doubtful a bad request will occur because of the plugin.  It's more likely a bad query that was entered by the user.
