### PR TITLE
Refactor getMacroMatches & fix a couple of bugs

### DIFF
--- a/data/sqlutil/macros_test.go
+++ b/data/sqlutil/macros_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func staticMacro(output string) MacroFunc {
@@ -26,8 +25,9 @@ var macros = Macros{
 		}
 		return "bar"
 	}),
-	"f": staticMacro("f(1)"),
-	"g": staticMacro("g(1)"),
+	"f":   staticMacro("f(1)"),
+	"g":   staticMacro("g(1)"),
+	"num": staticMacro("10000"),
 	"multiParams": argMacro(func(args []string) string {
 		return strings.Join(append([]string{"bar"}, args...), "_")
 	}),
@@ -39,9 +39,10 @@ func TestInterpolate(t *testing.T) {
 	tableName := "my_table"
 	tableColumn := "my_col"
 	type test struct {
-		name   string
-		input  string
-		output string
+		name    string
+		input   string
+		output  string
+		wantErr bool
 	}
 	tests := []test{
 		{
@@ -174,6 +175,26 @@ func TestInterpolate(t *testing.T) {
 			output: "select * from foo where f(1) > g(1)",
 			name:   "don't consume args after a space (see https://github.com/grafana/sqlds/issues/82)",
 		},
+		{
+			input:  "select * from foo where $__num*(table.a + table.b) > 1000000",
+			output: "select * from foo where 10000*(table.a + table.b) > 1000000",
+			name:   "don't consume args after other non-paren characters",
+		},
+		{
+			input:   "select * from foo where $__params(whoops",
+			name:    "error (not panic) on missing close bracket",
+			wantErr: true,
+		},
+		{
+			input:   "select * from foo where $__params(FUNC(foo, bar)",
+			name:    "error on missing close bracket, nested",
+			wantErr: true,
+		},
+		{
+			input:   "select * from foo where $__params(FUNC(foo, bar)) > $__timeTo(uhoh",
+			name:    "error on missing close bracket after good macros",
+			wantErr: true,
+		},
 	}
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("[%d/%d] %s", i+1, len(tests), tc.name), func(t *testing.T) {
@@ -183,8 +204,75 @@ func TestInterpolate(t *testing.T) {
 				Column: tableColumn,
 			}
 			interpolatedQuery, err := Interpolate(query, macros)
-			require.Nil(t, err)
-			assert.Equal(t, tc.output, interpolatedQuery)
+			assert.Equal(t, err != nil, tc.wantErr, "wantErr != gotErr")
+			if !tc.wantErr {
+				assert.Equal(t, tc.output, interpolatedQuery)
+			}
+		})
+	}
+}
+
+func Test_parseArgs(t *testing.T) {
+	var tests = []struct {
+		name       string
+		input      string
+		wantArgs   []string
+		wantLength int
+	}{
+		{
+			name:       "no parens, no args",
+			input:      "foo bar",
+			wantArgs:   nil,
+			wantLength: 0,
+		},
+		{
+			name:       "parens not at beginning, still no args",
+			input:      "foo(bar)",
+			wantArgs:   nil,
+			wantLength: 0,
+		},
+		{
+			name:       "even just a space is enough",
+			input:      " (bar)",
+			wantArgs:   nil,
+			wantLength: 0,
+		},
+		{
+			name:       "simple one-arg case",
+			input:      "(bar)",
+			wantArgs:   []string{"bar"},
+			wantLength: 5,
+		},
+		{
+			name:       "multiple args, spaces",
+			input:      "(bar, baz, quux)",
+			wantArgs:   []string{"bar", "baz", "quux"},
+			wantLength: 16,
+		},
+		{
+			name:       "nested parens are not parsed further",
+			input:      "(bar(some,thing))",
+			wantArgs:   []string{"bar(some,thing)"},
+			wantLength: 17,
+		},
+		{
+			name:       "stuff after the closing bracket is ignored",
+			input:      "(arg1, arg2), not_an_arg, nope",
+			wantArgs:   []string{"arg1", "arg2"},
+			wantLength: 12,
+		},
+		{
+			name:       "missing close bracket is an error",
+			input:      "(arg1, arg2",
+			wantArgs:   nil,
+			wantLength: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, length := parseArgs(tt.input)
+			assert.Equalf(t, tt.wantArgs, args, "parseArgs(%v) wrong args:\nwant: %v\ngot:  %v\n", tt.input, tt.wantArgs, args)
+			assert.Equalf(t, tt.wantLength, length, "parseArgs(%v) wrong length:\nwant: %d\ngot:  %d\n", tt.input, tt.wantLength, length)
 		})
 	}
 }
@@ -195,7 +283,7 @@ func TestGetMacroMatches(t *testing.T) {
 			matches, err := getMacroMatches(fmt.Sprintf("$__%s", macroName), macroName)
 
 			assert.NoError(t, err)
-			assert.Equal(t, []Macro{{fmt.Sprintf("$__%s", macroName), []string{""}}}, matches)
+			assert.Equal(t, []macroMatch{{fmt.Sprintf("$__%s", macroName), nil}}, matches)
 		}
 	})
 	t.Run("does not return matches for macro name which is substring", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This refactors and updates `getMacroMatches` and `parseArgs` to remove duplicated logic and address two bugs.

Refactoring: previously `getMacroMatches` and `parseArgs` did quite a bit of overlapping work: `getMacroMatches` would parse the input string to find a bracketed substring string representing macro arguments, then `parseArgs` would take that string and parse it again to extract the arguments. The logic was also implemented differently in each. I've moved all the work of parsing arguments into `parseArgs`.

Bugs addressed: 
- #859, an extension of https://github.com/grafana/sqlds/issues/82, where a bracketed substring was treated as an argument list when it shouldn't be
- #861, where a badly-formed macro argument string would cause `getMacroMatches` to panic

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #859, #861.

**Special notes for your reviewer**:

Once the base branch (`858-changes_from_sqlds`) is merged I'll retarget this to `main`.