### PR TITLE
Add retrieval of Grafana user agent from context

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -127,18 +127,20 @@ func (c *GrafanaCfg) AppURL() (string, error) {
 type userAgentKey struct{}
 
 // UserAgentFromContext returns user agent from context.
-func UserAgentFromContext(ctx context.Context) (*useragent.UserAgent, error) {
+func UserAgentFromContext(ctx context.Context) *useragent.UserAgent {
 	v := ctx.Value(userAgentKey{})
 	if v == nil {
-		return useragent.Empty()
+		e, _ := useragent.Empty()
+		return e
 	}
 
 	ua := v.(*useragent.UserAgent)
 	if ua == nil {
-		return useragent.Empty()
+		e, _ := useragent.Empty()
+		return e
 	}
 
-	return ua, nil
+	return ua
 }
 
 // WithUserAgent injects supplied user agent into context.

--- a/backend/config.go
+++ b/backend/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/useragent"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/featuretoggles"
 )
 
@@ -121,4 +122,27 @@ func (c *GrafanaCfg) AppURL() (string, error) {
 		return "", fmt.Errorf("app URL not set in config. A more recent version of Grafana may be required")
 	}
 	return url, nil
+}
+
+type userAgentKey struct{}
+
+// UserAgentFromContext returns user agent from context.
+func UserAgentFromContext(ctx context.Context) (*useragent.UserAgent, error) {
+	v := ctx.Value(userAgentKey{})
+	if v == nil {
+		return useragent.New("0.0.0", "unknown", "unknown")
+	}
+
+	ua := v.(*useragent.UserAgent)
+	if ua == nil {
+		return useragent.New("0.0.0", "unknown", "unknown")
+	}
+
+	return ua, nil
+}
+
+// WithUserAgent injects supplied user agent into context.
+func WithUserAgent(ctx context.Context, ua *useragent.UserAgent) context.Context {
+	ctx = context.WithValue(ctx, userAgentKey{}, ua)
+	return ctx
 }

