### PR TITLE
enhancement: add all variants of debug builds for cross-compilation

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -215,6 +215,31 @@ func (Build) Debug() error {
 	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
+func (Build) DebugLinuxAMD64() error {
+	cfg := newBuildConfig("linux", "amd64")
+	cfg.EnableDebug = true
+	return buildBackend(cfg)
+}
+func (Build) DebugLinuxARM64() error {
+	cfg := newBuildConfig("linux", "arm64")
+	cfg.EnableDebug = true
+	return buildBackend(cfg)
+}
+func (Build) DebugDarwinAMD64() error {
+	cfg := newBuildConfig("darwin", "amd64")
+	cfg.EnableDebug = true
+	return buildBackend(cfg)
+}
+func (Build) DebugDarwinARM64() error {
+	cfg := newBuildConfig("darwin", "arm64")
+	cfg.EnableDebug = true
+	return buildBackend(cfg)
+}
+func (Build) DebugWindowsAMD64() error {
+	cfg := newBuildConfig("windows", "amd64")
+	cfg.EnableDebug = true
+	return buildBackend(cfg)
+}
 
 // Backend build a production build for the current platform
 func (Build) Backend() error {

--- a/build/common.go
+++ b/build/common.go
@@ -215,26 +215,36 @@ func (Build) Debug() error {
 	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
+
+// DebugLinuxAMD64 builds the debug version targeted for linux on AMD64
 func (Build) DebugLinuxAMD64() error {
 	cfg := newBuildConfig("linux", "amd64")
 	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
+
+// DebugLinuxARM64 builds the debug version targeted for linux on ARM64
 func (Build) DebugLinuxARM64() error {
 	cfg := newBuildConfig("linux", "arm64")
 	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
+
+// DebugDarwinAMD64 builds the debug version targeted for darwin on AMD64
 func (Build) DebugDarwinAMD64() error {
 	cfg := newBuildConfig("darwin", "amd64")
 	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
+
+// DebugDarwinARM64 builds the debug version targeted for darwin on ARM64
 func (Build) DebugDarwinARM64() error {
 	cfg := newBuildConfig("darwin", "arm64")
 	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
+
+// DebugWindowsAMD64 builds the debug version targeted for windows on AMD64
 func (Build) DebugWindowsAMD64() error {
 	cfg := newBuildConfig("windows", "amd64")
 	cfg.EnableDebug = true

--- a/build/common.go
+++ b/build/common.go
@@ -170,12 +170,12 @@ func (Build) Windows() error {
 	return buildBackend(newBuildConfig("windows", "amd64"))
 }
 
-// Darwin builds the back-end plugin for OSX.
+// Darwin builds the back-end plugin for OSX on AMD64.
 func (Build) Darwin() error {
 	return buildBackend(newBuildConfig("darwin", "amd64"))
 }
 
-// DarwinARM64 builds the back-end plugin for OSX on ARM (M1).
+// DarwinARM64 builds the back-end plugin for OSX on ARM (M1/M2).
 func (Build) DarwinARM64() error {
 	return buildBackend(newBuildConfig("darwin", "arm64"))
 }
@@ -209,42 +209,42 @@ func (Build) GenerateManifestFile() error {
 	return nil
 }
 
-// Debug builds the debug version for the current platform
+// Debug builds the debug version for the current platform.
 func (Build) Debug() error {
 	cfg := newBuildConfig(runtime.GOOS, runtime.GOARCH)
 	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
 
-// DebugLinuxAMD64 builds the debug version targeted for linux on AMD64
+// DebugLinuxAMD64 builds the debug version targeted for linux on AMD64.
 func (Build) DebugLinuxAMD64() error {
 	cfg := newBuildConfig("linux", "amd64")
 	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
 
-// DebugLinuxARM64 builds the debug version targeted for linux on ARM64
+// DebugLinuxARM64 builds the debug version targeted for linux on ARM64.
 func (Build) DebugLinuxARM64() error {
 	cfg := newBuildConfig("linux", "arm64")
 	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
 
-// DebugDarwinAMD64 builds the debug version targeted for darwin on AMD64
+// DebugDarwinAMD64 builds the debug version targeted for OSX on AMD64.
 func (Build) DebugDarwinAMD64() error {
 	cfg := newBuildConfig("darwin", "amd64")
 	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
 
-// DebugDarwinARM64 builds the debug version targeted for darwin on ARM64
+// DebugDarwinARM64 builds the debug version targeted for OSX on ARM (M1/M2).
 func (Build) DebugDarwinARM64() error {
 	cfg := newBuildConfig("darwin", "arm64")
 	cfg.EnableDebug = true
 	return buildBackend(cfg)
 }
 
-// DebugWindowsAMD64 builds the debug version targeted for windows on AMD64
+// DebugWindowsAMD64 builds the debug version targeted for windows on AMD64.
 func (Build) DebugWindowsAMD64() error {
 	cfg := newBuildConfig("windows", "amd64")
 	cfg.EnableDebug = true


### PR DESCRIPTION
**What this PR does / why we need it**:

The current `mage` options only allow building a debug version of a plugin for the current os/arch.

This retains the default behavior and adds all other combinations as build options.
