### PR TITLE
Add Azure settings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/flatbuffers v23.1.21+incompatible // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/grafana/grafana-azure-sdk-go v1.10.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.2 // indirect
 	github.com/invopop/yaml v0.2.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/grafana/grafana-azure-sdk-go v1.10.0 h1:1bWIlCNldl5nB9GJmYVdW4DYSkRdso0sw94NvoUaNAA=
+github.com/grafana/grafana-azure-sdk-go v1.10.0/go.mod h1:R0F/1s/tICTs+ARF24Pnf1YEYXed58S8STemifecy8g=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=


### PR DESCRIPTION
Add a method to allow retrieving Azure settings from the Grafana config provided as a part of the plugin context in plugin requests.

An example of how to retrieve these settings:

```go
grafanaConfig := backend.GrafanaConfigFromContext(ctx)
azureSettings := grafanaConfig.Azure()
```

Where previously in Azure plugins this would've been retrieved using `azureSettings, err := azsettings.ReadFromEnv()`.

Depends on grafana/grafana#79342