### PR TITLE
Add backwards compatibility for reading PDC info as file paths

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -126,8 +126,11 @@ func (c *GrafanaCfg) proxy() (Proxy, error) {
 		return Proxy{
 			clientCfg: &proxy.ClientCfg{
 				ClientCert:    c.Get(proxy.PluginSecureSocksProxyClientCert),
+				ClientCertVal: c.Get(proxy.PluginSecureSocksProxyClientCertContents),
 				ClientKey:     c.Get(proxy.PluginSecureSocksProxyClientKey),
-				RootCAs:       strings.Split(c.Get(proxy.PluginSecureSocksProxyRootCAs), ","),
+				ClientKeyVal:  c.Get(proxy.PluginSecureSocksProxyClientKeyContents),
+				RootCAs:       strings.Split(c.Get(proxy.PluginSecureSocksProxyRootCAs), " "),
+				RootCAsVals:   strings.Split(c.Get(proxy.PluginSecureSocksProxyRootCAsContents), ","),
 				ProxyAddress:  c.Get(proxy.PluginSecureSocksProxyProxyAddress),
 				ServerName:    c.Get(proxy.PluginSecureSocksProxyServerName),
 				AllowInsecure: allowInsecure,

--- a/backend/config.go
+++ b/backend/config.go
@@ -123,6 +123,11 @@ func (c *GrafanaCfg) proxy() (Proxy, error) {
 			}
 		}
 
+		var rootCaVals []string
+		if v = c.Get(proxy.PluginSecureSocksProxyRootCAsContents); v != "" {
+			rootCaVals = strings.Split(c.Get(proxy.PluginSecureSocksProxyRootCAsContents), ",")
+		}
+
 		return Proxy{
 			clientCfg: &proxy.ClientCfg{
 				ClientCert:    c.Get(proxy.PluginSecureSocksProxyClientCert),
@@ -130,7 +135,7 @@ func (c *GrafanaCfg) proxy() (Proxy, error) {
 				ClientKey:     c.Get(proxy.PluginSecureSocksProxyClientKey),
 				ClientKeyVal:  c.Get(proxy.PluginSecureSocksProxyClientKeyContents),
 				RootCAs:       strings.Split(c.Get(proxy.PluginSecureSocksProxyRootCAs), " "),
-				RootCAsVals:   strings.Split(c.Get(proxy.PluginSecureSocksProxyRootCAsContents), ","),
+				RootCAsVals:   rootCaVals,
 				ProxyAddress:  c.Get(proxy.PluginSecureSocksProxyProxyAddress),
 				ServerName:    c.Get(proxy.PluginSecureSocksProxyServerName),
 				AllowInsecure: allowInsecure,

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -134,6 +134,36 @@ func TestConfig(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "feature toggles disabled and secure proxy enabled with file contents",
+				cfg: NewGrafanaCfg(map[string]string{
+					featuretoggles.EnabledFeatures:                 "",
+					proxy.PluginSecureSocksProxyEnabled:            "true",
+					proxy.PluginSecureSocksProxyProxyAddress:       "localhost:1234",
+					proxy.PluginSecureSocksProxyServerName:         "localhost",
+					proxy.PluginSecureSocksProxyClientKey:          "./clientKey",
+					proxy.PluginSecureSocksProxyClientCert:         "./clientCert",
+					proxy.PluginSecureSocksProxyRootCAs:            "./rootCACert ./rootCACert2",
+					proxy.PluginSecureSocksProxyClientKeyContents:  "clientKey",
+					proxy.PluginSecureSocksProxyClientCertContents: "clientCert",
+					proxy.PluginSecureSocksProxyRootCAsContents:    "rootCACert,rootCACert2",
+					proxy.PluginSecureSocksProxyAllowInsecure:      "true",
+				}),
+				expectedFeatureToggles: FeatureToggles{},
+				expectedProxy: Proxy{
+					clientCfg: &proxy.ClientCfg{
+						ClientCert:    "./clientCert",
+						ClientCertVal: "clientCert",
+						ClientKey:     "./clientKey",
+						ClientKeyVal:  "clientKey",
+						RootCAs:       []string{"./rootCACert", "./rootCACert2"},
+						RootCAsVals:   []string{"rootCACert", "rootCACert2"},
+						ProxyAddress:  "localhost:1234",
+						ServerName:    "localhost",
+						AllowInsecure: true,
+					},
+				},
+			},
 		}
 
 		for _, tc := range tcs {

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -192,6 +192,7 @@ func (p *cfgProxyWrapper) getTLSDialer() (*tls.Dialer, error) {
 }
 
 // Deprecated: getTLSDialerFromFiles is a helper function that creates a tls.Dialer from the client cert, client key, and root CA files on disk.
+// As of Grafana 11 we are moving to using the root CA and client cert/key values instead of files.
 func (p *cfgProxyWrapper) getTLSDialerFromFiles() (*tls.Dialer, error) {
 	certPool := x509.NewCertPool()
 	for _, rootCAFile := range p.opts.ClientCfg.RootCAs {

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -52,11 +52,15 @@ type Client interface {
 // ClientCfg contains the information needed to allow datasource connections to be
 // proxied to a secure socks proxy.
 type ClientCfg struct {
-	ClientCert    string
+	// Deprecated: ClientCert is the file path to the client certificate.
+	ClientCert string
+	// Deprecated: ClientKey is the file path to the client key.
+	ClientKey string
+	// Deprecated: RootCAs is a list of file paths to the root CA certificates.
+	RootCAs []string
+
 	ClientCertVal string
-	ClientKey     string
 	ClientKeyVal  string
-	RootCAs       []string
 	RootCAsVals   []string
 	ProxyAddress  string
 	ServerName    string

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -143,7 +143,6 @@ func TestNewSecureSocksProxyContextDialer_SupportsFilePathAndContents(t *testing
 			Enabled:  true,
 			Timeouts: &TimeoutOptions{Timeout: time.Duration(30), KeepAlive: time.Duration(15)},
 			Auth:     &AuthOptions{Username: "user1"},
-			// No need to include the TLS config since the proxy won't use it.
 			ClientCfg: &ClientCfg{
 				AllowInsecure: false,
 				ClientCertVal: string(clientCert),


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/grafana/grafana-plugin-sdk-go/releases/tag/v0.217.0 introduced a breaking change where plugins build prior to this version would expect a file path, but receive file contents (on more recent Grafana versions). To ensure support for these older versions, we should check to see if the values are filepaths so that we can handle both scenarios.