### PR TITLE
Downgrade go minimum version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-plugin-sdk-go
 
-go 1.21
+go 1.20
 
 require (
 	github.com/cheekybits/genny v1.0.0


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

This matches the version defined in Grafana. If those versions don't match, I get this error when trying to use the latest SDK:

```
$ make build-go
generate go files
/home/andres/go/bin/wire-v0.5.0 gen -tags "oss" ./pkg/server
wire: go [list -e -json -compiled=true -test=false -export=false -deps=true -find=false -tags=wireinject oss -- ./pkg/server]: exit status 1: go: cloud.google.com/go@v0.110.8 requires
		google.golang.org/genproto@v0.0.0-20230530153820-e85fd2cbaebc: missing go.sum entry for go.mod file; to add it:
		go mod download google.golang.org/genproto
	
wire: generate failed
make: *** [Makefile:113: gen-go] Error 1
```

@xnyo any reason I am missing for specifying go 1.21 as the minimum version? It was updated in https://github.com/grafana/grafana-plugin-sdk-go/pull/780

FTR, Grafana is being updated but it's a WIP https://github.com/grafana/grafana/pull/77304