### PR TITLE
Add datasource label to secure_socks_requests_duration

### DIFF
--- a/backend/proxy/options.go
+++ b/backend/proxy/options.go
@@ -5,9 +5,9 @@ import "time"
 // Options defines per datasource options for creating the proxy dialer.
 type Options struct {
 	Enabled bool
-	// The name of the datasource the proxy will be used to communicate with.
+	// DatasourceName is the name of the datasource the proxy will be used to communicate with.
 	DatasourceName string
-	// The type of the datasource the proxy will be used to communicate with.
+	// DatasourceType is the type of the datasource the proxy will be used to communicate with.
 	// It should be the value assigned to the type property in a datasource provisioning file (e.g mysql, prometheus)
 	DatasourceType string
 	Auth           *AuthOptions

--- a/backend/proxy/options.go
+++ b/backend/proxy/options.go
@@ -4,10 +4,15 @@ import "time"
 
 // Options defines per datasource options for creating the proxy dialer.
 type Options struct {
-	Enabled   bool
-	Auth      *AuthOptions
-	Timeouts  *TimeoutOptions
-	ClientCfg *ClientCfg
+	Enabled bool
+	// The name of the datasource the proxy will be used to communicate with.
+	DatasourceName string
+	// The type of the datasource the proxy will be used to communicate with.
+	// It should be the value assigned to the type property in a datasource provisioning file (e.g mysql, prometheus)
+	DatasourceType string
+	Auth           *AuthOptions
+	Timeouts       *TimeoutOptions
+	ClientCfg      *ClientCfg
 }
 
 // AuthOptions socks5 username and password options.

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -51,7 +51,7 @@ var (
 		Namespace: "grafana",
 		Name:      "secure_socks_requests_duration",
 		Help:      "Duration of requests to the secure socks proxy",
-	}, []string{"code", "datasource", "datasourceType"})
+	}, []string{"code", "datasource", "datasource_type"})
 )
 
 // Client is the main Proxy Client interface.

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -280,9 +280,9 @@ func SecureSocksProxyEnabledOnDS(jsonData map[string]interface{}) bool {
 // instrumentedSocksDialer  is a wrapper around the proxy.Dialer and proxy.DialContext
 // that records relevant socks secure socks proxy.
 type instrumentedSocksDialer struct {
-	// The name of the datasource the proxy will be used to communicate with.
+	// datasourceName is the name of the datasource the proxy will be used to communicate with.
 	datasourceName string
-	// The type of the datasourceType the proxy will be used to communicate with.
+	// datasourceType is the type of the datasourceType the proxy will be used to communicate with.
 	// It should be the value assigned to the type property in a datasourceType provisioning file (e.g mysql, prometheus)
 	datasourceType string
 	dialer         proxy.Dialer


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Adds the `datasource` and `datasourceType` labels to `secure_socks_requests_duration`. 

The operator experience squad wants to expose some Grafana private datasource connect to customers and these labels will make it easier to do so.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Part of https://github.com/grafana/hosted-grafana/issues/5151

-->

Part of https://github.com/grafana/hosted-grafana/issues/5151

**Special notes for your reviewer**:
