### PR TITLE
QueryTypes: Read maxdatapoints as string or int64

### DIFF
--- a/experimental/apis/data/v0alpha1/query.go
+++ b/experimental/apis/data/v0alpha1/query.go
@@ -306,16 +306,17 @@ func (g *CommonQueryProperties) readQuery(iter *jsoniter.Iterator,
 		case "datasource":
 			// Old datasource values may just be a string
 			next, err = iter.WhatIsNext()
-			if err == nil {
-				switch next {
-				case j.StringValue:
-					g.Datasource = &DataSourceRef{}
-					g.Datasource.UID, err = iter.ReadString()
-				case j.ObjectValue:
-					err = iter.ReadVal(&g.Datasource)
-				default:
-					return fmt.Errorf("expected string or object")
-				}
+			if err != nil {
+				return err
+			}
+			switch next {
+			case j.StringValue:
+				g.Datasource = &DataSourceRef{}
+				g.Datasource.UID, err = iter.ReadString()
+			case j.ObjectValue:
+				err = iter.ReadVal(&g.Datasource)
+			default:
+				return fmt.Errorf("expected string or object")
 			}
 
 		case "datasourceId":
@@ -324,22 +325,20 @@ func (g *CommonQueryProperties) readQuery(iter *jsoniter.Iterator,
 			g.QueryType, err = iter.ReadString()
 		case "maxDataPoints":
 			next, err = iter.WhatIsNext()
-			if err == nil {
-				switch next {
-				case j.StringValue:
-					var v string
-					v, err = iter.ReadString()
-					if err == nil {
-						g.MaxDataPoints, err = strconv.ParseInt(v, 10, 64)
-					}
-				case j.NumberValue:
-					g.MaxDataPoints, err = iter.ReadInt64()
-				default:
-					return fmt.Errorf("expected string or number")
-				}
-			}
 			if err != nil {
 				return err
+			}
+			switch next {
+			case j.StringValue:
+				var v string
+				v, err = iter.ReadString()
+				if err == nil {
+					g.MaxDataPoints, err = strconv.ParseInt(v, 10, 64)
+				}
+			case j.NumberValue:
+				g.MaxDataPoints, err = iter.ReadInt64()
+			default:
+				return fmt.Errorf("expected number or string for maxDataPoints")
 			}
 		case "intervalMs":
 			g.IntervalMS, err = iter.ReadFloat64()

--- a/experimental/apis/data/v0alpha1/query.go
+++ b/experimental/apis/data/v0alpha1/query.go
@@ -3,6 +3,7 @@ package v0alpha1
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"unsafe"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -322,7 +323,24 @@ func (g *CommonQueryProperties) readQuery(iter *jsoniter.Iterator,
 		case "queryType":
 			g.QueryType, err = iter.ReadString()
 		case "maxDataPoints":
-			g.MaxDataPoints, err = iter.ReadInt64()
+			next, err = iter.WhatIsNext()
+			if err == nil {
+				switch next {
+				case j.StringValue:
+					var v string
+					v, err = iter.ReadString()
+					if err == nil {
+						g.MaxDataPoints, err = strconv.ParseInt(v, 10, 64)
+					}
+				case j.NumberValue:
+					g.MaxDataPoints, err = iter.ReadInt64()
+				default:
+					return fmt.Errorf("expected string or number")
+				}
+			}
+			if err != nil {
+				return err
+			}
 		case "intervalMs":
 			g.IntervalMS, err = iter.ReadFloat64()
 		case "hide":

--- a/experimental/apis/data/v0alpha1/query_test.go
+++ b/experimental/apis/data/v0alpha1/query_test.go
@@ -25,7 +25,7 @@ func TestParseQueriesIntoQueryDataRequest(t *testing.T) {
 			{
 				"refId": "Z",
 				"datasource": "old",
-				"maxDataPoints": 10,
+				"maxDataPoints": "10",
 				"timeRange": {
 					"from": "100",
 					"to": "200"
@@ -127,3 +127,4 @@ func TestQueryBuilders(t *testing.T) {
 	testQ3.Set("maxDataPoints", 100)
 	require.Equal(t, int64(100), testQ3.MaxDataPoints)
 }
+

--- a/experimental/apis/data/v0alpha1/query_test.go
+++ b/experimental/apis/data/v0alpha1/query_test.go
@@ -54,6 +54,8 @@ func TestParseQueriesIntoQueryDataRequest(t *testing.T) {
 		err = json.Unmarshal(out, query)
 		require.NoError(t, err)
 		require.Equal(t, "spreadsheetID", query.GetString("spreadsheet"))
+		require.Equal(t, int64(794), query.MaxDataPoints)         // input was a number
+		require.Equal(t, int64(10), req.Queries[1].MaxDataPoints) // input was a string
 
 		// The second query has an explicit time range, and legacy datasource name
 		out, err = json.MarshalIndent(req.Queries[1], "", "  ")

--- a/experimental/apis/data/v0alpha1/query_test.go
+++ b/experimental/apis/data/v0alpha1/query_test.go
@@ -127,4 +127,3 @@ func TestQueryBuilders(t *testing.T) {
 	testQ3.Set("maxDataPoints", 100)
 	require.Equal(t, int64(100), testQ3.MaxDataPoints)
 }
-


### PR DESCRIPTION
**What this PR does / why we need it**:

Reads MaxDatapoints from JSON as string or int64.

Backwards compatibility, older things may send this as a string.

**Special notes for your reviewer**:
We should really fix the sender -- but this supports places that may be sending an invalid value currently