--- a/backend/config.go
+++ b/backend/config.go
@@ -130,14 +130,12 @@ type userAgentKey struct{}
 func UserAgentFromContext(ctx context.Context) *useragent.UserAgent {
 	v := ctx.Value(userAgentKey{})
 	if v == nil {
-		e, _ := useragent.Empty()
-		return e
+		return useragent.Empty()
 	}
 
 	ua := v.(*useragent.UserAgent)
 	if ua == nil {
-		e, _ := useragent.Empty()
-		return e
+		return useragent.Empty()
 	}
 
 	return ua

--- a/backend/config.go
+++ b/backend/config.go
@@ -130,12 +130,12 @@ type userAgentKey struct{}
 func UserAgentFromContext(ctx context.Context) (*useragent.UserAgent, error) {
 	v := ctx.Value(userAgentKey{})
 	if v == nil {
-		return useragent.New("0.0.0", "unknown", "unknown")
+		return useragent.Empty()
 	}
 
 	ua := v.(*useragent.UserAgent)
 	if ua == nil {
-		return useragent.New("0.0.0", "unknown", "unknown")
+		return useragent.Empty()
 	}
 
 	return ua, nil

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -146,12 +146,8 @@ func TestUserAgentFromContext(t *testing.T) {
 
 	result, err := UserAgentFromContext(ctx)
 	require.NoError(t, err)
-	if result.GrafanaVersion() != "10.0.0" {
-		t.Errorf("Expected Grafana version to be '10.0.0', got %s", result.GrafanaVersion())
-	}
-	if result.String() != "Grafana/10.0.0 (test; test)" {
-		t.Errorf("Expected correctly formed UA string, got %s", result.String())
-	}
+	require.Equal(t, "10.0.0", result.GrafanaVersion())
+	require.Equal(t, "Grafana/10.0.0 (test; test)", result.String())
 }
 
 func TestUserAgentFromContext_NoUserAgent(t *testing.T) {
@@ -159,10 +155,6 @@ func TestUserAgentFromContext_NoUserAgent(t *testing.T) {
 
 	result, err := UserAgentFromContext(ctx)
 	require.NoError(t, err)
-	if result.GrafanaVersion() != "0.0.0" {
-		t.Errorf("Expected Grafana version to be '0.0.0', got %s", result.GrafanaVersion())
-	}
-	if result.String() != "Grafana/0.0.0 (unknown; unknown)" {
-		t.Errorf("Expected correctly formed UA string, got %s", result.String())
-	}
+	require.Equal(t, "0.0.0", result.GrafanaVersion())
+	require.Equal(t, "Grafana/0.0.0 (unknown; unknown)", result.String())
 }

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -140,18 +140,12 @@ func TestAppURL(t *testing.T) {
 
 func TestUserAgentFromContext(t *testing.T) {
 	ua, err := useragent.New("10.0.0", "test", "test")
-
-	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
-	}
+	require.NoError(t, err)
 
 	ctx := WithUserAgent(context.Background(), ua)
 
 	result, err := UserAgentFromContext(ctx)
-
-	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
-	}
+	require.NoError(t, err)
 	if result.GrafanaVersion() != "10.0.0" {
 		t.Errorf("Expected Grafana version to be '10.0.0', got %s", result.GrafanaVersion())
 	}
@@ -164,10 +158,7 @@ func TestUserAgentFromContext_NoUserAgent(t *testing.T) {
 	ctx := context.Background()
 
 	result, err := UserAgentFromContext(ctx)
-
-	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
-	}
+	require.NoError(t, err)
 	if result.GrafanaVersion() != "0.0.0" {
 		t.Errorf("Expected Grafana version to be '0.0.0', got %s", result.GrafanaVersion())
 	}

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -143,9 +143,8 @@ func TestUserAgentFromContext(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := WithUserAgent(context.Background(), ua)
+	result := UserAgentFromContext(ctx)
 
-	result, err := UserAgentFromContext(ctx)
-	require.NoError(t, err)
 	require.Equal(t, "10.0.0", result.GrafanaVersion())
 	require.Equal(t, "Grafana/10.0.0 (test; test)", result.String())
 }
@@ -153,8 +152,7 @@ func TestUserAgentFromContext(t *testing.T) {
 func TestUserAgentFromContext_NoUserAgent(t *testing.T) {
 	ctx := context.Background()
 
-	result, err := UserAgentFromContext(ctx)
-	require.NoError(t, err)
+	result := UserAgentFromContext(ctx)
 	require.Equal(t, "0.0.0", result.GrafanaVersion())
 	require.Equal(t, "Grafana/0.0.0 (unknown; unknown)", result.String())
 }

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/useragent"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/featuretoggles"
 )
 
@@ -135,4 +136,42 @@ func TestAppURL(t *testing.T) {
 		_, err := cfg.AppURL()
 		require.Error(t, err)
 	})
+}
+
+func TestUserAgentFromContext(t *testing.T) {
+	ua, err := useragent.New("10.0.0", "test", "test")
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	ctx := WithUserAgent(context.Background(), ua)
+
+	result, err := UserAgentFromContext(ctx)
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if result.GrafanaVersion() != "10.0.0" {
+		t.Errorf("Expected Grafana version to be '10.0.0', got %s", result.GrafanaVersion())
+	}
+	if result.String() != "Grafana/10.0.0 (test; test)" {
+		t.Errorf("Expected correctly formed UA string, got %s", result.String())
+	}
+}
+
+func TestUserAgentFromContext_NoUserAgent(t *testing.T) {
+	ctx := context.Background()
+
+	result, err := UserAgentFromContext(ctx)
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if result.GrafanaVersion() != "0.0.0" {
+		t.Errorf("Expected Grafana version to be '0.0.0', got %s", result.GrafanaVersion())
+	}
+	if result.String() != "Grafana/0.0.0 (unknown; unknown)" {
+		t.Errorf("Expected correctly formed UA string, got %s", result.String())
+	}
 }

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -46,10 +46,11 @@ func withHeaderMiddleware(ctx context.Context, headers http.Header) context.Cont
 func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataRequest) (*pluginv2.QueryDataResponse, error) {
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(req.PluginContext.GrafanaConfig))
-	parsedRequest := FromProto().QueryDataRequest(req)
-	ctx = withHeaderMiddleware(ctx, parsedRequest.GetHTTPHeaders())
-	ctx = withContextualLogAttributes(ctx, parsedRequest.PluginContext, endpointQueryData)
-	resp, err := a.queryDataHandler.QueryData(ctx, parsedRequest)
+	parsedReq := FromProto().QueryDataRequest(req)
+	ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
+	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointQueryData)
+	ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)
+	resp, err := a.queryDataHandler.QueryData(ctx, parsedReq)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/diagnostics_adapter.go
+++ b/backend/diagnostics_adapter.go
@@ -51,6 +51,7 @@ func (a *diagnosticsSDKAdapter) CheckHealth(ctx context.Context, protoReq *plugi
 		parsedReq := FromProto().CheckHealthRequest(protoReq)
 		ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
 		ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointCheckHealth)
