### PR TITLE
Revert upgrade of getkin/kin-openapi to v0.122.0

### DIFF
--- a/experimental/e2e/storage/openapi.go
+++ b/experimental/e2e/storage/openapi.go
@@ -139,7 +139,7 @@ func (o *OpenAPI) getResponse(op *openapi3.Operation) (int, *openapi3.Response) 
 	fallbackStatus := http.StatusNotFound
 	fallbackRef := defaultRef
 
-	for k, r := range op.Responses.Map() {
+	for k, r := range op.Responses {
 		s, err := strconv.Atoi(k)
 		if err != nil {
 			continue

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/grafana/grafana-plugin-sdk-go
 
 go 1.21
 
+// The v0.120.0 is needed for now to be compatible with grafana/thema.
+replace github.com/getkin/kin-openapi => github.com/getkin/kin-openapi v0.120.0
+
 require (
 	github.com/cheekybits/genny v1.0.0
 	github.com/golang/protobuf v1.5.3 // indirect
@@ -30,7 +33,7 @@ require (
 	github.com/apache/arrow/go/v13 v13.0.0
 	github.com/chromedp/cdproto v0.0.0-20220208224320-6efb837e6bc2
 	github.com/elazarl/goproxy v0.0.0-20230731152917-f99041a5c027
-	github.com/getkin/kin-openapi v0.122.0
+	github.com/getkin/kin-openapi v0.120.0
 	github.com/go-jose/go-jose/v3 v3.0.1
 	github.com/google/uuid v1.4.0
 	github.com/unknwon/bra v0.0.0-20200517080246-1e3013ecaff8

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/getkin/kin-openapi v0.122.0 h1:WB9Jbl0Hp/T79/JF9xlSW5Kl9uYdk/AWD0yAd9HOM10=
-github.com/getkin/kin-openapi v0.122.0/go.mod h1:PCWw/lfBrJY4HcdqE3jj+QFkaFK8ABoqo7PvqVhXXqw=
+github.com/getkin/kin-openapi v0.120.0 h1:MqJcNJFrMDFNc07iwE8iFC5eT2k/NPUFDIpNeiZv8Jg=
+github.com/getkin/kin-openapi v0.120.0/go.mod h1:PCWw/lfBrJY4HcdqE3jj+QFkaFK8ABoqo7PvqVhXXqw=
 github.com/go-jose/go-jose/v3 v3.0.1 h1:pWmKFVtt+Jl0vBZTIpz/eAKwsm6LkIxDVVbFHKkchhA=
 github.com/go-jose/go-jose/v3 v3.0.1/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=


### PR DESCRIPTION
Too many issues with https://github.com/grafana/grafana/pull/79021 and grafana/thema so reverting this for now.