### PR TITLE
Chore: Fix lint warnings with golangci-lint v1.55.1

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -5,8 +5,8 @@ skip-files = ["data/.*\\.gen\\.go", "data/generic_nullable_vector\\.go", "data/g
 min-confidence = 1
 
 [linters-settings.goconst]
-min-len = 2
-min-occurrences = 2
+min-len = 5
+min-occurrences = 5
 
 [linters-settings.revive]
 ignore-generated-header = false

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -71,7 +71,7 @@ const (
 	IncludeSchemaOnly
 )
 
-// FrameJSON holds a byte representation of the schema separate from the data.
+// FrameJSONCache holds a byte representation of the schema separate from the data.
 // Methods of FrameJSON are not goroutine-safe.
 type FrameJSONCache struct {
 	schema json.RawMessage

--- a/experimental/authclient/authclient_test.go
+++ b/experimental/authclient/authclient_test.go
@@ -12,10 +12,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/authclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/authclient"
+)
+
+const (
+	handlerToken = "/token"
+	handlerFoo   = "/foo"
 )
 
 func TestNew(t *testing.T) {
@@ -30,12 +36,12 @@ func TestNew(t *testing.T) {
 					AuthMethod: authclient.AuthMethodOAuth2,
 					OAuth2Options: &authclient.OAuth2Options{
 						OAuth2Type: authclient.OAuth2TypeClientCredentials,
-						TokenURL:   server.URL + "/token",
+						TokenURL:   server.URL + handlerToken,
 					},
 				})
 				require.Nil(t, err)
 				require.NotNil(t, hc)
-				res, err := hc.Get(server.URL + "/foo")
+				res, err := hc.Get(server.URL + handlerFoo)
 				require.Nil(t, err)
 				require.NotNil(t, res)
 				if res != nil && res.Body != nil {
@@ -54,12 +60,12 @@ func TestNew(t *testing.T) {
 					AuthMethod: authclient.AuthMethodOAuth2,
 					OAuth2Options: &authclient.OAuth2Options{
 						OAuth2Type: authclient.OAuth2TypeClientCredentials,
-						TokenURL:   server.URL + "/token",
+						TokenURL:   server.URL + handlerToken,
 					},
 				})
 				require.Nil(t, err)
 				require.NotNil(t, hc)
-				res, err := hc.Get(server.URL + "/foo")
+				res, err := hc.Get(server.URL + handlerFoo)
 				require.Nil(t, err)
 				require.NotNil(t, res)
 				if res != nil && res.Body != nil {
@@ -80,13 +86,13 @@ func TestNew(t *testing.T) {
 					AuthMethod: authclient.AuthMethodOAuth2,
 					OAuth2Options: &authclient.OAuth2Options{
 						OAuth2Type: authclient.OAuth2TypeJWT,
-						TokenURL:   server.URL + "/token",
+						TokenURL:   server.URL + handlerToken,
 						PrivateKey: privateKey,
 					},
 				})
 				require.Nil(t, err)
 				require.NotNil(t, hc)
-				res, err := hc.Get(server.URL + "/foo")
+				res, err := hc.Get(server.URL + handlerFoo)
 				if res != nil && res.Body != nil {
 					defer res.Body.Close()
 				}
@@ -102,13 +108,13 @@ func TestNew(t *testing.T) {
 					AuthMethod: authclient.AuthMethodOAuth2,
 					OAuth2Options: &authclient.OAuth2Options{
 						OAuth2Type: authclient.OAuth2TypeJWT,
-						TokenURL:   server.URL + "/token",
+						TokenURL:   server.URL + handlerToken,
 						PrivateKey: privateKey,
 					},
 				})
 				require.Nil(t, err)
 				require.NotNil(t, hc)
