### PR TITLE
Introduce maputil

### DIFF
--- a/data/utils/maputil/maputil.go
+++ b/data/utils/maputil/maputil.go
@@ -1,0 +1,73 @@
+package maputil
+
+import "fmt"
+
+func GetMap(obj map[string]any, key string) (map[string]any, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(map[string]any); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be an object", key)
+			return nil, err
+		}
+	} else {
+		err := fmt.Errorf("the field '%s' should be set", key)
+		return nil, err
+	}
+}
+
+func GetBool(obj map[string]any, key string) (bool, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(bool); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be a bool", key)
+			return false, err
+		}
+	} else {
+		err := fmt.Errorf("the field '%s' should be set", key)
+		return false, err
+	}
+}
+
+func GetBoolOptional(obj map[string]any, key string) (bool, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(bool); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be a bool", key)
+			return false, err
+		}
+	} else {
+		// Value optional, not error
+		return false, nil
+	}
+}
+
+func GetString(obj map[string]any, key string) (string, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(string); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be a string", key)
+			return "", err
+		}
+	} else {
+		err := fmt.Errorf("the field '%s' should be set", key)
+		return "", err
+	}
+}
+
+func GetStringOptional(obj map[string]any, key string) (string, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(string); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be a string", key)
+			return "", err
+		}
+	} else {
+		// Value optional, not error
+		return "", nil
+	}
+}

--- a/data/utils/maputil/maputil.go
+++ b/data/utils/maputil/maputil.go
@@ -16,6 +16,20 @@ func GetMap(obj map[string]any, key string) (map[string]any, error) {
 	}
 }
 
+func GetMapOptional(obj map[string]any, key string) (map[string]any, error) {
+	if untypedValue, ok := obj[key]; ok {
+		if value, ok := untypedValue.(map[string]any); ok {
+			return value, nil
+		} else {
+			err := fmt.Errorf("the field '%s' should be an object", key)
+			return nil, err
+		}
+	} else {
+		// Value optional, not error
+		return nil, nil
+	}
+}
+
 func GetBool(obj map[string]any, key string) (bool, error) {
 	if untypedValue, ok := obj[key]; ok {
 		if value, ok := untypedValue.(bool); ok {

--- a/data/utils/maputil/maputil.go
+++ b/data/utils/maputil/maputil.go
@@ -10,10 +10,10 @@ func GetMap(obj map[string]any, key string) (map[string]any, error) {
 			err := fmt.Errorf("the field '%s' should be an object", key)
 			return nil, err
 		}
-	} else {
-		err := fmt.Errorf("the field '%s' should be set", key)
-		return nil, err
 	}
+
+	err := fmt.Errorf("the field '%s' should be set", key)
+	return nil, err
 }
 
 func GetMapOptional(obj map[string]any, key string) (map[string]any, error) {
@@ -24,10 +24,10 @@ func GetMapOptional(obj map[string]any, key string) (map[string]any, error) {
 			err := fmt.Errorf("the field '%s' should be an object", key)
 			return nil, err
 		}
-	} else {
-		// Value optional, not error
-		return nil, nil
 	}
+
+	// Value optional, not error
+	return nil, nil
 }
 
 func GetBool(obj map[string]any, key string) (bool, error) {
@@ -38,10 +38,10 @@ func GetBool(obj map[string]any, key string) (bool, error) {
 			err := fmt.Errorf("the field '%s' should be a bool", key)
 			return false, err
 		}
-	} else {
-		err := fmt.Errorf("the field '%s' should be set", key)
-		return false, err
 	}
+
+	err := fmt.Errorf("the field '%s' should be set", key)
+	return false, err
 }
 
 func GetBoolOptional(obj map[string]any, key string) (bool, error) {
@@ -52,10 +52,10 @@ func GetBoolOptional(obj map[string]any, key string) (bool, error) {
 			err := fmt.Errorf("the field '%s' should be a bool", key)
 			return false, err
 		}
-	} else {
-		// Value optional, not error
-		return false, nil
 	}
+
+	// Value optional, not error
+	return false, nil
 }
 
 func GetString(obj map[string]any, key string) (string, error) {
@@ -66,10 +66,10 @@ func GetString(obj map[string]any, key string) (string, error) {
 			err := fmt.Errorf("the field '%s' should be a string", key)
 			return "", err
 		}
-	} else {
-		err := fmt.Errorf("the field '%s' should be set", key)
-		return "", err
 	}
