### PR TITLE
Supports "Host" custom header.

### DIFF
--- a/backend/httpclient/custom_headers_middleware.go
+++ b/backend/httpclient/custom_headers_middleware.go
@@ -18,7 +18,12 @@ func CustomHeadersMiddleware() Middleware {
 
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			for key, value := range opts.Headers {
-				req.Header.Set(key, value)
+				// According to https://pkg.go.dev/net/http#Request.Header, Host is a special case
+				if http.CanonicalHeaderKey(key) == "Host" {
+					req.Host = value
+				} else {
+					req.Header.Set(key, value)
+				}
 			}
 
 			return next.RoundTrip(req)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

In certain situations, configuring domain resolution can be challenging, making it valuable to have the ability to customize the `Host` header. The `net/http` package treats the `Host` header as a special case as described in https://pkg.go.dev/net/http#Request.Header. This pull request addresses this need by introducing enhancements to facilitate custom "Host" header configuration, thereby improving the overall functionality and usability of the package.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #852

**Special notes for your reviewer**:

In the current Grafana datasource configuration, users have the flexibility to set the "Host" header just like any other header, but this approach often leads to unexpected behavior. This pull request addresses this issue by proposing a more robust and effective solution. By implementing the suggested changes, we aim to improve the functionality of Grafana's datasource configuration, ensuring that the "Host" header works as intended.