### PR TITLE
Update codeowners for backend/gtime

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,6 @@
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone opens a pull request.
 * @grafana/plugins-platform-backend
+/backend/gtime @grafana/observability-metrics @grafana/observability-logs @grafana/partner-datasources
 /data/ @grafana/data-plane-wg
 /data/sqlutil @grafana/oss-big-tent


### PR DESCRIPTION
Add @grafana/observability-metrics @grafana/observability-logs @grafana/partner-datasources squads to `backend/gtime`
Context https://github.com/grafana/grafana-plugin-sdk-go/pull/887#issuecomment-1932211582