### PR TITLE
Revert "Chore: Use jsoniter from wrapper"

### DIFF
--- a/backend/data.go
+++ b/backend/data.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
+	jsoniter "github.com/json-iterator/go"
 )
 
 // QueryDataHandler handles data queries.
@@ -116,7 +116,7 @@ type QueryDataResponse struct {
 
 // MarshalJSON writes the results as json
 func (r QueryDataResponse) MarshalJSON() ([]byte, error) {
-	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
@@ -126,12 +126,9 @@ func (r QueryDataResponse) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON will read JSON into a QueryDataResponse
 func (r *QueryDataResponse) UnmarshalJSON(b []byte) error {
-	iter, err := sdkjsoniter.ParseBytes(sdkjsoniter.ConfigDefault, b)
-	if err != nil {
-		return err
-	}
+	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, b)
 	readQueryDataResultsJSON(r, iter)
-	return iter.ReadError()
+	return iter.Error
 }
 
 // NewQueryDataResponse returns a QueryDataResponse with the Responses property initialized.
@@ -186,7 +183,7 @@ func ErrDataResponseWithSource(status Status, src ErrorSource, message string) D
 
 // MarshalJSON writes the results as json
 func (r DataResponse) MarshalJSON() ([]byte, error) {
-	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 

--- a/data/frame.go
+++ b/data/frame.go
@@ -19,9 +19,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/olekukonko/tablewriter"
-
-	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
 // Frame is a columnar data structure where each column is a Field.
@@ -50,13 +49,13 @@ type Frame struct {
 
 // UnmarshalJSON allows unmarshalling Frame from JSON.
 func (f *Frame) UnmarshalJSON(b []byte) error {
-	iter, _ := sdkjsoniter.ParseBytes(sdkjsoniter.ConfigDefault, b)
+	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, b)
 	return readDataFrameJSON(f, iter)
 }
 
 // MarshalJSON marshals Frame to JSON.
 func (f *Frame) MarshalJSON() ([]byte, error) {
-	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
@@ -76,7 +75,7 @@ func (f *Frame) MarshalJSON() ([]byte, error) {
 type Frames []*Frame
 
 func (frames *Frames) MarshalJSON() ([]byte, error) {
-	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
@@ -90,7 +89,7 @@ func (frames *Frames) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON allows unmarshalling Frame from JSON.
 func (frames *Frames) UnmarshalJSON(b []byte) error {
-	iter, _ := sdkjsoniter.ParseBytes(sdkjsoniter.ConfigDefault, b)
+	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, b)
 	return readDataFramesJSON(frames, iter)
 }
 

--- a/data/frame_json.gen.go
+++ b/data/frame_json.gen.go
@@ -3,11 +3,10 @@ package data
 import (
 	"github.com/apache/arrow/go/v13/arrow"
 	"github.com/apache/arrow/go/v13/arrow/array"
-
-	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
+	jsoniter "github.com/json-iterator/go"
 )
 
-func writeArrowDataBinary(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataBinary(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -31,7 +30,7 @@ func writeArrowDataBinary(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnt
 // The rest of this file is generated from frame_json_test.go
 // -------------------------------------------------------------
 
-func writeArrowDataUint8(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataUint8(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -51,54 +50,54 @@ func writeArrowDataUint8(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnti
 	return entities
 }
 
-func readUint8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint8Vector, error) {
+func readUint8VectorJSON(iter *jsoniter.Iterator, size int) (*uint8Vector, error) {
 	arr := newUint8Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readUint8VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadUint8()
+			v := iter.ReadUint8()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableUint8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableUint8Vector, error) {
+func readNullableUint8VectorJSON(iter *jsoniter.Iterator, size int) (*nullableUint8Vector, error) {
 	arr := newNullableUint8Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableUint8VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadUint8()
+			v := iter.ReadUint8()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableUint8VectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataUint16(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataUint16(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -118,54 +117,54 @@ func writeArrowDataUint16(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnt
 	return entities
 }
 
-func readUint16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint16Vector, error) {
+func readUint16VectorJSON(iter *jsoniter.Iterator, size int) (*uint16Vector, error) {
 	arr := newUint16Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readUint16VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadUint16()
+			v := iter.ReadUint16()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableUint16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableUint16Vector, error) {
+func readNullableUint16VectorJSON(iter *jsoniter.Iterator, size int) (*nullableUint16Vector, error) {
 	arr := newNullableUint16Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableUint16VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadUint16()
+			v := iter.ReadUint16()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableUint16VectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataUint32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataUint32(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -185,54 +184,54 @@ func writeArrowDataUint32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnt
 	return entities
 }
 
-func readUint32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint32Vector, error) {
+func readUint32VectorJSON(iter *jsoniter.Iterator, size int) (*uint32Vector, error) {
 	arr := newUint32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readUint32VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadUint32()
+			v := iter.ReadUint32()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableUint32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableUint32Vector, error) {
+func readNullableUint32VectorJSON(iter *jsoniter.Iterator, size int) (*nullableUint32Vector, error) {
 	arr := newNullableUint32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableUint32VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadUint32()
+			v := iter.ReadUint32()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableUint32VectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataUint64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataUint64(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -252,54 +251,54 @@ func writeArrowDataUint64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnt
 	return entities
 }
 
-func readUint64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*uint64Vector, error) {
+func readUint64VectorJSON(iter *jsoniter.Iterator, size int) (*uint64Vector, error) {
 	arr := newUint64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readUint64VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadUint64()
+			v := iter.ReadUint64()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableUint64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableUint64Vector, error) {
+func readNullableUint64VectorJSON(iter *jsoniter.Iterator, size int) (*nullableUint64Vector, error) {
 	arr := newNullableUint64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableUint64VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadUint64()
+			v := iter.ReadUint64()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableUint64VectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataInt8(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataInt8(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -319,54 +318,54 @@ func writeArrowDataInt8(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntit
 	return entities
 }
 
-func readInt8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int8Vector, error) {
+func readInt8VectorJSON(iter *jsoniter.Iterator, size int) (*int8Vector, error) {
 	arr := newInt8Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readInt8VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadInt8()
+			v := iter.ReadInt8()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableInt8VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableInt8Vector, error) {
+func readNullableInt8VectorJSON(iter *jsoniter.Iterator, size int) (*nullableInt8Vector, error) {
 	arr := newNullableInt8Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableInt8VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadInt8()
+			v := iter.ReadInt8()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableInt8VectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataInt16(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataInt16(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -386,54 +385,54 @@ func writeArrowDataInt16(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnti
 	return entities
 }
 
-func readInt16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int16Vector, error) {
+func readInt16VectorJSON(iter *jsoniter.Iterator, size int) (*int16Vector, error) {
 	arr := newInt16Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readInt16VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadInt16()
+			v := iter.ReadInt16()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableInt16VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableInt16Vector, error) {
+func readNullableInt16VectorJSON(iter *jsoniter.Iterator, size int) (*nullableInt16Vector, error) {
 	arr := newNullableInt16Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableInt16VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadInt16()
+			v := iter.ReadInt16()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableInt16VectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataInt32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataInt32(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -453,54 +452,54 @@ func writeArrowDataInt32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnti
 	return entities
 }
 
-func readInt32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int32Vector, error) {
+func readInt32VectorJSON(iter *jsoniter.Iterator, size int) (*int32Vector, error) {
 	arr := newInt32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readInt32VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadInt32()
+			v := iter.ReadInt32()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableInt32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableInt32Vector, error) {
+func readNullableInt32VectorJSON(iter *jsoniter.Iterator, size int) (*nullableInt32Vector, error) {
 	arr := newNullableInt32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableInt32VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadInt32()
+			v := iter.ReadInt32()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableInt32VectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataInt64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataInt64(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -520,54 +519,54 @@ func writeArrowDataInt64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnti
 	return entities
 }
 
-func readInt64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*int64Vector, error) {
+func readInt64VectorJSON(iter *jsoniter.Iterator, size int) (*int64Vector, error) {
 	arr := newInt64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readInt64VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadInt64()
+			v := iter.ReadInt64()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableInt64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableInt64Vector, error) {
+func readNullableInt64VectorJSON(iter *jsoniter.Iterator, size int) (*nullableInt64Vector, error) {
 	arr := newNullableInt64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableInt64VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadInt64()
+			v := iter.ReadInt64()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableInt64VectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataFloat32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataFloat32(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -598,54 +597,54 @@ func writeArrowDataFloat32(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEn
 	return entities
 }
 
-func readFloat32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*float32Vector, error) {
+func readFloat32VectorJSON(iter *jsoniter.Iterator, size int) (*float32Vector, error) {
 	arr := newFloat32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readFloat32VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadFloat32()
+			v := iter.ReadFloat32()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableFloat32VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableFloat32Vector, error) {
+func readNullableFloat32VectorJSON(iter *jsoniter.Iterator, size int) (*nullableFloat32Vector, error) {
 	arr := newNullableFloat32Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableFloat32VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadFloat32()
+			v := iter.ReadFloat32()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableFloat32VectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataFloat64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataFloat64(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -676,54 +675,54 @@ func writeArrowDataFloat64(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEn
 	return entities
 }
 
-func readFloat64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*float64Vector, error) {
+func readFloat64VectorJSON(iter *jsoniter.Iterator, size int) (*float64Vector, error) {
 	arr := newFloat64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readFloat64VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadFloat64()
+			v := iter.ReadFloat64()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableFloat64VectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableFloat64Vector, error) {
+func readNullableFloat64VectorJSON(iter *jsoniter.Iterator, size int) (*nullableFloat64Vector, error) {
 	arr := newNullableFloat64Vector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableFloat64VectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadFloat64()
+			v := iter.ReadFloat64()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableFloat64VectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataString(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataString(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -743,54 +742,54 @@ func writeArrowDataString(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEnt
 	return entities
 }
 
-func readStringVectorJSON(iter *sdkjsoniter.Iterator, size int) (*stringVector, error) {
+func readStringVectorJSON(iter *jsoniter.Iterator, size int) (*stringVector, error) {
 	arr := newStringVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readStringVectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadString()
+			v := iter.ReadString()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableStringVectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableStringVector, error) {
+func readNullableStringVectorJSON(iter *jsoniter.Iterator, size int) (*nullableStringVector, error) {
 	arr := newNullableStringVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableStringVectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadString()
+			v := iter.ReadString()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableStringVectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataBool(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataBool(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -810,54 +809,54 @@ func writeArrowDataBool(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntit
 	return entities
 }
 
-func readBoolVectorJSON(iter *sdkjsoniter.Iterator, size int) (*boolVector, error) {
+func readBoolVectorJSON(iter *jsoniter.Iterator, size int) (*boolVector, error) {
 	arr := newBoolVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readBoolVectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadBool()
+			v := iter.ReadBool()
 			arr.Set(i, v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableBoolVectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableBoolVector, error) {
+func readNullableBoolVectorJSON(iter *jsoniter.Iterator, size int) (*nullableBoolVector, error) {
 	arr := newNullableBoolVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableBoolVectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadBool()
+			v := iter.ReadBool()
 			arr.Set(i, &v)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableBoolVectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func writeArrowDataEnum(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntityLookup {
+func writeArrowDataEnum(stream *jsoniter.Stream, col arrow.Array) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 
@@ -877,50 +876,50 @@ func writeArrowDataEnum(stream *sdkjsoniter.Stream, col arrow.Array) *fieldEntit
 	return entities
 }
 
-func readEnumVectorJSON(iter *sdkjsoniter.Iterator, size int) (*enumVector, error) {
+func readEnumVectorJSON(iter *jsoniter.Iterator, size int) (*enumVector, error) {
 	arr := newEnumVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readEnumVectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
 
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadUint16()
+			v := iter.ReadUint16()
 			arr.Set(i, EnumItemIndex(v))
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("read", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }
 
-func readNullableEnumVectorJSON(iter *sdkjsoniter.Iterator, size int) (*nullableEnumVector, error) {
+func readNullableEnumVectorJSON(iter *jsoniter.Iterator, size int) (*nullableEnumVector, error) {
 	arr := newNullableEnumVector(size)
 	for i := 0; i < size; i++ {
-		if !iter.CanReadArray() {
+		if !iter.ReadArray() {
 			iter.ReportError("readNullableEnumVectorJSON", "expected array")
-			return nil, iter.ReadError()
+			return nil, iter.Error
 		}
-		t, _ := iter.WhatIsNext()
-		if t == sdkjsoniter.NilValue {
+		t := iter.WhatIsNext()
+		if t == jsoniter.NilValue {
 			iter.ReadNil()
 		} else {
-			v, _ := iter.ReadUint16()
+			v := iter.ReadUint16()
 			eII := EnumItemIndex(v)
 			arr.Set(i, &eII)
 		}
 	}
 
-	if iter.CanReadArray() {
+	if iter.ReadArray() {
 		iter.ReportError("readNullableEnumVectorJSON", "expected close array")
-		return nil, iter.ReadError()
+		return nil, iter.Error
 	}
 	return arr, nil
 }

--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -20,7 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
 // TestGoldenFrameJSON makes sure that the JSON produced from arrow and dataframes match
@@ -247,7 +247,7 @@ func BenchmarkFrameMarshalJSONIter(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := sdkjsoniter.Marshal(f)
+		_, err := jsoniter.Marshal(f)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -350,7 +350,7 @@ func TestGenerateGenericArrowCode(t *testing.T) {
 	}
 
 	code := `
-func writeArrowData{{.Type}}(stream *sdkjsoniter.Stream, col array.Interface) *fieldEntityLookup {
+func writeArrowData{{.Type}}(stream *jsoniter.Stream, col array.Interface) *fieldEntityLookup {
 	var entities *fieldEntityLookup
 	count := col.Len()
 

--- a/data/labels.go
+++ b/data/labels.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"unsafe"
 
-	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
+	jsoniter "github.com/json-iterator/go"
 )
 
 // Labels are used to add metadata to an object.  The JSON will always be sorted keys
@@ -17,7 +17,7 @@ import (
 type Labels map[string]string
 
 func init() { //nolint:gochecknoinits
-	sdkjsoniter.RegisterTypeEncoder("data.Labels", &dataLabelsCodec{})
+	jsoniter.RegisterTypeEncoder("data.Labels", &dataLabelsCodec{})
 }
 
 // Equals returns true if the argument has the same k=v pairs as the receiver.
@@ -149,7 +149,7 @@ func LabelsFromString(s string) (Labels, error) {
 
 // MarshalJSON marshals Labels to JSON.
 func (l Labels) MarshalJSON() ([]byte, error) {
-	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
@@ -161,7 +161,7 @@ func (l Labels) MarshalJSON() ([]byte, error) {
 	return append([]byte(nil), stream.Buffer()...), nil
 }
 
-func writeLabelsJSON(l Labels, stream *sdkjsoniter.Stream) {
+func writeLabelsJSON(l Labels, stream *jsoniter.Stream) {
 	keys := make([]string, len(l))
 	i := 0
 	for k := range l {
@@ -188,7 +188,7 @@ func (codec *dataLabelsCodec) IsEmpty(ptr unsafe.Pointer) bool {
 	return f.Fields == nil && f.RefID == "" && f.Meta == nil
 }
 
-func (codec *dataLabelsCodec) Encode(ptr unsafe.Pointer, stream *sdkjsoniter.Stream) {
+func (codec *dataLabelsCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 	v := (*Labels)(ptr)
 	if v == nil {
 		stream.WriteNil()

--- a/data/labels_test.go
+++ b/data/labels_test.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
 // Equals returns true if the argument has the same k=v pairs as the receiver.
@@ -38,8 +38,8 @@ func TestJSONReadWrite(t *testing.T) {
 	a0 := data.Labels{"a": "AAA", "b": "BBB"}
 	a1 := data.Labels{"b": "BBB", "a": "AAA"}
 
-	b0, _ := sdkjsoniter.Marshal(a0)
-	b1, _ := sdkjsoniter.Marshal(a1)
+	b0, _ := jsoniter.Marshal(a0)
+	b1, _ := jsoniter.Marshal(a1)
 
 	require.Equal(t, b0, b1)
 	require.Equal(t, `{"a":"AAA","b":"BBB"}`, string(b0))

--- a/data/utils/jsoniter/jsoniter.go
+++ b/data/utils/jsoniter/jsoniter.go
@@ -22,13 +22,8 @@ const (
 )
 
 var (
-	ConfigDefault                       = j.ConfigDefault
-	ConfigCompatibleWithStandardLibrary = j.ConfigCompatibleWithStandardLibrary
+	ConfigDefault = j.ConfigDefault
 )
-
-type Stream = j.Stream
-type ValEncoder = j.ValEncoder
-type ValDecoder = j.ValDecoder
 
 type Iterator struct {
 	// named property instead of embedded so there is no
@@ -38,14 +33,6 @@ type Iterator struct {
 
 func NewIterator(i *j.Iterator) *Iterator {
 	return &Iterator{i}
-}
-
-func (iter *Iterator) ReadError() error {
-	return iter.i.Error
-}
-
-func (iter *Iterator) SetError(err error) {
-	iter.i.Error = err
 }
 
 func (iter *Iterator) Read() (interface{}, error) {
@@ -58,11 +45,6 @@ func (iter *Iterator) ReadAny() (j.Any, error) {
 
 func (iter *Iterator) ReadArray() (bool, error) {
 	return iter.i.ReadArray(), iter.i.Error
-}
-
-func (iter *Iterator) CanReadArray() bool {
-	ok, err := iter.ReadArray()
-	return ok && err == nil
 }
 
 func (iter *Iterator) ReadObject() (string, error) {
@@ -82,53 +64,17 @@ func (iter *Iterator) Skip() error {
 	return iter.i.Error
 }
 
-func (iter *Iterator) SkipAndReturnBytes() ([]byte, error) {
-	return iter.i.SkipAndReturnBytes(), iter.i.Error
-}
-
 func (iter *Iterator) ReadVal(obj interface{}) error {
 	iter.i.ReadVal(obj)
 	return iter.i.Error
-}
-
-func (iter *Iterator) ReadFloat32() (float32, error) {
-	return iter.i.ReadFloat32(), iter.i.Error
 }
 
 func (iter *Iterator) ReadFloat64() (float64, error) {
 	return iter.i.ReadFloat64(), iter.i.Error
 }
 
-func (iter *Iterator) ReadInt() (int, error) {
-	return iter.i.ReadInt(), iter.i.Error
-}
-
 func (iter *Iterator) ReadInt8() (int8, error) {
 	return iter.i.ReadInt8(), iter.i.Error
-}
-
-func (iter *Iterator) ReadInt16() (int16, error) {
-	return iter.i.ReadInt16(), iter.i.Error
-}
-
-func (iter *Iterator) ReadInt32() (int32, error) {
-	return iter.i.ReadInt32(), iter.i.Error
-}
-
-func (iter *Iterator) ReadInt64() (int64, error) {
-	return iter.i.ReadInt64(), iter.i.Error
-}
-
-func (iter *Iterator) ReadUint8() (uint8, error) {
-	return iter.i.ReadUint8(), iter.i.Error
-}
-
-func (iter *Iterator) ReadUint16() (uint16, error) {
-	return iter.i.ReadUint16(), iter.i.Error
-}
-
-func (iter *Iterator) ReadUint32() (uint32, error) {
-	return iter.i.ReadUint32(), iter.i.Error
 }
 
 func (iter *Iterator) ReadUint64() (uint64, error) {
@@ -156,30 +102,22 @@ func (iter *Iterator) ReportError(op, msg string) error {
 	return iter.i.Error
 }
 
-func Marshal(v interface{}) ([]byte, error) {
-	return j.Marshal(v)
+func (iter *Iterator) Marshal(v interface{}) ([]byte, error) {
+	return ConfigDefault.Marshal(v)
 }
 
-func Unmarshal(data []byte, v interface{}) error {
-	return j.Unmarshal(data, v)
+func (iter *Iterator) Unmarshal(data []byte, v interface{}) error {
+	return ConfigDefault.Unmarshal(data, v)
 }
 
-func Parse(cfg j.API, reader io.Reader, bufSize int) (*Iterator, error) {
-	return &Iterator{j.Parse(cfg, reader, bufSize)}, nil
+func (iter *Iterator) Parse(cfg j.API, reader io.Reader, bufSize int) (*Iterator, error) {
+	return &Iterator{j.Parse(cfg, reader, bufSize)}, iter.i.Error
 }
 
-func ParseBytes(cfg j.API, input []byte) (*Iterator, error) {
-	return &Iterator{j.ParseBytes(cfg, input)}, nil
+func (iter *Iterator) ParseBytes(cfg j.API, input []byte) (*Iterator, error) {
+	return &Iterator{j.ParseBytes(cfg, input)}, iter.i.Error
 }
 
-func ParseString(cfg j.API, input string) (*Iterator, error) {
-	return &Iterator{j.ParseString(cfg, input)}, nil
-}
-
-func RegisterTypeEncoder(typ string, encoder ValEncoder) {
-	j.RegisterTypeEncoder(typ, encoder)
-}
-
-func RegisterTypeDecoder(typ string, decoder ValDecoder) {
-	j.RegisterTypeDecoder(typ, decoder)
+func (iter *Iterator) ParseString(cfg j.API, input string) (*Iterator, error) {
+	return &Iterator{j.ParseString(cfg, input)}, iter.i.Error
 }

--- a/data/utils/jsoniter/jsoniter_test.go
+++ b/data/utils/jsoniter/jsoniter_test.go
@@ -36,7 +36,8 @@ func TestRead(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	t.Run("should create a new iterator without any error", func(t *testing.T) {
-		iter, err := Parse(ConfigDefault, io.NopCloser(strings.NewReader(`{"test":123}`)), 128)
+		jiter := NewIterator(j.NewIterator(j.ConfigDefault))
+		iter, err := jiter.Parse(ConfigDefault, io.NopCloser(strings.NewReader(`{"test":123}`)), 128)
 		require.NoError(t, err)
 		require.NotNil(t, iter)
 	})

--- a/data/value_mapping.go
+++ b/data/value_mapping.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
+	jsoniter "github.com/json-iterator/go"
 )
 
 // MappingType see https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/valueMapping.ts
@@ -44,7 +44,7 @@ type ValueMappings []ValueMapping
 
 // MarshalJSON writes the results as json
 func (m ValueMappings) MarshalJSON() ([]byte, error) {
-	cfg := sdkjsoniter.ConfigCompatibleWithStandardLibrary
+	cfg := jsoniter.ConfigCompatibleWithStandardLibrary
 	stream := cfg.BorrowStream(nil)
 	defer cfg.ReturnStream(stream)
 
@@ -70,15 +70,12 @@ func (m ValueMappings) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON will read JSON into the appropriate go types
 func (m *ValueMappings) UnmarshalJSON(b []byte) error {
-	iter, _ := sdkjsoniter.ParseBytes(sdkjsoniter.ConfigDefault, b)
+	iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, b)
 	var mappings ValueMappings
 
-	for iter.CanReadArray() {
+	for iter.ReadArray() {
 		var objMap map[string]json.RawMessage
-		err := iter.ReadVal(&objMap)
-		if err != nil {
-			return err
-		}
+		iter.ReadVal(&objMap)
 		mt := mappingType(strings.Trim(string(objMap["type"]), `"`))
 
 		switch mt {
@@ -109,7 +106,7 @@ func (m *ValueMappings) UnmarshalJSON(b []byte) error {
 	}
 
 	*m = mappings
-	return iter.ReadError()
+	return iter.Error
 }
 
 // ValueMapper converts one set of strings to another


### PR DESCRIPTION
Reverts grafana/grafana-plugin-sdk-go#841

Context https://raintank-corp.slack.com/archives/CMSUYD6H3/p1706642169777429

```
Try this unit test anywhere in the grafana backend:
func TestMarshalUnmarshal(t *testing.T) {
	qdr := &backend.QueryDataResponse{
		Responses: backend.Responses{
			"A": {
				Status: 400,
				Error:  errors.New("test"),
			},
		},
	}
	resp, err := json.Marshal(qdr)
	require.NoError(t, err)
	qdr2 := &backend.QueryDataResponse{}
	require.NoError(t, json.Unmarshal(resp, qdr2))
	require.Equal(t, qdr, qdr2)
}


Michael
  [1 hour ago](https://raintank-corp.slack.com/archives/CMSUYD6H3/p1706642221131209?thread_ts=1706642169.777429&cid=CMSUYD6H3)
You’ll get
--- FAIL: TestMarshalUnmarshal (0.00s)
    /Users/mmandrus/dev/grafana/pkg/services/query/query_test.go:61: 
        	Error Trace:	/Users/mmandrus/dev/grafana/pkg/services/query/query_test.go:61
        	Error:      	Not equal: 
        	            	expected: &backend.QueryDataResponse{Responses:backend.Responses{"A":backend.DataResponse{Frames:data.Frames(nil), Error:(*errors.errorString)(0x14000d94950), Status:400, ErrorSource:""}}}
        	            	actual  : &backend.QueryDataResponse{Responses:backend.Responses{"A":backend.DataResponse{Frames:data.Frames(nil), Error:(*errors.errorString)(0x14000d94990), Status:400, ErrorSource:""}}}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -5,3 +5,3 @@
        	            	    Error: (*errors.errorString)({
        	            	-    s: (string) (len=4) "test"
        	            	+    s: (string) (len=19) "test%!(EXTRA <nil>)"
        	            	    }),
        	Test:       	TestMarshalUnmarshal
FAIL
FAIL	github.com/grafana/grafana/pkg/services/query	1.047s
```