### PR TITLE
SQL: Check if `scanType` value is `nil`

### DIFF
--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -83,7 +83,11 @@ func MakeScanRow(colTypes []*sql.ColumnType, colNames []string, converters ...Co
 		}
 
 		if !rc.hasConverter(i) {
-			v := NewDefaultConverter(colName, nullable, colType.ScanType())
+			scanTypeValue := colType.ScanType()
+			if scanTypeValue == nil {
+				return nil, fmt.Errorf(`type %s is not supported for column %s`, colType.DatabaseTypeName(), colName)
+			}
+			v := NewDefaultConverter(colName, nullable, scanTypeValue)
 			rc.append(colName, scanType(v, colType.ScanType()), v)
 		}
 	}


### PR DESCRIPTION
If the `scanType` value is `nil` (which is possible for certain SQL data types) a panic will be triggered rather than providing the user with a useful error to understand what has gone wrong.

This PR detects this case and returns an error detailing what column has the invalid type.

Related to grafana/grafana#81935