### PR TITLE
gtime: add FormatInterval

### DIFF
--- a/backend/gtime/gtime.go
+++ b/backend/gtime/gtime.go
@@ -86,7 +86,7 @@ func parse(inp string) (time.Duration, string, error) {
 	return time.Duration(num), string(result[2]), nil
 }
 
-// FormatInterval converts a duration into the kbn format e.g. 1m 2h or 3d
+// FormatInterval converts a duration into the units that Grafana uses
 func FormatInterval(inter time.Duration) string {
 	year := time.Hour * 24 * 365
 	day := time.Hour * 24

--- a/backend/gtime/gtime.go
+++ b/backend/gtime/gtime.go
@@ -85,3 +85,35 @@ func parse(inp string) (time.Duration, string, error) {
 
 	return time.Duration(num), string(result[2]), nil
 }
+
+// FormatInterval converts a duration into the kbn format e.g. 1m 2h or 3d
+func FormatInterval(inter time.Duration) string {
+	year := time.Hour * 24 * 365
+	day := time.Hour * 24
+
+	if inter >= year {
+		return fmt.Sprintf("%dy", inter/year)
+	}
+
+	if inter >= day {
+		return fmt.Sprintf("%dd", inter/day)
+	}
+
+	if inter >= time.Hour {
+		return fmt.Sprintf("%dh", inter/time.Hour)
+	}
+
+	if inter >= time.Minute {
+		return fmt.Sprintf("%dm", inter/time.Minute)
+	}
+
+	if inter >= time.Second {
+		return fmt.Sprintf("%ds", inter/time.Second)
+	}
+
+	if inter >= time.Millisecond {
+		return fmt.Sprintf("%dms", inter/time.Millisecond)
+	}
+
+	return "1ms"
+}

--- a/backend/gtime/gtime_test.go
+++ b/backend/gtime/gtime_test.go
@@ -100,3 +100,23 @@ func calculateDays5y() int {
 
 	return daysInYear
 }
+
+func TestFormatInterval(t *testing.T) {
+	testCases := []struct {
+		name     string
+		duration time.Duration
+		expected string
+	}{
+		{"61s", time.Second * 61, "1m"},
+		{"30ms", time.Millisecond * 30, "30ms"},
+		{"23h", time.Hour * 23, "23h"},
+		{"24h", time.Hour * 24, "1d"},
+		{"367d", time.Hour * 24 * 367, "1y"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, FormatInterval(tc.duration))
+		})
+	}
+}


### PR DESCRIPTION
when decoupling datasource plugins from core grafana, some of them call `interval2.FormatDuration` ( for example the  sql datasources: https://github.com/grafana/grafana/blob/7319a75110bff09e1d647535416f53abb4f78a80/pkg/tsdb/sqleng/sql_engine.go#L375 ).

to be able to call this in the decoupled form, we have to move this function here from `grafana/grafana`. i saw that `gtime` package, which already had things like `ParseInterval`, so i thought i can add it here. of course, i can move it somewhere else, if needed.

i can make the related PR in `grafana/grafana` afterwards, that deletes `intervalv2.FormatDuration` there.

(link to related internal discussion : https://raintank-corp.slack.com/archives/C01SFPX3000/p1694009081654909)

