### PR TITLE
secure socks proxy: add option to disable tls in the socks proxy dialer

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -125,7 +125,11 @@ func (s *DataSourceInstanceSettings) HTTPClientOptions(ctx context.Context) (htt
 	setCustomOptionsFromHTTPSettings(&opts, httpSettings)
 
 	cfg := GrafanaConfigFromContext(ctx)
-	opts.ProxyOptions, err = s.ProxyOptions(cfg.proxy().clientCfg)
+	proxy, err := cfg.proxy()
+	if err != nil {
+		return opts, err
+	}
+	opts.ProxyOptions, err = s.ProxyOptions(proxy.clientCfg)
 	if err != nil {
 		return opts, err
 	}

--- a/backend/config.go
+++ b/backend/config.go
@@ -103,13 +103,15 @@ type Proxy struct {
 
 func (c *GrafanaCfg) proxy() Proxy {
 	if v, exists := c.config[proxy.PluginSecureSocksProxyEnabled]; exists && v == strconv.FormatBool(true) {
+		allowInsecure, _ := strconv.ParseBool(c.Get(proxy.PluginSecureSocksProxyAllowInsecure))
 		return Proxy{
 			clientCfg: &proxy.ClientCfg{
-				ClientCert:   c.Get(proxy.PluginSecureSocksProxyClientCert),
-				ClientKey:    c.Get(proxy.PluginSecureSocksProxyClientKey),
-				RootCA:       c.Get(proxy.PluginSecureSocksProxyRootCACert),
-				ProxyAddress: c.Get(proxy.PluginSecureSocksProxyProxyAddress),
-				ServerName:   c.Get(proxy.PluginSecureSocksProxyServerName),
+				ClientCert:    c.Get(proxy.PluginSecureSocksProxyClientCert),
+				ClientKey:     c.Get(proxy.PluginSecureSocksProxyClientKey),
+				RootCA:        c.Get(proxy.PluginSecureSocksProxyRootCACert),
+				ProxyAddress:  c.Get(proxy.PluginSecureSocksProxyProxyAddress),
+				ServerName:    c.Get(proxy.PluginSecureSocksProxyServerName),
+				AllowInsecure: allowInsecure,
 			},
 		}
 	}

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
@@ -140,7 +141,10 @@ func TestConfig(t *testing.T) {
 			cfg := GrafanaConfigFromContext(ctx)
 
 			require.Equal(t, tc.expectedFeatureToggles, cfg.FeatureToggles())
-			require.Equal(t, tc.expectedProxy, cfg.proxy())
+			proxy, err := cfg.proxy()
+			assert.NoError(t, err)
+
+			require.Equal(t, tc.expectedProxy, proxy)
 		}
 	})
 }

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -109,6 +109,30 @@ func TestConfig(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "feature toggles disabled and insecure proxy enabled",
+				cfg: NewGrafanaCfg(map[string]string{
+					featuretoggles.EnabledFeatures:            "",
+					proxy.PluginSecureSocksProxyEnabled:       "true",
+					proxy.PluginSecureSocksProxyProxyAddress:  "localhost:1234",
+					proxy.PluginSecureSocksProxyServerName:    "localhost",
+					proxy.PluginSecureSocksProxyClientKey:     "clientKey",
+					proxy.PluginSecureSocksProxyClientCert:    "clientCert",
+					proxy.PluginSecureSocksProxyRootCACert:    "rootCACert",
+					proxy.PluginSecureSocksProxyAllowInsecure: "true",
+				}),
+				expectedFeatureToggles: FeatureToggles{},
+				expectedProxy: Proxy{
+					clientCfg: &proxy.ClientCfg{
+						ClientCert:    "clientCert",
+						ClientKey:     "clientKey",
+						RootCA:        "rootCACert",
+						ProxyAddress:  "localhost:1234",
+						ServerName:    "localhost",
+						AllowInsecure: true,
+					},
+				},
+			},
 		}
 
 		for _, tc := range tcs {

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -112,7 +112,7 @@ func (p *cfgProxyWrapper) ConfigureSecureSocksHTTPProxy(transport *http.Transpor
 	}
 
 	transport.DialContext = contextDialer.DialContext
-	return nil // No need to include the TLS config since the proxy won't use it.
+	return nil
 }
 
 // NewSecureSocksProxyContextDialer returns a proxy context dialer that can be used to allow datasource connections to go through a secure socks proxy

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -204,6 +204,26 @@ func getConfigFromEnv() *ClientCfg {
 		}
 	}
 