+
+	err := fmt.Errorf("the field '%s' should be set", key)
+	return "", err
 }
 
 func GetStringOptional(obj map[string]any, key string) (string, error) {
@@ -80,8 +80,8 @@ func GetStringOptional(obj map[string]any, key string) (string, error) {
 			err := fmt.Errorf("the field '%s' should be a string", key)
 			return "", err
 		}
-	} else {
-		// Value optional, not error
-		return "", nil
 	}
+
+	// Value optional, not error
+	return "", nil
 }

--- a/data/utils/maputil/maputil.go
+++ b/data/utils/maputil/maputil.go
@@ -6,10 +6,9 @@ func GetMap(obj map[string]any, key string) (map[string]any, error) {
 	if untypedValue, ok := obj[key]; ok {
 		if value, ok := untypedValue.(map[string]any); ok {
 			return value, nil
-		} else {
-			err := fmt.Errorf("the field '%s' should be an object", key)
-			return nil, err
 		}
+		err := fmt.Errorf("the field '%s' should be an object", key)
+		return nil, err
 	}
 
 	err := fmt.Errorf("the field '%s' should be set", key)
@@ -20,10 +19,9 @@ func GetMapOptional(obj map[string]any, key string) (map[string]any, error) {
 	if untypedValue, ok := obj[key]; ok {
 		if value, ok := untypedValue.(map[string]any); ok {
 			return value, nil
-		} else {
-			err := fmt.Errorf("the field '%s' should be an object", key)
-			return nil, err
 		}
+		err := fmt.Errorf("the field '%s' should be an object", key)
+		return nil, err
 	}
 
 	// Value optional, not error
@@ -34,10 +32,9 @@ func GetBool(obj map[string]any, key string) (bool, error) {
 	if untypedValue, ok := obj[key]; ok {
 		if value, ok := untypedValue.(bool); ok {
 			return value, nil
-		} else {
-			err := fmt.Errorf("the field '%s' should be a bool", key)
-			return false, err
 		}
+		err := fmt.Errorf("the field '%s' should be a bool", key)
+		return false, err
 	}
 
 	err := fmt.Errorf("the field '%s' should be set", key)
@@ -48,10 +45,9 @@ func GetBoolOptional(obj map[string]any, key string) (bool, error) {
 	if untypedValue, ok := obj[key]; ok {
 		if value, ok := untypedValue.(bool); ok {
 			return value, nil
-		} else {
-			err := fmt.Errorf("the field '%s' should be a bool", key)
-			return false, err
 		}
+		err := fmt.Errorf("the field '%s' should be a bool", key)
+		return false, err
 	}
 
 	// Value optional, not error
@@ -62,10 +58,9 @@ func GetString(obj map[string]any, key string) (string, error) {
 	if untypedValue, ok := obj[key]; ok {
 		if value, ok := untypedValue.(string); ok {
 			return value, nil
-		} else {
-			err := fmt.Errorf("the field '%s' should be a string", key)
-			return "", err
 		}
+		err := fmt.Errorf("the field '%s' should be a string", key)
+		return "", err
 	}
 
 	err := fmt.Errorf("the field '%s' should be set", key)
@@ -76,10 +71,9 @@ func GetStringOptional(obj map[string]any, key string) (string, error) {
 	if untypedValue, ok := obj[key]; ok {
 		if value, ok := untypedValue.(string); ok {
 			return value, nil
-		} else {
-			err := fmt.Errorf("the field '%s' should be a string", key)
-			return "", err
 		}
+		err := fmt.Errorf("the field '%s' should be a string", key)
+		return "", err
 	}
 
 	// Value optional, not error

--- a/data/utils/maputil/maputil_test.go
+++ b/data/utils/maputil/maputil_test.go
@@ -1,0 +1,296 @@
+package maputil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetMap(t *testing.T) {
+	tests := []struct {
+		name           string
+		obj            map[string]interface{}
+		key            string
+		expectedResult map[string]interface{}
+		expectedError  string
+	}{
+		{
+			name: "ExistingKey",
+			obj: map[string]interface{}{
+				"key1": map[string]interface{}{
+					"innerKey": "value",
+				},
+			},
+			key:            "key1",
+			expectedResult: map[string]interface{}{"innerKey": "value"},
+			expectedError:  "",
+		},
+		{
+			name:           "NonExistingKey",
+			obj:            map[string]interface{}{},
+			key:            "key1",
+			expectedResult: nil,
+			expectedError:  "the field 'key1' should be set",
+		},
+		{
+			name: "InvalidType",
+			obj: map[string]interface{}{
+				"key1": "not an object",
+			},
+			key:            "key1",
+			expectedResult: nil,
+			expectedError:  "the field 'key1' should be an object",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetMap(tt.obj, tt.key)
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("expected error '%s' but got nil", tt.expectedError)
+				} else if err.Error() != tt.expectedError {
+					t.Errorf("expected error '%s' but got '%s'", tt.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %s", err)
+				}
+
+				if !reflect.DeepEqual(result, tt.expectedResult) {
+					t.Errorf("expected %v but got %v", tt.expectedResult, result)
+				}
+			}
+		})
+	}
+}
+
+func TestGetBool(t *testing.T) {
+	tests := []struct {
+		name           string
+		obj            map[string]interface{}
+		key            string
+		expectedResult bool
+		expectedError  string
+	}{
+		{
+			name:           "ExistingKeyTrue",
+			obj:            map[string]interface{}{"key1": true},
+			key:            "key1",
+			expectedResult: true,
+			expectedError:  "",
+		},
+		{
+			name:           "ExistingKeyFalse",
+			obj:            map[string]interface{}{"key1": false},
+			key:            "key1",
+			expectedResult: false,
+			expectedError:  "",
+		},
+		{
+			name:           "NonExistingKey",
+			obj:            map[string]interface{}{},
+			key:            "key1",
+			expectedResult: false,
+			expectedError:  "the field 'key1' should be set",
+		},
+		{
+			name:           "InvalidType",
+			obj:            map[string]interface{}{"key1": "not a bool"},
+			key:            "key1",
+			expectedResult: false,
+			expectedError:  "the field 'key1' should be a bool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetBool(tt.obj, tt.key)
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("expected error '%s' but got nil", tt.expectedError)
+				} else if err.Error() != tt.expectedError {
+					t.Errorf("expected error '%s' but got '%s'", tt.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %s", err)
+				}
+
+				if result != tt.expectedResult {
+					t.Errorf("expected %v but got %v", tt.expectedResult, result)
+				}
+			}
+		})
+	}
+}
+
+func TestGetBoolOptional(t *testing.T) {
+	tests := []struct {
+		name           string
+		obj            map[string]interface{}
+		key            string
+		expectedResult bool
+		expectedError  string
+	}{
+		{
+			name:           "ExistingKeyTrue",
+			obj:            map[string]interface{}{"key1": true},
+			key:            "key1",
+			expectedResult: true,
+			expectedError:  "",
+		},
+		{
+			name:           "ExistingKeyFalse",
+			obj:            map[string]interface{}{"key1": false},
+			key:            "key1",
+			expectedResult: false,
+			expectedError:  "",
+		},
+		{
+			name:           "NonExistingKey",
+			obj:            map[string]interface{}{},
+			key:            "key1",
+			expectedResult: false,
+			expectedError:  "",
+		},
+		{
+			name:           "InvalidType",
+			obj:            map[string]interface{}{"key1": "not a bool"},
+			key:            "key1",
+			expectedResult: false,
+			expectedError:  "the field 'key1' should be a bool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetBoolOptional(tt.obj, tt.key)
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("expected error '%s' but got nil", tt.expectedError)
+				} else if err.Error() != tt.expectedError {
+					t.Errorf("expected error '%s' but got '%s'", tt.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %s", err)
+				}
+
+				if result != tt.expectedResult {
+					t.Errorf("expected %v but got %v", tt.expectedResult, result)
+				}
+			}
+		})
+	}
+}
+
+func TestGetString(t *testing.T) {
+	tests := []struct {
+		name           string
+		obj            map[string]interface{}
+		key            string
+		expectedResult string
+		expectedError  string
+	}{
+		{
+			name:           "ExistingKey",
+			obj:            map[string]interface{}{"key1": "value"},
+			key:            "key1",
+			expectedResult: "value",
+			expectedError:  "",
+		},
+		{
+			name:           "NonExistingKey",
+			obj:            map[string]interface{}{},
+			key:            "key1",
+			expectedResult: "",
+			expectedError:  "the field 'key1' should be set",
+		},
+		{
+			name:           "InvalidType",
+			obj:            map[string]interface{}{"key1": 123},
+			key:            "key1",
+			expectedResult: "",
+			expectedError:  "the field 'key1' should be a string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetString(tt.obj, tt.key)
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("expected error '%s' but got nil", tt.expectedError)
+				} else if err.Error() != tt.expectedError {
+					t.Errorf("expected error '%s' but got '%s'", tt.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %s", err)
+				}
+
+				if result != tt.expectedResult {
+					t.Errorf("expected %v but got %v", tt.expectedResult, result)
+				}
+			}
+		})
+	}
+}
+
+func TestGetStringOptional(t *testing.T) {
+	tests := []struct {
+		name           string
+		obj            map[string]interface{}
+		key            string
+		expectedResult string
+		expectedError  string
+	}{
+		{
+			name:           "ExistingKey",
+			obj:            map[string]interface{}{"key1": "value"},
+			key:            "key1",
+			expectedResult: "value",
+			expectedError:  "",
+		},
+		{
+			name:           "NonExistingKey",
+			obj:            map[string]interface{}{},
+			key:            "key1",
+			expectedResult: "",
+			expectedError:  "",
+		},
+		{
+			name:           "InvalidType",
+			obj:            map[string]interface{}{"key1": 123},
+			key:            "key1",
+			expectedResult: "",
+			expectedError:  "the field 'key1' should be a string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetStringOptional(tt.obj, tt.key)
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("expected error '%s' but got nil", tt.expectedError)
+				} else if err.Error() != tt.expectedError {
+					t.Errorf("expected error '%s' but got '%s'", tt.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %s", err)
+				}
+
+				if result != tt.expectedResult {
+					t.Errorf("expected %v but got %v", tt.expectedResult, result)
+				}
+			}
+		})
+	}
+}

