### PR TITLE
Fix parsing of uint64 fields in a Frame

### DIFF
--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -1331,8 +1331,3 @@ func readJSONVectorJSON(iter *jsoniter.Iterator, nullable bool, size int) (vecto
 	}
 	return arr, nil
 }
-
-func appendDefault[T any](t []T) []T {
-	var def T
-	return append(t, def)
-}

--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -3,6 +3,7 @@ package data_test
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -315,6 +316,25 @@ func TestFrame_UnmarshalJSON_DataOnly(t *testing.T) {
 	var newFrame data.Frame
 	err = json.Unmarshal(d, &newFrame)
 	require.Error(t, err)
+}
+
+func TestFrame_UnmarshallUint64(t *testing.T) {
+	expected := `
+	{"schema":{"name":"test","fields":[{"name":"test-field","type":"number","typeInfo":{"frame":"uint64"}}]},"data":{"values":[[18446744073709551615,"18446744073709551615",0,1,2,3,4,5]]}}
+	`
+
+	var actual data.Frame
+	require.NoError(t, json.Unmarshal([]byte(expected), &actual))
+	require.Len(t, actual.Fields, 1)
+	require.Equal(t, data.FieldTypeUint64, actual.Fields[0].Type())
+	var values []uint64
+	for i := 0; i < actual.Fields[0].Len(); i++ {
+		v, ok := actual.Fields[0].ConcreteAt(i)
+		require.True(t, ok)
+		require.IsType(t, v, uint64(1))
+		values = append(values, v.(uint64))
+	}
+	require.EqualValues(t, []uint64{math.MaxUint64, math.MaxUint64, 0, 1, 2, 3, 4, 5}, values)
 }
 
 // This function will write code to the console that should be copy/pasted into frame_json.gen.go

--- a/internal/jsonitere/wrapper.go
+++ b/internal/jsonitere/wrapper.go
@@ -1,0 +1,87 @@
+// package jsonitere wraps json-iterator/go's Iterator methods with error returns
+// so linting can catch unchecked errors.
+// The underlying iterator's Error property is returned and not reset.
+// See json-iterator/go for method documentation and additional methods that
+// can be added to this library.
+package jsonitere
+
+import (
+	j "github.com/json-iterator/go"
+)
+
+type Iterator struct {
+	// named property instead of embedded so there is no
+	// confusion about which method or property is called
+	i *j.Iterator
+}
+
+func NewIterator(i *j.Iterator) *Iterator {
+	return &Iterator{i}
+}
+
+func (iter *Iterator) Read() (interface{}, error) {
+	return iter.i.Read(), iter.i.Error
+}
+
+func (iter *Iterator) ReadAny() (j.Any, error) {
+	return iter.i.ReadAny(), iter.i.Error
+}
+
+func (iter *Iterator) ReadArray() (bool, error) {
+	return iter.i.ReadArray(), iter.i.Error
+}
+
+func (iter *Iterator) ReadObject() (string, error) {
+	return iter.i.ReadObject(), iter.i.Error
+}
+
+func (iter *Iterator) ReadString() (string, error) {
+	return iter.i.ReadString(), iter.i.Error
+}
+
+func (iter *Iterator) WhatIsNext() (j.ValueType, error) {
+	return iter.i.WhatIsNext(), iter.i.Error
+}
+
+func (iter *Iterator) Skip() error {
+	iter.i.Skip()
+	return iter.i.Error
+}
+
+func (iter *Iterator) ReadVal(obj interface{}) error {
+	iter.i.ReadVal(obj)
+	return iter.i.Error
+}
+
+func (iter *Iterator) ReadFloat64() (float64, error) {
+	return iter.i.ReadFloat64(), iter.i.Error
+}
+
+func (iter *Iterator) ReadInt8() (int8, error) {
+	return iter.i.ReadInt8(), iter.i.Error
+}
+
+func (iter *Iterator) ReadUint64() (uint64, error) {
+	return iter.i.ReadUint64(), iter.i.Error
+}
+
+func (iter *Iterator) ReadUint64Pointer() (*uint64, error) {
+	u := iter.i.ReadUint64()
+	if iter.i.Error != nil {
+		return nil, iter.i.Error
+	}
+	return &u, nil
+}
+
+func (iter *Iterator) ReadNil() (bool, error) {
+	return iter.i.ReadNil(), iter.i.Error
+}
+
+func (iter *Iterator) ReadBool() (bool, error) {
+	return iter.i.ReadBool(), iter.i.Error
+}
+
+func (iter *Iterator) ReportError(op, msg string) error {
+	iter.i.ReportError(op, msg)
+	return iter.i.Error
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
This PR fixes parsing of the first field of the data frame if it is a UINT64. This does not change how the rest of the fields are parsed.

Currently, the first field of the data frame is parsed differently because I think the size of the values is not known and is determined by the first field. The approach uses a different technique and reads the JSON array to `[]any` and then converts it to the actual type. However, during this conversion, jsoniter [reads all numbers as float64](https://github.com/json-iterator/go/blob/71ac16282d122fdd1e3a6d3e7f79b79b4cc3b50e/iter.go#L297-L300) which corrupts uint64 values. 

The parsing of the remaining fields uses a different, more correct, approach and reads the array using ReadUint64 method, the same as implemented in this PR. However, it is not possible to reuse this approach because it requires that the size of the array is known beforehand. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-plugin-sdk-go/issues/800

**Special notes for your reviewer**:

- I added a wrapper for jsoniter.Iterator that implements error handling during usage of jsoniter be more golang-ish.