### PR TITLE
Expose the concurrent query count key in sdk

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	AppURL = "GF_APP_URL"
+	AppURL               = "GF_APP_URL"
+	ConcurrentQueryCount = "GF_PLUGIN_CONCURRENT_QUERY_COUNT"
 )
 
 type configKey struct{}
@@ -136,6 +137,18 @@ func (c *GrafanaCfg) AppURL() (string, error) {
 		return "", fmt.Errorf("app URL not set in config. A more recent version of Grafana may be required")
 	}
 	return url, nil
+}
+
+func (c *GrafanaCfg) ConcurrentQueryCount() (int, error) {
+	count, ok := c.config[ConcurrentQueryCount]
+	if !ok {
+		return 0, fmt.Errorf("ConcurrentQueryCount not set in config")
+	}
+	i, err := strconv.Atoi(count)
+	if err != nil {
+		return 0, fmt.Errorf("ConcurrentQueryCount cannot be converted to integer")
+	}
+	return i, nil
 }
 
 type userAgentKey struct{}

--- a/backend/config.go
+++ b/backend/config.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	AppURL               = "GF_APP_URL"
-	ConcurrentQueryCount = "GF_PLUGIN_CONCURRENT_QUERY_COUNT"
+	ConcurrentQueryCount = "GF_CONCURRENT_QUERY_COUNT"
 )
 
 type configKey struct{}


### PR DESCRIPTION
We recently added a new configuration option `ConcurrentQueryCount`. See: https://github.com/grafana/grafana/pull/81212
This needs to be passed to the plugins (currently, Loki and [InfluxDB](https://github.com/grafana/grafana/pull/81209) need it). Reaching to that via using `github.com/grafana/grafana/pkg/setting` is against our decoupling goals. As it was suggested [here](https://github.com/grafana/grafana/pull/81209#discussion_r1469508109) exposing this key would be easier to reach without compromising our decoupling goals. 