### PR TITLE
Move roundInterval from grafana/grafana intervalv2

### DIFF
--- a/backend/gtime/gtime.go
+++ b/backend/gtime/gtime.go
@@ -166,3 +166,103 @@ func ParseIntervalStringToTimeDuration(interval string) (time.Duration, error) {
 	}
 	return parsedInterval, nil
 }
+
+// RoundInterval returns a predetermined, lower and rounder duration than the given
+//
+//nolint:gocyclo
+func RoundInterval(interval time.Duration) time.Duration {
+	switch {
+	// 0.01s
+	case interval <= 10*time.Millisecond:
+		return time.Millisecond * 1 // 0.001s
+	// 0.015s
+	case interval <= 15*time.Millisecond:
+		return time.Millisecond * 10 // 0.01s
+	// 0.035s
+	case interval <= 35*time.Millisecond:
+		return time.Millisecond * 20 // 0.02s
+	// 0.075s
+	case interval <= 75*time.Millisecond:
+		return time.Millisecond * 50 // 0.05s
+	// 0.15s
+	case interval <= 150*time.Millisecond:
+		return time.Millisecond * 100 // 0.1s
+	// 0.35s
+	case interval <= 350*time.Millisecond:
+		return time.Millisecond * 200 // 0.2s
+	// 0.75s
+	case interval <= 750*time.Millisecond:
+		return time.Millisecond * 500 // 0.5s
+	// 1.5s
+	case interval <= 1500*time.Millisecond:
+		return time.Millisecond * 1000 // 1s
+	// 3.5s
+	case interval <= 3500*time.Millisecond:
+		return time.Millisecond * 2000 // 2s
+	// 7.5s
+	case interval <= 7500*time.Millisecond:
+		return time.Millisecond * 5000 // 5s
+	// 12.5s
+	case interval <= 12500*time.Millisecond:
+		return time.Millisecond * 10000 // 10s
+	// 17.5s
+	case interval <= 17500*time.Millisecond:
+		return time.Millisecond * 15000 // 15s
+	// 25s
+	case interval <= 25000*time.Millisecond:
+		return time.Millisecond * 20000 // 20s
+	// 45s
+	case interval <= 45000*time.Millisecond:
+		return time.Millisecond * 30000 // 30s
+	// 1.5m
+	case interval <= 90000*time.Millisecond:
+		return time.Millisecond * 60000 // 1m
+	// 3.5m
+	case interval <= 210000*time.Millisecond:
+		return time.Millisecond * 120000 // 2m
+	// 7.5m
+	case interval <= 450000*time.Millisecond:
+		return time.Millisecond * 300000 // 5m
+	// 12.5m
+	case interval <= 750000*time.Millisecond:
+		return time.Millisecond * 600000 // 10m
+	// 17.5m
+	case interval <= 1050000*time.Millisecond:
+		return time.Millisecond * 900000 // 15m
+	// 25m
+	case interval <= 1500000*time.Millisecond:
+		return time.Millisecond * 1200000 // 20m
+	// 45m
+	case interval <= 2700000*time.Millisecond:
+		return time.Millisecond * 1800000 // 30m
+	// 1.5h
+	case interval <= 5400000*time.Millisecond:
+		return time.Millisecond * 3600000 // 1h
+	// 2.5h
+	case interval <= 9000000*time.Millisecond:
+		return time.Millisecond * 7200000 // 2h
+	// 4.5h
+	case interval <= 16200000*time.Millisecond:
+		return time.Millisecond * 10800000 // 3h
+	// 9h
+	case interval <= 32400000*time.Millisecond:
+		return time.Millisecond * 21600000 // 6h
+	// 24h
+	case interval <= 86400000*time.Millisecond:
+		return time.Millisecond * 43200000 // 12h
+	// 48h
+	case interval <= 172800000*time.Millisecond:
+		return time.Millisecond * 86400000 // 24h
+	// 1w
+	case interval <= 604800000*time.Millisecond:
+		return time.Millisecond * 86400000 // 24h
+	// 3w
+	case interval <= 1814400000*time.Millisecond:
+		return time.Millisecond * 604800000 // 1w
+	// 2y
+	case interval < 3628800000*time.Millisecond:
+		return time.Millisecond * 2592000000 // 30d
+	default:
+		return time.Millisecond * 31536000000 // 1y
+	}
+}

