### PR TITLE
Chore: Use jsoniter from wrapper

### DIFF
--- a/backend/data.go
+++ b/backend/data.go
@@ -7,8 +7,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	jsoniter "github.com/json-iterator/go"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
 // QueryDataHandler handles data queries.
@@ -116,7 +118,7 @@ type QueryDataResponse struct {
 
 // MarshalJSON writes the results as json
 func (r QueryDataResponse) MarshalJSON() ([]byte, error) {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
@@ -183,7 +185,7 @@ func ErrDataResponseWithSource(status Status, src ErrorSource, message string) D
 
 // MarshalJSON writes the results as json
 func (r DataResponse) MarshalJSON() ([]byte, error) {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 

--- a/backend/data.go
+++ b/backend/data.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
-
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
@@ -128,9 +126,9 @@ func (r QueryDataResponse) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON will read JSON into a QueryDataResponse
 func (r *QueryDataResponse) UnmarshalJSON(b []byte) error {
-	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, b)
+	iter, _ := sdkjsoniter.ParseBytes(sdkjsoniter.ConfigDefault, b)
 	readQueryDataResultsJSON(r, iter)
-	return iter.Error
+	return iter.ReadError()
 }
 
 // NewQueryDataResponse returns a QueryDataResponse with the Responses property initialized.

--- a/backend/data.go
+++ b/backend/data.go
@@ -126,7 +126,10 @@ func (r QueryDataResponse) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON will read JSON into a QueryDataResponse
 func (r *QueryDataResponse) UnmarshalJSON(b []byte) error {
-	iter, _ := sdkjsoniter.ParseBytes(sdkjsoniter.ConfigDefault, b)
+	iter, err := sdkjsoniter.ParseBytes(sdkjsoniter.ConfigDefault, b)
+	if err != nil {
+		return err
+	}
 	readQueryDataResultsJSON(r, iter)
 	return iter.ReadError()
 }

--- a/backend/json.go
+++ b/backend/json.go
@@ -5,8 +5,10 @@ import (
 	"sort"
 	"unsafe"
 
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	jsoniter "github.com/json-iterator/go"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
 func init() { //nolint:gochecknoinits
@@ -21,7 +23,7 @@ func (codec *dataResponseCodec) IsEmpty(ptr unsafe.Pointer) bool {
 	return dr.Error == nil && dr.Frames == nil
 }
 
-func (codec *dataResponseCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+func (codec *dataResponseCodec) Encode(ptr unsafe.Pointer, stream *sdkjsoniter.Stream) {
 	dr := (*DataResponse)(ptr)
 	writeDataResponseJSON(dr, stream)
 }
@@ -33,7 +35,7 @@ func (codec *queryDataResponseCodec) IsEmpty(ptr unsafe.Pointer) bool {
 	return qdr.Responses == nil
 }
 
-func (codec *queryDataResponseCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+func (codec *queryDataResponseCodec) Encode(ptr unsafe.Pointer, stream *sdkjsoniter.Stream) {
 	qdr := (*QueryDataResponse)(ptr)
 	writeQueryDataResponseJSON(qdr, stream)
 }
@@ -44,11 +46,11 @@ func (codec *queryDataResponseCodec) Decode(ptr unsafe.Pointer, iter *jsoniter.I
 	*((*QueryDataResponse)(ptr)) = qdr
 }
 
-//-----------------------------------------------------------------
+// -----------------------------------------------------------------
 // Private stream readers
-//-----------------------------------------------------------------
+// -----------------------------------------------------------------
 
-func writeDataResponseJSON(dr *DataResponse, stream *jsoniter.Stream) {
+func writeDataResponseJSON(dr *DataResponse, stream *sdkjsoniter.Stream) {
 	stream.WriteObjectStart()
 	started := false
 
@@ -102,7 +104,7 @@ func writeDataResponseJSON(dr *DataResponse, stream *jsoniter.Stream) {
 	stream.WriteObjectEnd()
 }
 
-func writeQueryDataResponseJSON(qdr *QueryDataResponse, stream *jsoniter.Stream) {
+func writeQueryDataResponseJSON(qdr *QueryDataResponse, stream *sdkjsoniter.Stream) {
 	stream.WriteObjectStart()
 	stream.WriteObjectField("results")
 	stream.WriteObjectStart()
@@ -131,9 +133,9 @@ func writeQueryDataResponseJSON(qdr *QueryDataResponse, stream *jsoniter.Stream)
 	stream.WriteObjectEnd()
 }
 
-//-----------------------------------------------------------------
+// -----------------------------------------------------------------
 // Private stream readers
-//-----------------------------------------------------------------
+// -----------------------------------------------------------------
 
 func readQueryDataResultsJSON(qdr *QueryDataResponse, iter *jsoniter.Iterator) {
 	found := false

--- a/backend/json.go
+++ b/backend/json.go
@@ -12,8 +12,8 @@ import (
 )
 
 func init() { //nolint:gochecknoinits
-	jsoniter.RegisterTypeEncoder("backend.DataResponse", &dataResponseCodec{})
-	jsoniter.RegisterTypeEncoder("backend.QueryDataResponse", &queryDataResponseCodec{})
+	sdkjsoniter.RegisterTypeEncoder("backend.DataResponse", &dataResponseCodec{})
+	sdkjsoniter.RegisterTypeEncoder("backend.QueryDataResponse", &queryDataResponseCodec{})
 }
 
 type dataResponseCodec struct{}

--- a/backend/json.go
+++ b/backend/json.go
@@ -144,7 +144,7 @@ func readQueryDataResultsJSON(qdr *QueryDataResponse, iter *sdkjsoniter.Iterator
 		switch l1Field {
 		case "results":
 			if found {
-				iter.ReportError("read results", "already found results")
+				_ = iter.ReportError("read results", "already found results")
 				return
 			}
 			found = true
@@ -158,7 +158,7 @@ func readQueryDataResultsJSON(qdr *QueryDataResponse, iter *sdkjsoniter.Iterator
 			}
 
 		default:
-			iter.ReportError("bind l1", "unexpected field: "+l1Field)
+			_ = iter.ReportError("bind l1", "unexpected field: "+l1Field)
 			return
 		}
 	}
@@ -181,15 +181,15 @@ func readDataResponseJSON(rsp *DataResponse, iter *sdkjsoniter.Iterator) {
 		case "frames":
 			for iter.CanReadArray() {
 				frame := &data.Frame{}
-				iter.ReadVal(frame)
-				if iter.ReadError() != nil {
+				err := iter.ReadVal(frame)
+				if err != nil {
 					return
 				}
 				rsp.Frames = append(rsp.Frames, frame)
 			}
 
 		default:
-			iter.ReportError("bind l2", "unexpected field: "+l2Field)
+			_ = iter.ReportError("bind l2", "unexpected field: "+l2Field)
 			return
 		}
 	}

--- a/data/frame.go
+++ b/data/frame.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/olekukonko/tablewriter"
 
 	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
@@ -51,7 +50,7 @@ type Frame struct {
 
 // UnmarshalJSON allows unmarshalling Frame from JSON.
 func (f *Frame) UnmarshalJSON(b []byte) error {
-	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, b)
+	iter, _ := sdkjsoniter.ParseBytes(sdkjsoniter.ConfigDefault, b)
 	return readDataFrameJSON(f, iter)
 }
 
@@ -91,7 +90,7 @@ func (frames *Frames) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON allows unmarshalling Frame from JSON.
 func (frames *Frames) UnmarshalJSON(b []byte) error {
-	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, b)
+	iter, _ := sdkjsoniter.ParseBytes(sdkjsoniter.ConfigDefault, b)
 	return readDataFramesJSON(frames, iter)
 }
 

--- a/data/frame.go
+++ b/data/frame.go
@@ -21,6 +21,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/olekukonko/tablewriter"
+
+	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
 // Frame is a columnar data structure where each column is a Field.
@@ -55,7 +57,7 @@ func (f *Frame) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON marshals Frame to JSON.
 func (f *Frame) MarshalJSON() ([]byte, error) {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
@@ -75,7 +77,7 @@ func (f *Frame) MarshalJSON() ([]byte, error) {
 type Frames []*Frame
 
 func (frames *Frames) MarshalJSON() ([]byte, error) {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 

--- a/data/frame_json.gen.go
+++ b/data/frame_json.gen.go
@@ -52,49 +52,49 @@ func writeArrowDataUint8(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnti
 	return entities
 }
 
-func readUint8VectorJSON(iter *jsoniter.Iterator, size int) (*uint8Vector, error) {
+func readUint8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint8Vector, error) {
 	arr := newUint8Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readUint8VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadUint8()
+			v, _ := iter.ReadUint8()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableUint8VectorJSON(iter *jsoniter.Iterator, size int) (*nullableUint8Vector, error) {
+func readNullableUint8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableUint8Vector, error) {
 	arr := newNullableUint8Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableUint8VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadUint8()
+			v, _ := iter.ReadUint8()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableUint8VectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -119,49 +119,49 @@ func writeArrowDataUint16(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnt
 	return entities
 }
 
-func readUint16VectorJSON(iter *jsoniter.Iterator, size int) (*uint16Vector, error) {
+func readUint16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint16Vector, error) {
 	arr := newUint16Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readUint16VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadUint16()
+			v, _ := iter.ReadUint16()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableUint16VectorJSON(iter *jsoniter.Iterator, size int) (*nullableUint16Vector, error) {
+func readNullableUint16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableUint16Vector, error) {
 	arr := newNullableUint16Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableUint16VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadUint16()
+			v, _ := iter.ReadUint16()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableUint16VectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -186,49 +186,49 @@ func writeArrowDataUint32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnt
 	return entities
 }
 
-func readUint32VectorJSON(iter *jsoniter.Iterator, size int) (*uint32Vector, error) {
+func readUint32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint32Vector, error) {
 	arr := newUint32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readUint32VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadUint32()
+			v, _ := iter.ReadUint32()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableUint32VectorJSON(iter *jsoniter.Iterator, size int) (*nullableUint32Vector, error) {
+func readNullableUint32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableUint32Vector, error) {
 	arr := newNullableUint32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableUint32VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadUint32()
+			v, _ := iter.ReadUint32()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableUint32VectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -253,49 +253,49 @@ func writeArrowDataUint64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnt
 	return entities
 }
 
-func readUint64VectorJSON(iter *jsoniter.Iterator, size int) (*uint64Vector, error) {
+func readUint64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint64Vector, error) {
 	arr := newUint64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readUint64VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadUint64()
+			v, _ := iter.ReadUint64()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableUint64VectorJSON(iter *jsoniter.Iterator, size int) (*nullableUint64Vector, error) {
+func readNullableUint64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableUint64Vector, error) {
 	arr := newNullableUint64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableUint64VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadUint64()
+			v, _ := iter.ReadUint64()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableUint64VectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -320,49 +320,49 @@ func writeArrowDataInt8(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntit
 	return entities
 }
 
-func readInt8VectorJSON(iter *jsoniter.Iterator, size int) (*int8Vector, error) {
+func readInt8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int8Vector, error) {
 	arr := newInt8Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readInt8VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadInt8()
+			v, _ := iter.ReadInt8()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableInt8VectorJSON(iter *jsoniter.Iterator, size int) (*nullableInt8Vector, error) {
+func readNullableInt8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableInt8Vector, error) {
 	arr := newNullableInt8Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableInt8VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadInt8()
+			v, _ := iter.ReadInt8()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableInt8VectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -387,49 +387,49 @@ func writeArrowDataInt16(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnti
 	return entities
 }
 
-func readInt16VectorJSON(iter *jsoniter.Iterator, size int) (*int16Vector, error) {
+func readInt16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int16Vector, error) {
 	arr := newInt16Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readInt16VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadInt16()
+			v, _ := iter.ReadInt16()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableInt16VectorJSON(iter *jsoniter.Iterator, size int) (*nullableInt16Vector, error) {
+func readNullableInt16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableInt16Vector, error) {
 	arr := newNullableInt16Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableInt16VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadInt16()
+			v, _ := iter.ReadInt16()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableInt16VectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -454,49 +454,49 @@ func writeArrowDataInt32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnti
 	return entities
 }
 
-func readInt32VectorJSON(iter *jsoniter.Iterator, size int) (*int32Vector, error) {
+func readInt32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int32Vector, error) {
 	arr := newInt32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readInt32VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadInt32()
+			v, _ := iter.ReadInt32()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableInt32VectorJSON(iter *jsoniter.Iterator, size int) (*nullableInt32Vector, error) {
+func readNullableInt32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableInt32Vector, error) {
 	arr := newNullableInt32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableInt32VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadInt32()
+			v, _ := iter.ReadInt32()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableInt32VectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -521,49 +521,49 @@ func writeArrowDataInt64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnti
 	return entities
 }
 
-func readInt64VectorJSON(iter *jsoniter.Iterator, size int) (*int64Vector, error) {
+func readInt64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int64Vector, error) {
 	arr := newInt64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readInt64VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadInt64()
+			v, _ := iter.ReadInt64()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableInt64VectorJSON(iter *jsoniter.Iterator, size int) (*nullableInt64Vector, error) {
+func readNullableInt64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableInt64Vector, error) {
 	arr := newNullableInt64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableInt64VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadInt64()
+			v, _ := iter.ReadInt64()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableInt64VectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -599,49 +599,49 @@ func writeArrowDataFloat32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEn
 	return entities
 }
 
-func readFloat32VectorJSON(iter *jsoniter.Iterator, size int) (*float32Vector, error) {
+func readFloat32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*float32Vector, error) {
 	arr := newFloat32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readFloat32VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadFloat32()
+			v, _ := iter.ReadFloat32()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableFloat32VectorJSON(iter *jsoniter.Iterator, size int) (*nullableFloat32Vector, error) {
+func readNullableFloat32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableFloat32Vector, error) {
 	arr := newNullableFloat32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableFloat32VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadFloat32()
+			v, _ := iter.ReadFloat32()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableFloat32VectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -677,49 +677,49 @@ func writeArrowDataFloat64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEn
 	return entities
 }
 
-func readFloat64VectorJSON(iter *jsoniter.Iterator, size int) (*float64Vector, error) {
+func readFloat64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*float64Vector, error) {
 	arr := newFloat64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readFloat64VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadFloat64()
+			v, _ := iter.ReadFloat64()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableFloat64VectorJSON(iter *jsoniter.Iterator, size int) (*nullableFloat64Vector, error) {
+func readNullableFloat64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableFloat64Vector, error) {
 	arr := newNullableFloat64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableFloat64VectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadFloat64()
+			v, _ := iter.ReadFloat64()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableFloat64VectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -744,49 +744,49 @@ func writeArrowDataString(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnt
 	return entities
 }
 
-func readStringVectorJSON(iter *jsoniter.Iterator, size int) (*stringVector, error) {
+func readStringVectorJSON(iter *sdkjsoniter.Iterator, size int) (*stringVector, error) {
 	arr := newStringVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readStringVectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadString()
+			v, _ := iter.ReadString()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableStringVectorJSON(iter *jsoniter.Iterator, size int) (*nullableStringVector, error) {
+func readNullableStringVectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableStringVector, error) {
 	arr := newNullableStringVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableStringVectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadString()
+			v, _ := iter.ReadString()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableStringVectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -811,49 +811,49 @@ func writeArrowDataBool(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntit
 	return entities
 }
 
-func readBoolVectorJSON(iter *jsoniter.Iterator, size int) (*boolVector, error) {
+func readBoolVectorJSON(iter *sdkjsoniter.Iterator, size int) (*boolVector, error) {
 	arr := newBoolVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readBoolVectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadBool()
+			v, _ := iter.ReadBool()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableBoolVectorJSON(iter *jsoniter.Iterator, size int) (*nullableBoolVector, error) {
+func readNullableBoolVectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableBoolVector, error) {
 	arr := newNullableBoolVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableBoolVectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadBool()
+			v, _ := iter.ReadBool()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableBoolVectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
@@ -878,50 +878,50 @@ func writeArrowDataEnum(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntit
 	return entities
 }
 
-func readEnumVectorJSON(iter *jsoniter.Iterator, size int) (*enumVector, error) {
+func readEnumVectorJSON(iter *sdkjsoniter.Iterator, size int) (*enumVector, error) {
 	arr := newEnumVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readEnumVectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
 
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadUint16()
+			v, _ := iter.ReadUint16()
 			arr.Set(i, EnumItemIndex(v))
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }
 
-func readNullableEnumVectorJSON(iter *jsoniter.Iterator, size int) (*nullableEnumVector, error) {
+func readNullableEnumVectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableEnumVector, error) {
 	arr := newNullableEnumVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.ReadArray() {
+		if !iter.CanReadArray() {
 			iter.ReportError("readNullableEnumVectorJSON", "expected array")
-			return nil, iter.Error
+			return nil, iter.ReadError()
 		}
-		t := iter.WhatIsNext()
+		t, _ := iter.WhatIsNext()
 		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v := iter.ReadUint16()
+			v, _ := iter.ReadUint16()
 			eII := EnumItemIndex(v)
 			arr.Set(i, &eII)
 		}
 	}
 
-	if iter.ReadArray() {
+	if iter.CanReadArray() {
 		iter.ReportError("readNullableEnumVectorJSON", "expected close array")
-		return nil, iter.Error
+		return nil, iter.ReadError()
 	}
 	return arr, nil
 }

--- a/data/frame_json.gen.go
+++ b/data/frame_json.gen.go
@@ -4,9 +4,11 @@ import (
 	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/apache/arrow/go/v13/arrow/array"
 	jsoniter "github.com/json-iterator/go"
+
+	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
-func writeArrowDataBinary(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataBinary(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -30,7 +32,7 @@ func writeArrowDataBinary(stream *jsoniter.Stream, col arrow.Array) *fieldEntity
 // The rest of this file is generated from frame_json_test.go
 // -------------------------------------------------------------
 
-func writeArrowDataUint8(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataUint8(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -97,7 +99,7 @@ func readNullableUint8VectorJSON(iter *jsoniter.Iterator, size int) (*nullableUi
 	return arr, nil
 }
 
-func writeArrowDataUint16(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataUint16(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -164,7 +166,7 @@ func readNullableUint16VectorJSON(iter *jsoniter.Iterator, size int) (*nullableU
 	return arr, nil
 }
 
-func writeArrowDataUint32(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataUint32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -231,7 +233,7 @@ func readNullableUint32VectorJSON(iter *jsoniter.Iterator, size int) (*nullableU
 	return arr, nil
 }
 
-func writeArrowDataUint64(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataUint64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -298,7 +300,7 @@ func readNullableUint64VectorJSON(iter *jsoniter.Iterator, size int) (*nullableU
 	return arr, nil
 }
 
-func writeArrowDataInt8(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataInt8(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -365,7 +367,7 @@ func readNullableInt8VectorJSON(iter *jsoniter.Iterator, size int) (*nullableInt
 	return arr, nil
 }
 
-func writeArrowDataInt16(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataInt16(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -432,7 +434,7 @@ func readNullableInt16VectorJSON(iter *jsoniter.Iterator, size int) (*nullableIn
 	return arr, nil
 }
 
-func writeArrowDataInt32(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataInt32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -499,7 +501,7 @@ func readNullableInt32VectorJSON(iter *jsoniter.Iterator, size int) (*nullableIn
 	return arr, nil
 }
 
-func writeArrowDataInt64(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataInt64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -566,7 +568,7 @@ func readNullableInt64VectorJSON(iter *jsoniter.Iterator, size int) (*nullableIn
 	return arr, nil
 }
 
-func writeArrowDataFloat32(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataFloat32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -644,7 +646,7 @@ func readNullableFloat32VectorJSON(iter *jsoniter.Iterator, size int) (*nullable
 	return arr, nil
 }
 
-func writeArrowDataFloat64(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataFloat64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -722,7 +724,7 @@ func readNullableFloat64VectorJSON(iter *jsoniter.Iterator, size int) (*nullable
 	return arr, nil
 }
 
-func writeArrowDataString(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataString(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -789,7 +791,7 @@ func readNullableStringVectorJSON(iter *jsoniter.Iterator, size int) (*nullableS
 	return arr, nil
 }
 
-func writeArrowDataBool(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataBool(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -856,7 +858,7 @@ func readNullableBoolVectorJSON(iter *jsoniter.Iterator, size int) (*nullableBoo
 	return arr, nil
 }
 
-func writeArrowDataEnum(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataEnum(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 

--- a/data/frame_json.gen.go
+++ b/data/frame_json.gen.go
@@ -3,7 +3,6 @@ package data
 import (
 	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/apache/arrow/go/v13/arrow/array"
-	jsoniter "github.com/json-iterator/go"
 
 	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
@@ -61,7 +60,7 @@ func readUint8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint8Vector, er
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadUint8()
@@ -84,7 +83,7 @@ func readNullableUint8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullabl
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadUint8()
@@ -128,7 +127,7 @@ func readUint16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint16Vector, 
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadUint16()
@@ -151,7 +150,7 @@ func readNullableUint16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullab
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadUint16()
@@ -195,7 +194,7 @@ func readUint32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint32Vector, 
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadUint32()
@@ -218,7 +217,7 @@ func readNullableUint32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullab
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadUint32()
@@ -262,7 +261,7 @@ func readUint64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint64Vector, 
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadUint64()
@@ -285,7 +284,7 @@ func readNullableUint64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullab
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadUint64()
@@ -329,7 +328,7 @@ func readInt8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int8Vector, erro
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadInt8()
@@ -352,7 +351,7 @@ func readNullableInt8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullable
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadInt8()
@@ -396,7 +395,7 @@ func readInt16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int16Vector, er
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadInt16()
@@ -419,7 +418,7 @@ func readNullableInt16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullabl
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadInt16()
@@ -463,7 +462,7 @@ func readInt32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int32Vector, er
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadInt32()
@@ -486,7 +485,7 @@ func readNullableInt32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullabl
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadInt32()
@@ -530,7 +529,7 @@ func readInt64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int64Vector, er
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadInt64()
@@ -553,7 +552,7 @@ func readNullableInt64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullabl
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadInt64()
@@ -608,7 +607,7 @@ func readFloat32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*float32Vector
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadFloat32()
@@ -631,7 +630,7 @@ func readNullableFloat32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nulla
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadFloat32()
@@ -686,7 +685,7 @@ func readFloat64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*float64Vector
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadFloat64()
@@ -709,7 +708,7 @@ func readNullableFloat64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nulla
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadFloat64()
@@ -753,7 +752,7 @@ func readStringVectorJSON(iter *sdkjsoniter.Iterator, size int) (*stringVector, 
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadString()
@@ -776,7 +775,7 @@ func readNullableStringVectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullab
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadString()
@@ -820,7 +819,7 @@ func readBoolVectorJSON(iter *sdkjsoniter.Iterator, size int) (*boolVector, erro
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadBool()
@@ -843,7 +842,7 @@ func readNullableBoolVectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullable
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadBool()
@@ -887,7 +886,7 @@ func readEnumVectorJSON(iter *sdkjsoniter.Iterator, size int) (*enumVector, erro
 		}
 
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadUint16()
@@ -910,7 +909,7 @@ func readNullableEnumVectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullable
 			return nil, iter.ReadError()
 		}
 		t, _ := iter.WhatIsNext()
-		if t == jsoniter.NilValue {
+		if t == sdkjsoniter.NilValue {
 			iter.ReadNil()
 		} else {
 			v, _ := iter.ReadUint16()

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -113,7 +113,7 @@ func (f *FrameJSONCache) SameSchema(dst *FrameJSONCache) bool {
 
 // SetData updates the data bytes with new values
 func (f *FrameJSONCache) setData(frame *Frame) error {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
@@ -131,7 +131,7 @@ func (f *FrameJSONCache) setData(frame *Frame) error {
 
 // SetSchema updates the schema bytes with new values
 func (f *FrameJSONCache) setSchema(frame *Frame) error {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
@@ -158,7 +158,7 @@ func (f *FrameJSONCache) MarshalJSON() ([]byte, error) {
 //
 // NOTE: the format should be considered experimental until grafana 8 is released.
 func FrameToJSON(frame *Frame, include FrameInclude) ([]byte, error) {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
@@ -1031,7 +1031,7 @@ func ArrowBufferToJSON(b []byte, include FrameInclude) ([]byte, error) {
 // ArrowToJSON writes a frame to JSON
 // NOTE: the format should be considered experimental until grafana 8 is released.
 func ArrowToJSON(record arrow.Record, include FrameInclude) ([]byte, error) {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -32,7 +32,7 @@ const jsonKeyData = "data"
 
 func init() { //nolint:gochecknoinits
 	sdkjsoniter.RegisterTypeEncoder("data.Frame", &dataFrameCodec{})
-	jsoniter.RegisterTypeDecoder("data.Frame", &dataFrameCodec{})
+	sdkjsoniter.RegisterTypeDecoder("data.Frame", &dataFrameCodec{})
 }
 
 type dataFrameCodec struct{}

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -31,7 +31,7 @@ const jsonKeySchema = "schema"
 const jsonKeyData = "data"
 
 func init() { //nolint:gochecknoinits
-	jsoniter.RegisterTypeEncoder("data.Frame", &dataFrameCodec{})
+	sdkjsoniter.RegisterTypeEncoder("data.Frame", &dataFrameCodec{})
 	jsoniter.RegisterTypeDecoder("data.Frame", &dataFrameCodec{})
 }
 

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -42,7 +42,7 @@ func (codec *dataFrameCodec) IsEmpty(ptr unsafe.Pointer) bool {
 	return f.Fields == nil && f.RefID == "" && f.Meta == nil
 }
 
-func (codec *dataFrameCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+func (codec *dataFrameCodec) Encode(ptr unsafe.Pointer, stream *sdkjsoniter.Stream) {
 	f := (*Frame)(ptr)
 	writeDataFrame(f, stream, true, true)
 }
@@ -781,7 +781,7 @@ func isSpecialEntity(v float64) (string, bool) {
 	}
 }
 
-func writeDataFrame(frame *Frame, stream *jsoniter.Stream, includeSchema bool, includeData bool) {
+func writeDataFrame(frame *Frame, stream *sdkjsoniter.Stream, includeSchema bool, includeData bool) {
 	stream.WriteObjectStart()
 	if includeSchema {
 		stream.WriteObjectField(jsonKeySchema)
@@ -799,7 +799,7 @@ func writeDataFrame(frame *Frame, stream *jsoniter.Stream, includeSchema bool, i
 	stream.WriteObjectEnd()
 }
 
-func writeDataFrameSchema(frame *Frame, stream *jsoniter.Stream) {
+func writeDataFrameSchema(frame *Frame, stream *sdkjsoniter.Stream) {
 	started := false
 	stream.WriteObjectStart()
 
@@ -895,7 +895,7 @@ func writeDataFrameSchema(frame *Frame, stream *jsoniter.Stream) {
 	stream.WriteObjectEnd()
 }
 
-func writeDataFrameData(frame *Frame, stream *jsoniter.Stream) {
+func writeDataFrameData(frame *Frame, stream *sdkjsoniter.Stream) {
 	rowCount, err := frame.RowLen()
 	if err != nil {
 		stream.Error = err
@@ -995,7 +995,7 @@ func writeDataFrameData(frame *Frame, stream *jsoniter.Stream) {
 	stream.WriteObjectEnd()
 }
 
-func writeDataFrames(frames *Frames, stream *jsoniter.Stream) {
+func writeDataFrames(frames *Frames, stream *sdkjsoniter.Stream) {
 	if frames == nil {
 		return
 	}
@@ -1061,7 +1061,7 @@ func ArrowToJSON(record arrow.Record, include FrameInclude) ([]byte, error) {
 	return append([]byte(nil), stream.Buffer()...), nil
 }
 
-func writeArrowSchema(stream *jsoniter.Stream, record arrow.Record) {
+func writeArrowSchema(stream *sdkjsoniter.Stream, record arrow.Record) {
 	started := false
 	metaData := record.Schema().Metadata()
 
@@ -1156,7 +1156,7 @@ func writeArrowSchema(stream *jsoniter.Stream, record arrow.Record) {
 	stream.WriteObjectEnd()
 }
 
-func writeArrowData(stream *jsoniter.Stream, record arrow.Record) error {
+func writeArrowData(stream *sdkjsoniter.Stream, record arrow.Record) error {
 	fieldCount := len(record.Schema().Fields())
 
 	stream.WriteObjectStart()
@@ -1237,7 +1237,7 @@ func writeArrowData(stream *jsoniter.Stream, record arrow.Record) error {
 }
 
 // Custom timestamp extraction... assumes nanoseconds for everything now
-func writeArrowDataTIMESTAMP(stream *jsoniter.Stream, col arrow.Array) []int64 {
+func writeArrowDataTIMESTAMP(stream *sdkjsoniter.Stream, col arrow.Array) []int64 {
 	count := col.Len()
 	var hasNSTime bool
 	nsTime := make([]int64, count)

--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -350,7 +350,7 @@ func TestGenerateGenericArrowCode(t *testing.T) {
 	}
 
 	code := `
-func writeArrowData{{.Type}}(stream *jsoniter.Stream, col array.Interface) *fieldEntityLookup {
+func writeArrowData{{.Type}}(stream *sdkjsoniter.Stream, col array.Interface) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 

--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -12,7 +12,6 @@ import (
 	"text/template"
 	"time"
 
-	jsoniter "github.com/json-iterator/go"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
 // TestGoldenFrameJSON makes sure that the JSON produced from arrow and dataframes match
@@ -247,7 +247,7 @@ func BenchmarkFrameMarshalJSONIter(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := jsoniter.Marshal(f)
+		_, err := sdkjsoniter.Marshal(f)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/data/labels.go
+++ b/data/labels.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"unsafe"
 
-	jsoniter "github.com/json-iterator/go"
-
 	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
@@ -19,7 +17,7 @@ import (
 type Labels map[string]string
 
 func init() { //nolint:gochecknoinits
-	jsoniter.RegisterTypeEncoder("data.Labels", &dataLabelsCodec{})
+	sdkjsoniter.RegisterTypeEncoder("data.Labels", &dataLabelsCodec{})
 }
 
 // Equals returns true if the argument has the same k=v pairs as the receiver.

--- a/data/labels.go
+++ b/data/labels.go
@@ -9,6 +9,8 @@ import (
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
+
+	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
 // Labels are used to add metadata to an object.  The JSON will always be sorted keys
@@ -161,7 +163,7 @@ func (l Labels) MarshalJSON() ([]byte, error) {
 	return append([]byte(nil), stream.Buffer()...), nil
 }
 
-func writeLabelsJSON(l Labels, stream *jsoniter.Stream) {
+func writeLabelsJSON(l Labels, stream *sdkjsoniter.Stream) {
 	keys := make([]string, len(l))
 	i := 0
 	for k := range l {
@@ -188,7 +190,7 @@ func (codec *dataLabelsCodec) IsEmpty(ptr unsafe.Pointer) bool {
 	return f.Fields == nil && f.RefID == "" && f.Meta == nil
 }
 
-func (codec *dataLabelsCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+func (codec *dataLabelsCodec) Encode(ptr unsafe.Pointer, stream *sdkjsoniter.Stream) {
 	v := (*Labels)(ptr)
 	if v == nil {
 		stream.WriteNil()

--- a/data/labels.go
+++ b/data/labels.go
@@ -151,7 +151,7 @@ func LabelsFromString(s string) (Labels, error) {
 
 // MarshalJSON marshals Labels to JSON.
 func (l Labels) MarshalJSON() ([]byte, error) {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 

--- a/data/labels_test.go
+++ b/data/labels_test.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
 // Equals returns true if the argument has the same k=v pairs as the receiver.
@@ -38,8 +38,8 @@ func TestJSONReadWrite(t *testing.T) {
 	a0 := data.Labels{"a": "AAA", "b": "BBB"}
 	a1 := data.Labels{"b": "BBB", "a": "AAA"}
 
-	b0, _ := jsoniter.Marshal(a0)
-	b1, _ := jsoniter.Marshal(a1)
+	b0, _ := sdkjsoniter.Marshal(a0)
+	b1, _ := sdkjsoniter.Marshal(a1)
 
 	require.Equal(t, b0, b1)
 	require.Equal(t, `{"a":"AAA","b":"BBB"}`, string(b0))

--- a/data/utils/jsoniter/jsoniter.go
+++ b/data/utils/jsoniter/jsoniter.go
@@ -59,6 +59,11 @@ func (iter *Iterator) ReadArray() (bool, error) {
 	return iter.i.ReadArray(), iter.i.Error
 }
 
+func (iter *Iterator) CanReadArray() bool {
+	ok, err := iter.ReadArray()
+	return ok && err == nil
+}
+
 func (iter *Iterator) ReadObject() (string, error) {
 	return iter.i.ReadObject(), iter.i.Error
 }

--- a/data/utils/jsoniter/jsoniter.go
+++ b/data/utils/jsoniter/jsoniter.go
@@ -28,6 +28,7 @@ var (
 
 type Stream = j.Stream
 type ValEncoder = j.ValEncoder
+type ValDecoder = j.ValDecoder
 
 type Iterator struct {
 	// named property instead of embedded so there is no
@@ -177,4 +178,8 @@ func ParseString(cfg j.API, input string) (*Iterator, error) {
 
 func RegisterTypeEncoder(typ string, encoder ValEncoder) {
 	j.RegisterTypeEncoder(typ, encoder)
+}
+
+func RegisterTypeDecoder(typ string, decoder ValDecoder) {
+	j.RegisterTypeDecoder(typ, decoder)
 }

--- a/data/utils/jsoniter/jsoniter.go
+++ b/data/utils/jsoniter/jsoniter.go
@@ -22,8 +22,12 @@ const (
 )
 
 var (
-	ConfigDefault = j.ConfigDefault
+	ConfigDefault                       = j.ConfigDefault
+	ConfigCompatibleWithStandardLibrary = j.ConfigCompatibleWithStandardLibrary
 )
+
+type Stream = j.Stream
+type ValEncoder = j.ValEncoder
 
 type Iterator struct {
 	// named property instead of embedded so there is no
@@ -33,6 +37,14 @@ type Iterator struct {
 
 func NewIterator(i *j.Iterator) *Iterator {
 	return &Iterator{i}
+}
+
+func (iter *Iterator) ReadError() error {
+	return iter.i.Error
+}
+
+func (iter *Iterator) SetError(err error) {
+	iter.i.Error = err
 }
 
 func (iter *Iterator) Read() (interface{}, error) {
@@ -64,17 +76,53 @@ func (iter *Iterator) Skip() error {
 	return iter.i.Error
 }
 
+func (iter *Iterator) SkipAndReturnBytes() ([]byte, error) {
+	return iter.i.SkipAndReturnBytes(), iter.i.Error
+}
+
 func (iter *Iterator) ReadVal(obj interface{}) error {
 	iter.i.ReadVal(obj)
 	return iter.i.Error
+}
+
+func (iter *Iterator) ReadFloat32() (float32, error) {
+	return iter.i.ReadFloat32(), iter.i.Error
 }
 
 func (iter *Iterator) ReadFloat64() (float64, error) {
 	return iter.i.ReadFloat64(), iter.i.Error
 }
 
+func (iter *Iterator) ReadInt() (int, error) {
+	return iter.i.ReadInt(), iter.i.Error
+}
+
 func (iter *Iterator) ReadInt8() (int8, error) {
 	return iter.i.ReadInt8(), iter.i.Error
+}
+
+func (iter *Iterator) ReadInt16() (int16, error) {
+	return iter.i.ReadInt16(), iter.i.Error
+}
+
+func (iter *Iterator) ReadInt32() (int32, error) {
+	return iter.i.ReadInt32(), iter.i.Error
+}
+
+func (iter *Iterator) ReadInt64() (int64, error) {
+	return iter.i.ReadInt64(), iter.i.Error
+}
+
+func (iter *Iterator) ReadUint8() (uint8, error) {
+	return iter.i.ReadUint8(), iter.i.Error
+}
+
+func (iter *Iterator) ReadUint16() (uint16, error) {
+	return iter.i.ReadUint16(), iter.i.Error
+}
+
+func (iter *Iterator) ReadUint32() (uint32, error) {
+	return iter.i.ReadUint32(), iter.i.Error
 }
 
 func (iter *Iterator) ReadUint64() (uint64, error) {
@@ -102,22 +150,26 @@ func (iter *Iterator) ReportError(op, msg string) error {
 	return iter.i.Error
 }
 
-func (iter *Iterator) Marshal(v interface{}) ([]byte, error) {
-	return ConfigDefault.Marshal(v)
+func Marshal(v interface{}) ([]byte, error) {
+	return j.Marshal(v)
 }
 
-func (iter *Iterator) Unmarshal(data []byte, v interface{}) error {
-	return ConfigDefault.Unmarshal(data, v)
+func Unmarshal(data []byte, v interface{}) error {
+	return j.Unmarshal(data, v)
 }
 
-func (iter *Iterator) Parse(cfg j.API, reader io.Reader, bufSize int) (*Iterator, error) {
-	return &Iterator{j.Parse(cfg, reader, bufSize)}, iter.i.Error
+func Parse(cfg j.API, reader io.Reader, bufSize int) (*Iterator, error) {
+	return &Iterator{j.Parse(cfg, reader, bufSize)}, nil
 }
 
-func (iter *Iterator) ParseBytes(cfg j.API, input []byte) (*Iterator, error) {
-	return &Iterator{j.ParseBytes(cfg, input)}, iter.i.Error
+func ParseBytes(cfg j.API, input []byte) (*Iterator, error) {
+	return &Iterator{j.ParseBytes(cfg, input)}, nil
 }
 
-func (iter *Iterator) ParseString(cfg j.API, input string) (*Iterator, error) {
-	return &Iterator{j.ParseString(cfg, input)}, iter.i.Error
+func ParseString(cfg j.API, input string) (*Iterator, error) {
+	return &Iterator{j.ParseString(cfg, input)}, nil
+}
+
+func RegisterTypeEncoder(typ string, encoder ValEncoder) {
+	j.RegisterTypeEncoder(typ, encoder)
 }

--- a/data/utils/jsoniter/jsoniter_test.go
+++ b/data/utils/jsoniter/jsoniter_test.go
@@ -36,8 +36,7 @@ func TestRead(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	t.Run("should create a new iterator without any error", func(t *testing.T) {
-		jiter := NewIterator(j.NewIterator(j.ConfigDefault))
-		iter, err := jiter.Parse(ConfigDefault, io.NopCloser(strings.NewReader(`{"test":123}`)), 128)
+		iter, err := Parse(ConfigDefault, io.NopCloser(strings.NewReader(`{"test":123}`)), 128)
 		require.NoError(t, err)
 		require.NotNil(t, iter)
 	})

--- a/data/value_mapping.go
+++ b/data/value_mapping.go
@@ -75,7 +75,10 @@ func (m *ValueMappings) UnmarshalJSON(b []byte) error {
 
 	for iter.CanReadArray() {
 		var objMap map[string]json.RawMessage
-		iter.ReadVal(&objMap)
+		err := iter.ReadVal(&objMap)
+		if err != nil {
+			return err
+		}
 		mt := mappingType(strings.Trim(string(objMap["type"]), `"`))
 
 		switch mt {

--- a/data/value_mapping.go
+++ b/data/value_mapping.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
+
+	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
 // MappingType see https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/valueMapping.ts
@@ -44,7 +46,7 @@ type ValueMappings []ValueMapping
 
 // MarshalJSON writes the results as json
 func (m ValueMappings) MarshalJSON() ([]byte, error) {
-	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 

--- a/data/value_mapping.go
+++ b/data/value_mapping.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	jsoniter "github.com/json-iterator/go"
-
 	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
@@ -72,10 +70,10 @@ func (m ValueMappings) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON will read JSON into the appropriate go types
 func (m *ValueMappings) UnmarshalJSON(b []byte) error {
-	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, b)
+	iter, _ := sdkjsoniter.ParseBytes(sdkjsoniter.ConfigDefault, b)
 	var mappings ValueMappings
 
-	for iter.ReadArray() {
+	for iter.CanReadArray() {
 		var objMap map[string]json.RawMessage
 		iter.ReadVal(&objMap)
 		mt := mappingType(strings.Trim(string(objMap["type"]), `"`))
@@ -108,7 +106,7 @@ func (m *ValueMappings) UnmarshalJSON(b []byte) error {
 	}
 
 	*m = mappings
-	return iter.Error
+	return iter.ReadError()
 }
 
 // ValueMapper converts one set of strings to another


### PR DESCRIPTION
**What this PR does / why we need it**:

We wrapped json-iter package in our own wrapper to be able to handle errors properly. 
See PRs: 
- https://github.com/grafana/grafana-plugin-sdk-go/pull/806/files#diff-8e5b18e6f1890379e6cdbf3d3d60875715d525ebe4abc0a9bcf3223805d0c58b
- https://github.com/grafana/grafana-plugin-sdk-go/pull/837

We will also use these methods in grafana/grafana repo. For instance:
- https://github.com/grafana/grafana/blob/main/pkg/util/converter/prom.go
- https://github.com/grafana/grafana/blob/main/pkg/tsdb/influxdb/influxql/converter/converter.go

In this PR I ensure that the wrapper package `data/utils/jsoniter/jsoniter.go` is the only place we import json-iterator methods. 

--------------------
# Release notice breaking change

Users who use the following APIs must update their code:

Removed: 
```
(*Iterator).Marshal: removed
(*Iterator).Parse: removed
(*Iterator).ParseBytes: removed
(*Iterator).ParseString: removed
(*Iterator).Unmarshal: removed
```

Added:

```
Marshal: added
Parse: added
ParseBytes: added
ParseString: added
Unmarshal: added
```

### How to update the code:

```
// Before:
import (
	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
)

iter := sdkjsoniter.NewIterator(jsoniterPointer)
iter.Marshal(myInterface)

// After
import (
	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
)

jsoniter.Marshall(myInterface)
```