### PR TITLE
Chore: Add more functions to jsoniter package

### DIFF
--- a/data/utils/jsoniter/jsoniter.go
+++ b/data/utils/jsoniter/jsoniter.go
@@ -22,8 +22,13 @@ const (
 )
 
 var (
-	ConfigDefault = j.ConfigDefault
+	ConfigDefault                       = j.ConfigDefault
+	ConfigCompatibleWithStandardLibrary = j.ConfigCompatibleWithStandardLibrary
 )
+
+type Stream = j.Stream
+type ValEncoder = j.ValEncoder
+type ValDecoder = j.ValDecoder
 
 type Iterator struct {
 	// named property instead of embedded so there is no
@@ -33,6 +38,14 @@ type Iterator struct {
 
 func NewIterator(i *j.Iterator) *Iterator {
 	return &Iterator{i}
+}
+
+func (iter *Iterator) ReadError() error {
+	return iter.i.Error
+}
+
+func (iter *Iterator) SetError(err error) {
+	iter.i.Error = err
 }
 
 func (iter *Iterator) Read() (interface{}, error) {
@@ -49,6 +62,11 @@ func (iter *Iterator) ReadArray() (bool, error) {
 
 func (iter *Iterator) ReadObject() (string, error) {
 	return iter.i.ReadObject(), iter.i.Error
+}
+
+func (iter *Iterator) CanReadArray() bool {
+	ok, err := iter.ReadArray()
+	return ok && err == nil
 }
 
 func (iter *Iterator) ReadString() (string, error) {
@@ -73,12 +91,44 @@ func (iter *Iterator) ReadVal(obj interface{}) error {
 	return iter.i.Error
 }
 
+func (iter *Iterator) ReadFloat32() (float32, error) {
+	return iter.i.ReadFloat32(), iter.i.Error
+}
+
 func (iter *Iterator) ReadFloat64() (float64, error) {
 	return iter.i.ReadFloat64(), iter.i.Error
 }
 
+func (iter *Iterator) ReadInt() (int, error) {
+	return iter.i.ReadInt(), iter.i.Error
+}
+
 func (iter *Iterator) ReadInt8() (int8, error) {
 	return iter.i.ReadInt8(), iter.i.Error
+}
+
+func (iter *Iterator) ReadInt16() (int16, error) {
+	return iter.i.ReadInt16(), iter.i.Error
+}
+
+func (iter *Iterator) ReadInt32() (int32, error) {
+	return iter.i.ReadInt32(), iter.i.Error
+}
+
+func (iter *Iterator) ReadInt64() (int64, error) {
+	return iter.i.ReadInt64(), iter.i.Error
+}
+
+func (iter *Iterator) ReadUint8() (uint8, error) {
+	return iter.i.ReadUint8(), iter.i.Error
+}
+
+func (iter *Iterator) ReadUint16() (uint16, error) {
+	return iter.i.ReadUint16(), iter.i.Error
+}
+
+func (iter *Iterator) ReadUint32() (uint32, error) {
+	return iter.i.ReadUint32(), iter.i.Error
 }
 
 func (iter *Iterator) ReadUint64() (uint64, error) {
@@ -127,4 +177,12 @@ func ParseBytes(cfg j.API, input []byte) (*Iterator, error) {
 func ParseString(cfg j.API, input string) (*Iterator, error) {
 	iter := &Iterator{j.ParseString(cfg, input)}
 	return iter, iter.i.Error
+}
+
+func RegisterTypeEncoder(typ string, encoder ValEncoder) {
+	j.RegisterTypeEncoder(typ, encoder)
+}
+
+func RegisterTypeDecoder(typ string, decoder ValDecoder) {
+	j.RegisterTypeDecoder(typ, decoder)
 }

--- a/data/utils/jsoniter/jsoniter_test.go
+++ b/data/utils/jsoniter/jsoniter_test.go
@@ -1,31 +1,36 @@
-package jsoniter
+package jsoniter_test
 
 import (
+	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	j "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	sdkjsoniter "github.com/grafana/grafana-plugin-sdk-go/data/utils/jsoniter"
 )
 
 func TestNewIterator(t *testing.T) {
 	iter := j.NewIterator(j.ConfigDefault)
-	jiter := NewIterator(iter)
+	jiter := sdkjsoniter.NewIterator(iter)
 	require.NotNil(t, jiter)
 }
 
 func TestRead(t *testing.T) {
 	t.Run("should be able read the error", func(t *testing.T) {
-		jiter := NewIterator(j.NewIterator(j.ConfigDefault))
+		jiter := sdkjsoniter.NewIterator(j.NewIterator(j.ConfigDefault))
 		read, err := jiter.Read()
 		require.Error(t, err)
 		require.Nil(t, read)
 	})
 
 	t.Run("should be able read the json data", func(t *testing.T) {
-		iter := j.Parse(ConfigDefault, io.NopCloser(strings.NewReader(`{"test":123}`)), 128)
-		jiter := NewIterator(iter)
+		iter := j.Parse(sdkjsoniter.ConfigDefault, io.NopCloser(strings.NewReader(`{"test":123}`)), 128)
+		jiter := sdkjsoniter.NewIterator(iter)
 		read, err := jiter.Read()
 		require.NoError(t, err)
 		require.NotNil(t, read)
@@ -36,8 +41,24 @@ func TestRead(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	t.Run("should create a new iterator without any error", func(t *testing.T) {
-		iter, err := Parse(ConfigDefault, io.NopCloser(strings.NewReader(`{"test":123}`)), 128)
+		iter, err := sdkjsoniter.Parse(sdkjsoniter.ConfigDefault, io.NopCloser(strings.NewReader(`{"test":123}`)), 128)
 		require.NoError(t, err)
 		require.NotNil(t, iter)
 	})
+}
+
+func TestMarshalUnmarshal(t *testing.T) {
+	qdr := &backend.QueryDataResponse{
+		Responses: backend.Responses{
+			"A": {
+				Status: 400,
+				Error:  errors.New("test"),
+			},
+		},
+	}
+	resp, err := json.Marshal(qdr)
+	require.NoError(t, err)
+	qdr2 := &backend.QueryDataResponse{}
+	require.NoError(t, json.Unmarshal(resp, qdr2))
+	require.Equal(t, qdr, qdr2)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is just adding necessary functions to the `jsoniter` package.
This was done by https://github.com/grafana/grafana-plugin-sdk-go/pull/841
But unfortunately it was [reverted](https://github.com/grafana/grafana-plugin-sdk-go/pull/878) due to issues: https://raintank-corp.slack.com/archives/CMSUYD6H3/p1706642169777429

So here I am adding only functions and unit tests without changing any logic in existing code. The rest of the changes will be done after merging this PR.  
