### PR TITLE
experimental error source middleware fix

### DIFF
--- a/experimental/errorsource/error_source_middleware.go
+++ b/experimental/errorsource/error_source_middleware.go
@@ -23,10 +23,10 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 			if err == nil {
 				err = errors.New(res.Status)
 			}
-			return nil, Error{source: errorSource, err: err}
+			return res, Error{source: errorSource, err: err}
 		}
 		if errors.Is(err, syscall.ECONNREFUSED) {
-			return nil, Error{source: backend.ErrorSourceDownstream, err: err}
+			return res, Error{source: backend.ErrorSourceDownstream, err: err}
 		}
 		return res, err
 	})


### PR DESCRIPTION
When the response contains useful error message, we need to pass them to downstream. Currently we are swallowing the response. In most APIs, with response body will contain error message.