### PR TITLE
jsoniter: fix helpers

### DIFF
--- a/data/utils/jsoniter/jsoniter.go
+++ b/data/utils/jsoniter/jsoniter.go
@@ -114,14 +114,17 @@ func (iter *Iterator) Unmarshal(data []byte, v interface{}) error {
 	return ConfigDefault.Unmarshal(data, v)
 }
 
-func (iter *Iterator) Parse(cfg j.API, reader io.Reader, bufSize int) (*Iterator, error) {
-	return &Iterator{j.Parse(cfg, reader, bufSize)}, iter.i.Error
+func Parse(cfg j.API, reader io.Reader, bufSize int) (*Iterator, error) {
+	iter := &Iterator{j.Parse(cfg, reader, bufSize)}
+	return iter, iter.i.Error
 }
 
-func (iter *Iterator) ParseBytes(cfg j.API, input []byte) (*Iterator, error) {
-	return &Iterator{j.ParseBytes(cfg, input)}, iter.i.Error
+func ParseBytes(cfg j.API, input []byte) (*Iterator, error) {
+	iter := &Iterator{j.ParseBytes(cfg, input)}
+	return iter, iter.i.Error
 }
 
-func (iter *Iterator) ParseString(cfg j.API, input string) (*Iterator, error) {
-	return &Iterator{j.ParseString(cfg, input)}, iter.i.Error
+func ParseString(cfg j.API, input string) (*Iterator, error) {
+	iter := &Iterator{j.ParseString(cfg, input)}
+	return iter, iter.i.Error
 }

--- a/data/utils/jsoniter/jsoniter_test.go
+++ b/data/utils/jsoniter/jsoniter_test.go
@@ -36,8 +36,7 @@ func TestRead(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	t.Run("should create a new iterator without any error", func(t *testing.T) {
-		jiter := NewIterator(j.NewIterator(j.ConfigDefault))
-		iter, err := jiter.Parse(ConfigDefault, io.NopCloser(strings.NewReader(`{"test":123}`)), 128)
+		iter, err := Parse(ConfigDefault, io.NopCloser(strings.NewReader(`{"test":123}`)), 128)
 		require.NoError(t, err)
 		require.NotNil(t, iter)
 	})


### PR DESCRIPTION
The current helpers return an error from a different iterator!

This is a breaking change (i guess) but seems easier to use and a quick fix