### PR TITLE
backend/log: Add an "Off" log level and support dynamic log levels.

### DIFF
--- a/backend/log/log.go
+++ b/backend/log/log.go
@@ -16,6 +16,7 @@ const (
 	Info
 	Warn
 	Error
+	Off
 )
 
 // Logger is the main Logger interface.
@@ -27,9 +28,11 @@ type Logger interface {
 	With(args ...interface{}) Logger
 	Level() Level
 	FromContext(ctx context.Context) Logger
+
+	SetLevel(level Level)
 }
 
-// New creates a new logger.
+// New creates a new logger with the Debug level.
 func New() Logger {
 	return NewWithLevel(Debug)
 }
@@ -38,7 +41,6 @@ func New() Logger {
 func NewWithLevel(level Level) Logger {
 	return &hclogWrapper{
 		logger: hclog.New(&hclog.LoggerOptions{
-			// Use debug as level since anything less severe is suppressed.
 			Level: hclog.Level(level),
 			// Use JSON format to make the output in Grafana format and work
 			// when using multiple arguments such as Debug("message", "key", "value").
@@ -91,6 +93,10 @@ func (l *hclogWrapper) Level() Level {
 		return Error
 	}
 	return NoLevel
+}
+
+func (l *hclogWrapper) SetLevel(level Level) {
+	l.logger.SetLevel(hclog.Level(level))
 }
 
 // With creates a sub-logger that will always have the given key/value pairs.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an "Off" log level, and adds the ability to dynamically change the level of an existing logger. The "Off" log level is useful for cleaning up test output when logging isn't needed, or as an emergency fix to stop logging sensitive data quickly. Dynamic log level support is also required for that capability.

Being able to dynamically change the logging level means that re-initialization of systems that share a logger isn't required when the logging level needs to change.