+		ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)
 		res, err := a.checkHealthHandler.CheckHealth(ctx, parsedReq)
 		if err != nil {
 			return nil, err

--- a/backend/resource_adapter.go
+++ b/backend/resource_adapter.go
@@ -40,5 +40,6 @@ func (a *resourceSDKAdapter) CallResource(protoReq *pluginv2.CallResourceRequest
 	parsedReq := FromProto().CallResourceRequest(protoReq)
 	ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointCallResource)
+	ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)
 	return a.callResourceHandler.CallResource(ctx, parsedReq, fn)
 }

--- a/backend/stream_adapter.go
+++ b/backend/stream_adapter.go
@@ -67,6 +67,7 @@ func (a *streamSDKAdapter) RunStream(protoReq *pluginv2.RunStreamRequest, protoS
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().RunStreamRequest(protoReq)
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointRunStream)
+	ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)
 	sender := NewStreamSender(&runStreamServer{protoSrv: protoSrv})
 	return a.streamHandler.RunStream(ctx, parsedReq, sender)
 }

--- a/backend/useragent/user_agent.go
+++ b/backend/useragent/user_agent.go
@@ -45,6 +45,11 @@ func Parse(s string) (*UserAgent, error) {
 	}, nil
 }
 
+// Empty creates a new UserAgent with default values.
+func Empty() (*UserAgent, error) {
+	return New("0.0.0", "unknown", "unknown")
+}
+
 func (ua *UserAgent) GrafanaVersion() string {
 	return ua.grafanaVersion
 }

--- a/backend/useragent/user_agent.go
+++ b/backend/useragent/user_agent.go
@@ -46,8 +46,12 @@ func Parse(s string) (*UserAgent, error) {
 }
 
 // Empty creates a new UserAgent with default values.
-func Empty() (*UserAgent, error) {
-	return New("0.0.0", "unknown", "unknown")
+func Empty() *UserAgent {
+	return &UserAgent{
+		grafanaVersion: "0.0.0",
+		os:             "unknown",
+		arch:           "unknown",
+	}
 }
 
 func (ua *UserAgent) GrafanaVersion() string {

--- a/backend/useragent/user_agent_test.go
+++ b/backend/useragent/user_agent_test.go
@@ -113,3 +113,14 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+func TestEmpty(t *testing.T) {
+	expected := &UserAgent{
+		grafanaVersion: "0.0.0",
+		os:             "unknown",
+		arch:           "unknown",
+	}
+	res, err := Empty()
+	require.NoError(t, err)
+	require.Equal(t, expected, res)
+}

--- a/backend/useragent/user_agent_test.go
+++ b/backend/useragent/user_agent_test.go
@@ -120,7 +120,6 @@ func TestEmpty(t *testing.T) {
 		os:             "unknown",
 		arch:           "unknown",
 	}
-	res, err := Empty()
-	require.NoError(t, err)
+	res := Empty()
 	require.Equal(t, expected, res)
 }


### PR DESCRIPTION
This PR adds the ability to store and retrieve the Grafana user agent in the `context.Context` struct passed to a datasource. This is needed in the Clickhouse datasource in order to replace the current method of getting the Grafana version via environment variable.