### PR TITLE
Build: Add pluginID to buildinfo

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -96,7 +96,7 @@ func buildBackend(cfg Config) error {
 	}
 
 	info := getBuildInfoFromEnvironment()
-	pluginID, err := internal.GetStringValueFromJSON(filepath.Join("src", "plugin.json"), "id")
+	pluginID, err := internal.GetStringValueFromJSON(pluginJSONPath, "id")
 	if err == nil && len(pluginID) > 0 {
 		info.PluginID = pluginID
 	}

--- a/build/common.go
+++ b/build/common.go
@@ -10,6 +10,11 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+	bra "github.com/unknwon/bra/cmd"
+	"github.com/urfave/cli"
+
 	"github.com/grafana/grafana-plugin-sdk-go/build/utils"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e"
 	ca "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/certificate_authority"
@@ -17,10 +22,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/fixture"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/storage"
 	"github.com/grafana/grafana-plugin-sdk-go/internal"
-	"github.com/magefile/mage/mg"
-	"github.com/magefile/mage/sh"
-	bra "github.com/unknwon/bra/cmd"
-	"github.com/urfave/cli"
 )
 
 var defaultOutputBinaryPath = "dist"
@@ -95,6 +96,10 @@ func buildBackend(cfg Config) error {
 	}
 
 	info := getBuildInfoFromEnvironment()
+	pluginID, err := internal.GetStringValueFromJSON(filepath.Join("src", "plugin.json"), "id")
+	if err == nil && len(pluginID) > 0 {
+		info.PluginID = pluginID
+	}
 	version, err := internal.GetStringValueFromJSON("package.json", "version")
 	if err == nil && len(version) > 0 {
 		info.Version = version

--- a/build/common.go
+++ b/build/common.go
@@ -96,7 +96,7 @@ func buildBackend(cfg Config) error {
 	}
 
 	info := getBuildInfoFromEnvironment()
-	pluginID, err := internal.GetStringValueFromJSON(pluginJSONPath, "id")
+	pluginID, err := internal.GetStringValueFromJSON(filepath.Join(pluginJSONPath, "plugin.json"), "id")
 	if err == nil && len(pluginID) > 0 {
 		info.PluginID = pluginID
 	}

--- a/build/info.go
+++ b/build/info.go
@@ -18,18 +18,22 @@ var now = time.Now
 
 // Info See also PluginBuildInfo in https://github.com/grafana/grafana/blob/master/pkg/plugins/models.go
 type Info struct {
-	Time    int64  `json:"time,omitempty"`
-	Version string `json:"version,omitempty"`
-	Repo    string `json:"repo,omitempty"`
-	Branch  string `json:"branch,omitempty"`
-	Hash    string `json:"hash,omitempty"`
-	Build   int64  `json:"build,omitempty"`
-	PR      int64  `json:"pr,omitempty"`
+	Time     int64  `json:"time,omitempty"`
+	PluginID string `json:"pluginID,omitempty"`
+	Version  string `json:"version,omitempty"`
+	Repo     string `json:"repo,omitempty"`
+	Branch   string `json:"branch,omitempty"`
+	Hash     string `json:"hash,omitempty"`
+	Build    int64  `json:"build,omitempty"`
+	PR       int64  `json:"pr,omitempty"`
 }
 
 // this will append build flags -- the keys are picked to match existing
 // grafana build flags from bra
 func (v Info) appendFlags(flags map[string]string) {
+	if v.PluginID != "" {
+		flags["main.pluginID"] = v.PluginID
+	}
 	if v.Version != "" {
 		flags["main.version"] = v.Version
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Proposal to add `pluginID` to buildinfo when building a plugin using the official Mage targets, similar to what we do for `version`.

```
./dist/gpx_datasource_http_backend_linux_amd64 -buildinfo
{"time":1698416415872,"pluginID":"grafana-datasourcehttpbackend-datasource","version":"1.0.0","repo":"git@github.com:grafana/grafana-plugin-examples.git","branch":"main","hash":"a73e78015bc5a5050f1e200213811df3f15d0aeb"}
```

This can be useful to set a service name for the tracer (required in PR #781), without relying on environment variables:

https://github.com/grafana/grafana-plugin-sdk-go/blob/9e2870c05105168e5c813ae5b3d47ffccbcd71f4/backend/setup.go#L189-L190

This approach would make it very similar to what we do to retrieve the plugin's version:

https://github.com/grafana/grafana-plugin-sdk-go/blob/d21f48e91ac308a02f5745675815f9d021357acc/backend/setup.go#L99-L104

It could also be used for other things in the future as well.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
