### PR TITLE
make source accessible

### DIFF
--- a/experimental/errorsource/error_source.go
+++ b/experimental/errorsource/error_source.go
@@ -28,6 +28,11 @@ func (r Error) Unwrap() error {
 	return r.err
 }
 
+// Source provides the error source
+func (r Error) Source() backend.ErrorSource {
+	return r.source
+}
+
 // PluginError will apply the source as plugin
 func PluginError(err error, override bool) error {
 	return SourceError(backend.ErrorSourcePlugin, err, override)


### PR DESCRIPTION
an alternative to this [pr](https://github.com/grafana/grafana-plugin-sdk-go/pull/791)

allows accessing the source value from the error so we can set it on the response.  if we merge the other one, we don't need this
