### PR TITLE
SchemaBuilder: Fix enum value extraction

### DIFF
--- a/experimental/schemabuilder/enums.go
+++ b/experimental/schemabuilder/enums.go
@@ -88,6 +88,7 @@ func findEnumFields(base, startpath string) ([]EnumField, error) {
 					if txt == "" {
 						txt = x.Comment.Text()
 					}
+					typ = fmt.Sprintf("%v", x.Type)
 					if typ == field.Name && len(x.Values) > 0 {
 						for _, n := range x.Names {
 							if ast.IsExported(n.String()) {

--- a/experimental/schemabuilder/enums_test.go
+++ b/experimental/schemabuilder/enums_test.go
@@ -15,11 +15,8 @@ func TestFindEnums(t *testing.T) {
 			"../../data")
 		require.NoError(t, err)
 
-		out, err := json.MarshalIndent(fields, "", "  ")
-		require.NoError(t, err)
-		fmt.Printf("%s", string(out))
-
 		require.Equal(t, 1, len(fields))
+		require.Equal(t, "FrameType", fields[0].Name)
 	})
 
 	t.Run("verify enum extraction", func(t *testing.T) {
@@ -28,11 +25,6 @@ func TestFindEnums(t *testing.T) {
 				"github.com/grafana/grafana-plugin-sdk-go/experimental/schemabuilder/example",
 				"./example")
 			require.NoError(t, err)
-
-			for _, f := range fields {
-				fmt.Printf("%s\n", f.Name)
-			}
-
 			require.Equal(t, 3, len(fields))
 
 			var reduceMode EnumField

--- a/experimental/schemabuilder/enums_test.go
+++ b/experimental/schemabuilder/enums_test.go
@@ -22,16 +22,47 @@ func TestFindEnums(t *testing.T) {
 		require.Equal(t, 1, len(fields))
 	})
 
-	t.Run("example", func(t *testing.T) {
-		fields, err := findEnumFields(
-			"github.com/grafana/grafana-plugin-sdk-go/experimental/schemabuilder/example",
-			"./example")
-		require.NoError(t, err)
+	t.Run("verify enum extraction", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			fields, err := findEnumFields(
+				"github.com/grafana/grafana-plugin-sdk-go/experimental/schemabuilder/example",
+				"./example")
+			require.NoError(t, err)
 
-		out, err := json.MarshalIndent(fields, "", "  ")
-		require.NoError(t, err)
-		fmt.Printf("%s", string(out))
+			for _, f := range fields {
+				fmt.Printf("%s\n", f.Name)
+			}
 
-		require.Equal(t, 3, len(fields))
+			require.Equal(t, 3, len(fields))
+
+			var reduceMode EnumField
+			for _, f := range fields {
+				if f.Name == "ReduceMode" {
+					reduceMode = f
+					break
+				}
+			}
+			require.NotNil(t, reduceMode)
+
+			out, err := json.MarshalIndent(reduceMode, "", "  ")
+			require.NoError(t, err)
+			fmt.Printf("%s", string(out))
+
+			require.JSONEq(t, `{
+				"Package": "github.com/grafana/grafana-plugin-sdk-go/experimental/schemabuilder/example",
+				"Name": "ReduceMode",
+				"Comment": "Non-Number behavior mode",
+				"Values": [
+				  {
+					"Value": "dropNN",
+					"Comment": "Drop non-numbers"
+				  },
+				  {
+					"Value": "replaceNN",
+					"Comment": "Replace non-numbers"
+				  }
+				]
+			  } `, string(out))
+		}
 	})
 }

--- a/experimental/schemabuilder/example/query.go
+++ b/experimental/schemabuilder/example/query.go
@@ -59,6 +59,9 @@ const (
 // +enum
 type ReduceMode string
 
+// Dummy value makes sure the enum extraction logic is valid
+const DummyValueA = "dummyA"
+
 const (
 	// Drop non-numbers
 	ReduceModeDrop ReduceMode = "dropNN"
@@ -66,6 +69,9 @@ const (
 	// Replace non-numbers
 	ReduceModeReplace ReduceMode = "replaceNN"
 )
+
+// Dummy value makes sure the enum extraction logic is valid
+const DummyValueB = "dummyB"
 
 // QueryType = resample
 type ResampleQuery struct {

--- a/experimental/schemabuilder/reflector.go
+++ b/experimental/schemabuilder/reflector.go
@@ -146,6 +146,10 @@ func NewSchemaBuilder(opts BuilderOptions) (*Builder, error) {
 	}, nil
 }
 
+func (b *Builder) Reflector() *jsonschema.Reflector {
+	return b.reflector
+}
+
 func (b *Builder) AddQueries(inputs ...QueryTypeInfo) error {
 	for _, info := range inputs {
 		schema := b.reflector.ReflectFromType(info.GoType)


### PR DESCRIPTION
This fixes an issue where the detected enum value is not verified against its type.  This means that the (non-stable) field ordering returned from the ast leads to flaky tests and sometimes wrong values