-				res, err := hc.Get(server.URL + "/foo")
+				res, err := hc.Get(server.URL + handlerFoo)
 				require.Nil(t, err)
 				require.NotNil(t, res)
 				if res != nil && res.Body != nil {
@@ -130,7 +136,7 @@ func getOAuthServer(t *testing.T) *httptest.Server {
 		t.Run("ensure custom headers propagated correctly", func(t *testing.T) {
 			require.Equal(t, "v1", r.Header.Get("h1"))
 		})
-		if r.URL.String() == "/token" {
+		if r.URL.String() == handlerToken {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, fmt.Sprintf(`{"access_token": "%s", "refresh_token": "bar"}`, oAuth2TokenValue))
 			return

--- a/experimental/e2e/proxy_test.go
+++ b/experimental/e2e/proxy_test.go
@@ -10,12 +10,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/config"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/fixture"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/storage"
-	"github.com/stretchr/testify/require"
 )
+
+const handlerFoo = "/foo"
 
 func TestProxy(t *testing.T) {
 	t.Run("Append", func(t *testing.T) {
@@ -37,17 +40,17 @@ func TestProxy(t *testing.T) {
 		t.Run("should add new request to store", func(t *testing.T) {
 			proxy, client, s := setupProxy(e2e.ProxyModeAppend)
 			defer s.Close()
-			req, err := http.NewRequest(http.MethodGet, srv.URL+"/foo", nil)
+			req, err := http.NewRequest(http.MethodGet, srv.URL+handlerFoo, nil)
 			require.NoError(t, err)
 			res, err := client.Do(req)
 			require.NoError(t, err)
 			defer res.Body.Close()
-			require.Equal(t, "/foo", proxy.Fixtures[0].Entries()[0].Request.URL.Path)
+			require.Equal(t, handlerFoo, proxy.Fixtures[0].Entries()[0].Request.URL.Path)
 			require.Equal(t, http.StatusOK, proxy.Fixtures[0].Entries()[0].Response.StatusCode)
 			require.Equal(t, http.StatusOK, res.StatusCode)
 			resBody, err := io.ReadAll(res.Body)
 			require.NoError(t, err)
-			require.Equal(t, "/foo", string(resBody))
+			require.Equal(t, handlerFoo, string(resBody))
 		})
 
 		t.Run("should not add or modify existing request", func(t *testing.T) {
@@ -55,7 +58,7 @@ func TestProxy(t *testing.T) {
 			proxy, client, s := setupProxy(e2e.ProxyModeAppend)
 			defer s.Close()
 			// Add an existing request directly to the fixture
-			req, err := http.NewRequest(http.MethodPost, srv.URL+"/foo", bytes.NewBuffer([]byte("bar")))
+			req, err := http.NewRequest(http.MethodPost, srv.URL+handlerFoo, bytes.NewBuffer([]byte("bar")))
 			require.NoError(t, err)
 			req.Header = make(http.Header)
 			res := &http.Response{
@@ -67,13 +70,13 @@ func TestProxy(t *testing.T) {
 			err = proxy.Fixtures[0].Add(req, res)
 			require.NoError(t, err)
 			require.Len(t, proxy.Fixtures[0].Entries(), 1)
-			req, err = http.NewRequest(http.MethodPost, srv.URL+"/foo", bytes.NewBuffer([]byte("bar")))
+			req, err = http.NewRequest(http.MethodPost, srv.URL+handlerFoo, bytes.NewBuffer([]byte("bar")))
 			require.NoError(t, err)
 			resp, err := client.Do(req)
 			require.NoError(t, err)
 			defer resp.Body.Close()
 			require.Len(t, proxy.Fixtures[0].Entries(), 1)
-			require.Equal(t, "/foo", proxy.Fixtures[0].Entries()[0].Request.URL.Path)
+			require.Equal(t, handlerFoo, proxy.Fixtures[0].Entries()[0].Request.URL.Path)
 			require.Equal(t, http.StatusOK, proxy.Fixtures[0].Entries()[0].Response.StatusCode)
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
@@ -100,17 +103,17 @@ func TestProxy(t *testing.T) {
 		t.Run("should add new request to store", func(t *testing.T) {
 			proxy, client, s := setupProxy(e2e.ProxyModeOverwrite)
 			defer s.Close()
-			req, err := http.NewRequest(http.MethodGet, srv.URL+"/foo", nil)
+			req, err := http.NewRequest(http.MethodGet, srv.URL+handlerFoo, nil)
 			require.NoError(t, err)
 			res, err := client.Do(req)
 			require.NoError(t, err)
 			defer res.Body.Close()
-			require.Equal(t, "/foo", proxy.Fixtures[0].Entries()[0].Request.URL.Path)
+			require.Equal(t, handlerFoo, proxy.Fixtures[0].Entries()[0].Request.URL.Path)
 			require.Equal(t, http.StatusOK, proxy.Fixtures[0].Entries()[0].Response.StatusCode)
 			require.Equal(t, http.StatusOK, res.StatusCode)
 			resBody, err := io.ReadAll(res.Body)
 			require.NoError(t, err)
-			require.Equal(t, "/foo", string(resBody))
+			require.Equal(t, handlerFoo, string(resBody))
 		})
 
 		t.Run("should replace existing request", func(t *testing.T) {
@@ -118,7 +121,7 @@ func TestProxy(t *testing.T) {
 			proxy, client, s := setupProxy(e2e.ProxyModeOverwrite)
 			defer s.Close()
 			// Add an existing request directly to the fixture
-			req, err := http.NewRequest(http.MethodGet, srv.URL+"/foo", nil)
+			req, err := http.NewRequest(http.MethodGet, srv.URL+handlerFoo, nil)
 			require.NoError(t, err)
 			req.Header = make(http.Header)
 			req.Body = io.NopCloser(bytes.NewBuffer([]byte("bar")))
@@ -132,11 +135,11 @@ func TestProxy(t *testing.T) {
 			resp, err := client.Do(req)
 			require.NoError(t, err)
 			defer resp.Body.Close()
-			require.Equal(t, "/foo", proxy.Fixtures[0].Entries()[0].Request.URL.Path)
+			require.Equal(t, handlerFoo, proxy.Fixtures[0].Entries()[0].Request.URL.Path)
 			require.Equal(t, http.StatusOK, proxy.Fixtures[0].Entries()[0].Response.StatusCode)
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
-			require.Equal(t, "/foo", string(body))
+			require.Equal(t, handlerFoo, string(body))
 		})
 	})
 

--- a/experimental/oauthtokenretriever/sign_test.go
+++ b/experimental/oauthtokenretriever/sign_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	//nolint: gosec
+	// gosec warning G101 can be ignored because this is just test data
 	testRSAKey = `-----BEGIN RSA PRIVATE KEY-----
 MIICWwIBAAKBgQC35vznv35Kaby20gu+RQBDj/kHhPd64b6p9TKKxqiAs8kukNFj
 Q8keR6MOO41Md0Jh4b/ZSo1O3C3K3K587NORJDWz0H2wVyTWDvSMI36nI/EnGDhh
@@ -23,6 +25,9 @@ ZDmoDYnHv5IAtxpjIQJASxC/V51AHfuQ+rWvbZ6jzoHW6owbFpC2RbZPtFanOlda
 ozjy/YI5hvWLr/bre/wZ3N81pLA9lPgEpJiOPYem3Q==
 -----END RSA PRIVATE KEY-----
 `
+
+	//nolint: gosec
+	// gosec warning G101 can be ignored because this is just test data
 	testECDSAKey = `-----BEGIN PRIVATE KEY-----
 MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgYH3q1su2TRDIr4RB
 2okegCNvfhn/Q9CycAXtPnfYsZehRANCAARSs6LcDI314KqKqGHbv2FLGoMXjm6B


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

I updated golangci-lint to v1.55.1 on my machine and it started returning new warnings once again.

This PR fixes those warnings.

The image used in CI does not use such version of golangci-lint yet.

```
╭─ ~/grafana/grafana-plugin-sdk-go on giuseppe/fix…lint-v1.55.1                   ✘ INT  
╰─❯ mage lint  
data/frame_json.go:85:43: string `":` has 3 occurrences, make it a constant (goconst)  
               out := append([]byte(`{"`+jsonKeySchema+`":`), f.schema...)  
                                                       ^  
experimental/oauthtokenretriever/sign_test.go:10:2: G101: Potential hardcoded credentials: RSA private key (gosec)  
       testRSAKey = `-----BEGIN RSA PRIVATE KEY-----  
MIICWwIBAAKBgQC35vznv35Kaby20gu+RQBDj/kHhPd64b6p9TKKxqiAs8kukNFj  
Q8keR6MOO41Md0Jh4b/ZSo1O3C3K3K587NORJDWz0H2wVyTWDvSMI36nI/EnGDhh  
4fImv5E/9jIvhOxCJ3Dej57//tMt8TEG1ZETrAKzUvB7EfCfsnazGraMQwIDAQAB  
AoGAfbFh4B+w+LlGY4oyvow4vvTTV4FZCOLsRwuwzMs09iprcelHQ9pbxtddqeeo  
DsBgXbhHQQPEi0bQAZxNolLX0m4nQ8n9H6by42qOJlwywYZIl7Di3aWYiOiT56v7  
PfqCsShSqsvWH8Ok4Jy6/Vcc4QcO4mGi8y8EZdSqfytGvkkCQQDhO+1Y4x36ETAh  
NOQx1E/psPuSH8H6YeDoWYeap5z1KXzN4eTo01p8ckPSD93uXIig7LmfIWPMqlGV  
yOBSyqD/AkEA0QXBLeDksi8hX8B2XOMfY9hWOBwBRXrlKX6TVF/9Kw+ulJpe3sU5  
lc53oytpk1VwXAfJrjNRqyIIIRnFyTJQvQJAMBgFxFcqzXziFBUhLOqy7amW7krN  
ttMznSmQ5RspTsg/GA9GO9j1l2EmzjIJJ56mpgYmVK5iiw9LQHqWO9d8rQJASUDz  
CtkeTTQnRh91W+hdP+i5jsCB0Y/YcEpj59YcK9M7I+lWBkyoec/6Lb0xKuluj1JL  
ZDmoDYnHv5IAtxpjIQJASxC/V51AHfuQ+rWvbZ6jzoHW6owbFpC2RbZPtFanOlda  
ozjy/YI5hvWLr/bre/wZ3N81pLA9lPgEpJiOPYem3Q==  
-----END RSA PRIVATE KEY-----  
`  
experimental/authclient/authclient_test.go:33:32: string `/token` has 5 occurrences, make it a constant (goconst)  
                                               TokenURL:   server.URL + "/token",  
                                                                        ^  
experimental/authclient/authclient_test.go:38:37: string `/foo` has 4 occurrences, make it a constant (goconst)  
                               res, err := hc.Get(server.URL + "/foo")  
                                                               ^  
experimental/e2e/proxy_test.go:40:56: string `/foo` has 5 occurrences, make it a constant (goconst)  
                       req, err := http.NewRequest(http.MethodGet, srv.URL+"/foo", nil)  
                                                                           ^  
data/frame_json_test.go:463:71: string `VectorJSON(iter, size)  
` has 2 occurrences, make it a constant (goconst)  
               fmt.Printf("    case FieldType" + tname + ": return read" + tname + "VectorJSON(iter, size)\n")  
                                                                                   ^  
backend/http_headers_test.go:91:24: string `x-custom` has 2 occurrences, make it a constant (goconst)  
                               httpHeaderPrefix + "x-custom": "d",  
                                                  ^  
backend/http_headers_test.go:111:24: string `X-Custom` has 2 occurrences, but such constant `customHeaderName` already exists (goconst)  
                               httpHeaderPrefix + "X-Custom": "d",  
                                                  ^  
backend/json.go:159:32: string `unexpected field: ` has 2 occurrences, make it a constant (goconst)  
                       iter.ReportError("bind l1", "unexpected field: "+l1Field)  
                                                   ^  
experimental/golden_response_checker.go:241:39: string `//  ` has 2 occurrences, make it a constant (goconst)  
       chunks := strings.Split(string(raw), "//  "+machineStr)  
                                            ^  
Error: running "golangci-lint run ./..." failed with exit code 1
```


**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