--- a/data/utils/maputil/maputil_test.go
+++ b/data/utils/maputil/maputil_test.go
@@ -65,6 +65,64 @@ func TestGetMap(t *testing.T) {
 	}
 }
 
+func TestGetMapOptional(t *testing.T) {
+	tests := []struct {
+		name           string
+		obj            map[string]interface{}
+		key            string
+		expectedResult map[string]interface{}
+		expectedError  string
+	}{
+		{
+			name: "ExistingKeyMap",
+			obj: map[string]interface{}{
+				"key1": map[string]interface{}{
+					"innerKey": "value",
+				},
+			},
+			key:            "key1",
+			expectedResult: map[string]interface{}{"innerKey": "value"},
+			expectedError:  "",
+		},
+		{
+			name:           "ExistingKeyNonMap",
+			obj:            map[string]interface{}{"key1": "not an object"},
+			key:            "key1",
+			expectedResult: nil,
+			expectedError:  "the field 'key1' should be an object",
+		},
+		{
+			name:           "NonExistingKey",
+			obj:            map[string]interface{}{},
+			key:            "key1",
+			expectedResult: nil,
+			expectedError:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetMapOptional(tt.obj, tt.key)
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("expected error '%s' but got nil", tt.expectedError)
+				} else if err.Error() != tt.expectedError {
+					t.Errorf("expected error '%s' but got '%s'", tt.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %s", err)
+				}
+
+				if !reflect.DeepEqual(result, tt.expectedResult) {
+					t.Errorf("expected %v but got %v", tt.expectedResult, result)
+				}
+			}
+		})
+	}
+}
+
 func TestGetBool(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
**What this PR does / why we need it**:

moving `maputil` from grafana/grafana.
https://github.com/grafana/grafana/blob/025b2f3011821bb7e6ab4781e252f3a1ecd19130/pkg/util/maputil/maputil.go

Also `grafana-azure-sdk-go` [has it](https://github.com/grafana/grafana-azure-sdk-go/tree/main/util/maputil). With this in place azure and future promlib can use it from `grafana-plugin-sdk-go`.

