### PR TITLE
Add `FromService` field

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -178,6 +178,10 @@ type PluginContext struct {
 	// UserAgent is the user agent of the Grafana server that initiated the gRPC request.
 	// Will only be set if request is made from Grafana v10.2.0 or later.
 	UserAgent *useragent.UserAgent
+
+	// FromService is the service in Grafana that initiated the request.
+	// Will only be set if request is made from Grafana v10.4.0 or later.
+	FromService string
 }
 
 func setCustomOptionsFromHTTPSettings(opts *httpclient.Options, httpSettings *HTTPSettings) {


### PR DESCRIPTION
This field can be used to identify the origin service of a plugin request.

This is a first attempt at resolving the issue discussed in [this](https://raintank-corp.slack.com/archives/C03E2AQKU2W/p1704716276022269) thread. 

Relevant PR's in grafana and enterprise:
- grafana/grafana#81199
- grafana/grafana-enterprise#6202