+	proxyAddress := ""
+	if value, ok := os.LookupEnv(PluginSecureSocksProxyProxyAddress); ok {
+		proxyAddress = value
+	} else {
+		return nil
+	}
+
+	allowInsecure := false
+	if value, ok := os.LookupEnv(PluginSecureSocksProxyAllowInsecure); ok {
+		allowInsecure, _ = strconv.ParseBool(value)
+	}
+
+	// We only need to fill these fields on insecure mode.
+	if allowInsecure {
+		return &ClientCfg{
+			ProxyAddress:  proxyAddress,
+			AllowInsecure: allowInsecure,
+		}
+	}
+
 	clientCert := ""
 	if value, ok := os.LookupEnv(PluginSecureSocksProxyClientCert); ok {
 		clientCert = value
@@ -225,23 +245,11 @@ func getConfigFromEnv() *ClientCfg {
 		return nil
 	}
 
-	proxyAddress := ""
-	if value, ok := os.LookupEnv(PluginSecureSocksProxyProxyAddress); ok {
-		proxyAddress = value
-	} else {
-		return nil
-	}
-
 	serverName := ""
 	if value, ok := os.LookupEnv(PluginSecureSocksProxyServerName); ok {
 		serverName = value
 	} else {
 		return nil
-	}
-
-	allowInsecure := false
-	if value, ok := os.LookupEnv(PluginSecureSocksProxyAllowInsecure); ok {
-		allowInsecure, _ = strconv.ParseBool(value)
 	}
 
 	return &ClientCfg{
@@ -250,7 +258,7 @@ func getConfigFromEnv() *ClientCfg {
 		RootCA:        rootCA,
 		ProxyAddress:  proxyAddress,
 		ServerName:    serverName,
-		AllowInsecure: allowInsecure,
+		AllowInsecure: false,
 	}
 }
 

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -108,21 +108,117 @@ func TestSecureSocksProxyEnabled(t *testing.T) {
 	})
 }
 
+func TestGetConfigFromEnv(t *testing.T) {
+	cases := []struct {
+		description string
+		envVars     map[string]string
+		expected    *ClientCfg
+	}{
+		{
+			description: "socks proxy not enabled, should return nil",
+			envVars: map[string]string{
+				PluginSecureSocksProxyEnabled:      "false",
+				PluginSecureSocksProxyProxyAddress: "localhost",
+				PluginSecureSocksProxyClientCert:   "cert",
+				PluginSecureSocksProxyClientKey:    "key",
+				PluginSecureSocksProxyRootCACert:   "root_ca",
+				PluginSecureSocksProxyServerName:   "server_name",
+			},
+			expected: nil,
+		},
+		{
+			description: "allowInsecure=true, should return config without tls fields filled",
+			envVars: map[string]string{
+				PluginSecureSocksProxyEnabled:       "true",
+				PluginSecureSocksProxyProxyAddress:  "localhost",
+				PluginSecureSocksProxyAllowInsecure: "true",
+			},
+			expected: &ClientCfg{
+				ProxyAddress:  "localhost",
+				AllowInsecure: true,
+			},
+		},
+		{
+			description: "allowInsecure=false, client cert is required, should return nil",
+			envVars: map[string]string{
+				PluginSecureSocksProxyEnabled:       "true",
+				PluginSecureSocksProxyProxyAddress:  "localhost",
+				PluginSecureSocksProxyAllowInsecure: "false",
+			},
+			expected: nil,
+		},
+		{
+			description: "allowInsecure=false, client key is required, should return nil",
+			envVars: map[string]string{
+				PluginSecureSocksProxyEnabled:       "true",
+				PluginSecureSocksProxyProxyAddress:  "localhost",
+				PluginSecureSocksProxyAllowInsecure: "false",
+				PluginSecureSocksProxyClientCert:    "cert",
+			},
+			expected: nil,
+		},
+		{
+			description: "allowInsecure=false, root ca is required, should return nil",
+			envVars: map[string]string{
+				PluginSecureSocksProxyEnabled:       "true",
+				PluginSecureSocksProxyProxyAddress:  "localhost",
+				PluginSecureSocksProxyAllowInsecure: "false",
+				PluginSecureSocksProxyClientCert:    "cert",
+				PluginSecureSocksProxyClientKey:     "key",
+			},
+			expected: nil,
+		},
+		{
+			description: "allowInsecure=false, server name is required, should return nil",
+			envVars: map[string]string{
+				PluginSecureSocksProxyEnabled:       "true",
+				PluginSecureSocksProxyProxyAddress:  "localhost",
+				PluginSecureSocksProxyAllowInsecure: "false",
+				PluginSecureSocksProxyClientCert:    "cert",
+				PluginSecureSocksProxyClientKey:     "key",
+				PluginSecureSocksProxyRootCACert:    "root",
+			},
+			expected: nil,
+		},
+		{
+			description: "allowInsecure=false, should return config with tls fields filled",
+			envVars: map[string]string{
+				PluginSecureSocksProxyEnabled:       "true",
+				PluginSecureSocksProxyProxyAddress:  "localhost",
+				PluginSecureSocksProxyAllowInsecure: "false",
+				PluginSecureSocksProxyClientCert:    "cert",
+				PluginSecureSocksProxyClientKey:     "key",
+				PluginSecureSocksProxyRootCACert:    "root",
+				PluginSecureSocksProxyServerName:    "name",
+			},
+			expected: &ClientCfg{
+				ProxyAddress:  "localhost",
+				ClientCert:    "cert",
+				ClientKey:     "key",
+				RootCA:        "root",
+				ServerName:    "name",
+				AllowInsecure: false,
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.description, func(t *testing.T) {
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+			assert.Equal(t, tt.expected, getConfigFromEnv())
+		})
+	}
+}
+
 func TestSecureSocksProxyConfig(t *testing.T) {
 	expected := ClientCfg{
-		ClientCert:    "client.crt",
-		ClientKey:     "client.key",
-		RootCA:        "ca.crt",
 		ProxyAddress:  "localhost:8080",
-		ServerName:    "testServer",
 		AllowInsecure: true,
 	}
 	t.Setenv(PluginSecureSocksProxyEnabled, "true")
-	t.Setenv(PluginSecureSocksProxyClientCert, expected.ClientCert)
-	t.Setenv(PluginSecureSocksProxyClientKey, expected.ClientKey)
-	t.Setenv(PluginSecureSocksProxyRootCACert, expected.RootCA)
 	t.Setenv(PluginSecureSocksProxyProxyAddress, expected.ProxyAddress)
-	t.Setenv(PluginSecureSocksProxyServerName, expected.ServerName)
 	t.Setenv(PluginSecureSocksProxyAllowInsecure, fmt.Sprint(expected.AllowInsecure))
 
 	t.Run("test env variables", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Description taken from https://github.com/grafana/hosted-grafana/issues/4935:

> Sometimes there's a use case for testing grafana's SOCKs backend locally, and this would be significantly easier if we could disable the TLS requirement for the socks backend.

**Which issue(s) this PR fixes**:
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/hosted-grafana/issues/4935

