### PR TITLE
socks proxy: check context done before trying to dial

### DIFF
--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -305,7 +305,7 @@ func (d *instrumentedSocksDialer) Dial(network, addr string) (net.Conn, error) {
 // DialContext -
 func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr string) (net.Conn, error) {
 	if ctx.Err() != nil {
-		log.DefaultLogger.Debug("context cancelled, returning context error")
+		log.DefaultLogger.Debug("context cancelled or deadline exceeded, returning context error")
 		return nil, ctx.Err()
 	}
 

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -304,6 +304,11 @@ func (d *instrumentedSocksDialer) Dial(network, addr string) (net.Conn, error) {
 
 // DialContext -
 func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr string) (net.Conn, error) {
+	if ctx.Err() != nil {
+		log.DefaultLogger.Debug("context cancelled, returning context error")
+		return nil, ctx.Err()
+	}
+
 	start := time.Now()
 	dialer, ok := d.dialer.(proxy.ContextDialer)
 	if !ok {

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -1,14 +1,17 @@
 package proxy
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/fs"
 	"math/big"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/proxy"
 )
 
 func TestNewSecureSocksProxyContextDialerInsecureProxy(t *testing.T) {
@@ -383,4 +387,77 @@ func setupTestSecureSocksProxySettings(t *testing.T) *ClientCfg {
 	}
 
 	return cfg
+}
+
+// fakeConn implements proxy.Dialer and proxy.ContextDialer
+type fakeConn struct {
+	net.Conn
+	err error
+}
+
+func (fc fakeConn) Dial(network, addr string) (c net.Conn, err error) {
+	if fc.err != nil {
+		return nil, fc.err
+	}
+	return fc, nil
+}
+
+func (fc fakeConn) DialContext(ctx context.Context, network, addr string) (c net.Conn, err error) {
+	if fc.err != nil {
+		return nil, fc.err
+	}
+	return fc, nil
+}
+
+func (fc *fakeConn) withError(e error) {
+	fc.err = e
+}
+
+func TestInstrumentedSocksDialer(t *testing.T) {
+	t.Parallel()
+	t.Run("returns context err if context is done", func(t *testing.T) {
+		t.Parallel()
+		md := fakeConn{}
+		d := newInstrumentedSocksDialer(md, "name", "type")
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cancel(errors.New("my custom error"))
+
+		cd, ok := d.(proxy.ContextDialer)
+		require.True(t, ok)
+
+		c, err := cd.DialContext(ctx, "n", "addr")
+		assert.Nil(t, c)
+		assert.NotNil(t, err)
+		assert.Equal(t, "context canceled", err.Error())
+		assert.Equal(t, "my custom error", context.Cause(ctx).Error())
+	})
+
+	t.Run("returns conn if no error given", func(t *testing.T) {
+		t.Parallel()
+		md := fakeConn{}
+		d := newInstrumentedSocksDialer(md, "name", "type")
+
+		cd, ok := d.(proxy.ContextDialer)
+		require.True(t, ok)
+
+		c, err := cd.DialContext(context.Background(), "n", "addr")
+		assert.Nil(t, err)
+		assert.NotNil(t, c)
+	})
+
+	t.Run("returns error if dialer errors", func(t *testing.T) {
+		t.Parallel()
+		md := fakeConn{}
+		md.withError(errors.New("custom error"))
+		d := newInstrumentedSocksDialer(md, "name", "type")
+
+		cd, ok := d.(proxy.ContextDialer)
+		require.True(t, ok)
+
+		c, err := cd.DialContext(context.Background(), "n", "addr")
+		assert.Nil(t, c)
+		assert.NotNil(t, err)
+		assert.Equal(t, "custom error", err.Error())
+	})
 }

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -395,14 +395,14 @@ type fakeConn struct {
 	err error
 }
 
-func (fc fakeConn) Dial(network, addr string) (c net.Conn, err error) {
+func (fc fakeConn) Dial(_, _ string) (c net.Conn, err error) {
 	if fc.err != nil {
 		return nil, fc.err
 	}
 	return fc, nil
 }
 
-func (fc fakeConn) DialContext(ctx context.Context, network, addr string) (c net.Conn, err error) {
+func (fc fakeConn) DialContext(_ context.Context, _, _ string) (c net.Conn, err error) {
 	if fc.err != nil {
 		return nil, fc.err
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

We see a lot of `context_canceled` and `io_timeout` opErrors from the [socks proxy dialer](https://github.com/grafana/grafana-plugin-sdk-go/blob/main/backend/proxy/secure_socks_proxy.go#L306), even when requests are succeeding.

One simple change we can make to improve this is to check the context.Err response before trying to dial. This will stop us getting opErrors  in the case where the context is already done.

Looking at our metrics for this, the majority of `context_canceled` errors for example return within 10ms of the function starting.

**Which issue(s) this PR fixes**:

Constributes to https://github.com/grafana/hosted-grafana/issues/5341


**Special notes for your reviewer**:
