### PR TITLE
proxy: add method to retrieve a confgured proxy-client

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -285,3 +285,17 @@ func (s *DataSourceInstanceSettings) ProxyOptions(clientCfg *proxy.ClientCfg) (*
 
 	return opts, nil
 }
+
+func (s *DataSourceInstanceSettings) ProxyClient(ctx context.Context) (proxy.Client, error) {
+	cfg := GrafanaConfigFromContext(ctx)
+	p, err := cfg.proxy()
+	if err != nil {
+		return nil, err
+	}
+	proxyOpts, err := s.ProxyOptions(p.clientCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return proxy.New(proxyOpts), nil
+}


### PR DESCRIPTION
this is needed for getting a socks-proxy-enabled dialer in a datasource plugin (when your plugin is not http-based, like sql plugins)