### PR TITLE
feat(explore): let plugins define the height of the panels when rende..

### DIFF
--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -46,7 +46,7 @@ type FrameMeta struct {
 	PreferredVisualizationPluginID string `json:"preferredVisualisationPluginId,omitempty"`
 
 	// PreferredVisualizationPanelHeight sets the panel height when rendering in Explore.
-	PreferredVisualizationPanelHeight int `json:"preferredVisualizationPanelHeight,omitempty"`
+	PreferredVisualizationPanelHeight int `json:"preferredVisualisationPanelHeight,omitempty"`
 
 	// ExecutedQueryString is the raw query sent to the underlying system. All macros and templating
 	// have been applied.  When metadata contains this value, it will be shown in the query inspector.

--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -41,9 +41,12 @@ type FrameMeta struct {
 	// PreferredVisualization is currently used to show results in Explore only in preferred visualisation option.
 	PreferredVisualization VisType `json:"preferredVisualisationType,omitempty"`
 
-	// PreferredVisualizationPluginId sets the panel plugin id to use to render the data when using Explore. If
+	// PreferredVisualizationPluginID sets the panel plugin id to use to render the data when using Explore. If
 	// the plugin cannot be found will fall back to PreferredVisualization.
 	PreferredVisualizationPluginID string `json:"preferredVisualisationPluginId,omitempty"`
+
+	// PreferredVisualizationPanelHeight sets the panel height when rendering in Explore.
+	PreferredVisualizationPanelHeight int `json:"preferredVisualizationPanelHeight,omitempty"`
 
 	// ExecutedQueryString is the raw query sent to the underlying system. All macros and templating
 	// have been applied.  When metadata contains this value, it will be shown in the query inspector.


### PR DESCRIPTION
…red in explore


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

This adds the field `PreferredVisualizationPanelHeight` to let plugins set the panel height in explore.

related to https://github.com/grafana/grafana/pull/83249

**Special notes for your reviewer**:
