### PR TITLE
plugins: added more config-params to the plugin config

### DIFF
--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -184,3 +184,117 @@ func TestUserAgentFromContext_NoUserAgent(t *testing.T) {
 	require.Equal(t, "0.0.0", result.GrafanaVersion())
 	require.Equal(t, "Grafana/0.0.0 (unknown; unknown)", result.String())
 }
+
+func TestUserFacingDefaultError(t *testing.T) {
+	t.Run("it should return the configured default error message", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{
+			UserFacingDefaultError: "something failed",
+		})
+		v, err := cfg.UserFacingDefaultError()
+		require.NoError(t, err)
+		require.Equal(t, "something failed", v)
+	})
+
+	t.Run("it should return an error if the default error message is missing", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{})
+		_, err := cfg.UserFacingDefaultError()
+		require.Error(t, err)
+	})
+}
+
+func TestSql(t *testing.T) {
+	t.Run("it should return the configured sql default values", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{
+			SQLRowLimit:                      "5",
+			SQLMaxOpenConnsDefault:           "11",
+			SQLMaxIdleConnsDefault:           "22",
+			SQLMaxConnLifetimeSecondsDefault: "33",
+		})
+		v, err := cfg.SQL()
+		require.NoError(t, err)
+		require.Equal(t, int64(5), v.RowLimit)
+		require.Equal(t, 11, v.DefaultMaxOpenConns)
+		require.Equal(t, 22, v.DefaultMaxIdleConns)
+		require.Equal(t, 33, v.DefaultMaxConnLifetimeSeconds)
+	})
+
+	t.Run("it should return an error if any of the defaults is missing", func(t *testing.T) {
+		cfg1 := NewGrafanaCfg(map[string]string{
+			SQLMaxOpenConnsDefault:           "11",
+			SQLMaxIdleConnsDefault:           "22",
+			SQLMaxConnLifetimeSecondsDefault: "33",
+		})
+
+		cfg2 := NewGrafanaCfg(map[string]string{
+			SQLRowLimit:                      "5",
+			SQLMaxIdleConnsDefault:           "22",
+			SQLMaxConnLifetimeSecondsDefault: "33",
+		})
+
+		cfg3 := NewGrafanaCfg(map[string]string{
+			SQLRowLimit:                      "5",
+			SQLMaxOpenConnsDefault:           "11",
+			SQLMaxConnLifetimeSecondsDefault: "33",
+		})
+
+		cfg4 := NewGrafanaCfg(map[string]string{
+			SQLRowLimit:            "5",
+			SQLMaxOpenConnsDefault: "11",
+			SQLMaxIdleConnsDefault: "22",
+		})
+
+		_, err := cfg1.SQL()
+		require.ErrorContains(t, err, "not set")
+
+		_, err = cfg2.SQL()
+		require.ErrorContains(t, err, "not set")
+
+		_, err = cfg3.SQL()
+		require.ErrorContains(t, err, "not set")
+
+		_, err = cfg4.SQL()
+		require.ErrorContains(t, err, "not set")
+	})
+
+	t.Run("it should return an error if any of the defaults is not an integer", func(t *testing.T) {
+		cfg1 := NewGrafanaCfg(map[string]string{
+			SQLRowLimit:                      "not-an-integer",
+			SQLMaxOpenConnsDefault:           "11",
+			SQLMaxIdleConnsDefault:           "22",
+			SQLMaxConnLifetimeSecondsDefault: "33",
+		})
+
+		cfg2 := NewGrafanaCfg(map[string]string{
+			SQLRowLimit:                      "5",
+			SQLMaxOpenConnsDefault:           "11",
+			SQLMaxIdleConnsDefault:           "not-an-integer",
+			SQLMaxConnLifetimeSecondsDefault: "33",
+		})
+
+		cfg3 := NewGrafanaCfg(map[string]string{
+			SQLRowLimit:                      "5",
+			SQLMaxOpenConnsDefault:           "11",
+			SQLMaxIdleConnsDefault:           "not-an-integer",
+			SQLMaxConnLifetimeSecondsDefault: "33",
+		})
+
+		cfg4 := NewGrafanaCfg(map[string]string{
+			SQLRowLimit:                      "5",
+			SQLMaxOpenConnsDefault:           "11",
+			SQLMaxIdleConnsDefault:           "22",
+			SQLMaxConnLifetimeSecondsDefault: "not-an-integer",
+		})
+
+		_, err := cfg1.SQL()
+		require.ErrorContains(t, err, "not a valid integer")
+
+		_, err = cfg2.SQL()
+		require.ErrorContains(t, err, "not a valid integer")
+
+		_, err = cfg3.SQL()
+		require.ErrorContains(t, err, "not a valid integer")
+
+		_, err = cfg4.SQL()
+		require.ErrorContains(t, err, "not a valid integer")
+	})
+}


### PR DESCRIPTION
as part of the decouple-core-plugins effort, the core sql plugins use certain grafana-config-values. to decouple then, we need to add these configs to GrafanaConfig.

( see related grafana-PR: https://github.com/grafana/grafana/pull/82562 that sets these values and consumes them in `mysql`)