--- a/backend/gtime/gtime_test.go
+++ b/backend/gtime/gtime_test.go
@@ -183,3 +183,48 @@ func TestParseIntervalStringToTimeDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestRoundInterval(t *testing.T) {
+	tcs := []struct {
+		input    time.Duration
+		expected time.Duration
+	}{
+		{input: 9 * time.Millisecond, expected: time.Millisecond * 1},
+		{input: 14 * time.Millisecond, expected: time.Millisecond * 10},
+		{input: 34 * time.Millisecond, expected: time.Millisecond * 20},
+		{input: 74 * time.Millisecond, expected: time.Millisecond * 50},
+		{input: 140 * time.Millisecond, expected: time.Millisecond * 100},
+		{input: 320 * time.Millisecond, expected: time.Millisecond * 200},
+		{input: 740 * time.Millisecond, expected: time.Millisecond * 500},
+		{input: 1400 * time.Millisecond, expected: time.Millisecond * 1000},
+		{input: 3200 * time.Millisecond, expected: time.Millisecond * 2000},
+		{input: 7400 * time.Millisecond, expected: time.Millisecond * 5000},
+		{input: 12400 * time.Millisecond, expected: time.Millisecond * 10000},
+		{input: 17250 * time.Millisecond, expected: time.Millisecond * 15000},
+		{input: 23000 * time.Millisecond, expected: time.Millisecond * 20000},
+		{input: 42000 * time.Millisecond, expected: time.Millisecond * 30000},
+		{input: 85000 * time.Millisecond, expected: time.Millisecond * 60000},
+		{input: 200000 * time.Millisecond, expected: time.Millisecond * 120000},
+		{input: 420000 * time.Millisecond, expected: time.Millisecond * 300000},
+		{input: 720000 * time.Millisecond, expected: time.Millisecond * 600000},
+		{input: 1000000 * time.Millisecond, expected: time.Millisecond * 900000},
+		{input: 1250000 * time.Millisecond, expected: time.Millisecond * 1200000},
+		{input: 2500000 * time.Millisecond, expected: time.Millisecond * 1800000},
+		{input: 5200000 * time.Millisecond, expected: time.Millisecond * 3600000},
+		{input: 8500000 * time.Millisecond, expected: time.Millisecond * 7200000},
+		{input: 15000000 * time.Millisecond, expected: time.Millisecond * 10800000},
+		{input: 30000000 * time.Millisecond, expected: time.Millisecond * 21600000},
+		{input: 85000000 * time.Millisecond, expected: time.Millisecond * 43200000},
+		{input: 150000000 * time.Millisecond, expected: time.Millisecond * 86400000},
+		{input: 600000000 * time.Millisecond, expected: time.Millisecond * 86400000},
+		{input: 1500000000 * time.Millisecond, expected: time.Millisecond * 604800000},
+		{input: 3500000000 * time.Millisecond, expected: time.Millisecond * 2592000000},
+		{input: 40000000000 * time.Millisecond, expected: time.Millisecond * 31536000000},
+	}
+	for i, tc := range tcs {
+		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {
+			res := RoundInterval(tc.input)
+			require.Equal(t, tc.expected, res, "input %q", tc.input)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the part of decoupling intervalv2 package. 
For more information and context you can read this amazing (but long) post https://raintank-corp.slack.com/archives/C05QFJUHUQ6/p1700064431005089

Previously I moved some of its functions here: https://github.com/grafana/grafana-plugin-sdk-go/pull/886

I decided to move this utility function here since `intervalv2.Calculator` methods are using it. And Calculator is being used by `prometheus`, `azuremonitor`, `cloud-monitoring` and `public-dashboards`. Each of them (except public-dashboards) created a copy of intervalv2. That creates too many code duplication. 

I don't want to move `Calculator` itself here because I think it is special to each datasource. So each datasource can treat it as they want. But `roundInterval` function is a utility and duplicating it in multiple places creates pollution. I believe having it in `grafana-plugin-sdk-go` and using it from there is a much more cleaner approach. 

After having it here I'll go ahead and do the house keeping.
- removing intervalv2 package
- copy the necessary code in public dashboards
- remove redundant code from other datasources and use `gtime` functions
  - Removing from Prometheus: https://github.com/grafana/grafana/pull/82064