### PR TITLE
codeowners: assign sql to big-tent squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 # these will be requested for review when someone opens a pull request.
 * @grafana/plugins-platform-backend
 /data/ @grafana/data-plane-wg
+/data/sqlutil @grafana/oss-big-tent


### PR DESCRIPTION
currently the whole `/data` folder is owned by the dataplane-working-group.i assume the intent was to have the dataplane-working-group own the dataframe-related code, but i do not think dataplane is a good match for `sqlutil`.

this PR moves sqlutil-ownership to the oss-big-tent-squad (my squad), who own postgres and mysql.
of course, of someone else would like to take ownership, we can discuss it and change the PR, no problem 👍 thanks!

(NOTE: there'sa CI error for the codeowner file, i'll fix that if/when this gets approved)