### PR TITLE
PDC: Fix env var config fallback

### DIFF
--- a/backend/proxy/env.go
+++ b/backend/proxy/env.go
@@ -102,9 +102,9 @@ func clientCfgFromEnv() *ClientCfg {
 	}
 
 	return &ClientCfg{
-		ClientCert:    clientCert,
-		ClientKey:     clientKey,
-		RootCAs:       rootCAs,
+		ClientCertVal: clientCert,
+		ClientKeyVal:  clientKey,
+		RootCAsVals:   rootCAs,
 		ProxyAddress:  proxyAddress,
 		ServerName:    serverName,
 		AllowInsecure: false,

--- a/backend/proxy/env_test.go
+++ b/backend/proxy/env_test.go
@@ -102,9 +102,9 @@ func TestClientCfgFromEnv(t *testing.T) {
 			},
 			expected: &ClientCfg{
 				ProxyAddress:  "localhost",
-				ClientCert:    testFileData,
-				ClientKey:     testFileData,
-				RootCAs:       []string{testFileData, testFileData},
+				ClientCertVal: testFileData,
+				ClientKeyVal:  testFileData,
+				RootCAsVals:   []string{testFileData, testFileData},
 				ServerName:    "name",
 				AllowInsecure: false,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we now read the file paths that are passed as environment variable values, we need to update to use the correct field names for the configuration struct.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/10097

**Special notes for your reviewer**:
In order to avoid a breaking change, the field name were not updated, but are documented FYI.

```go
// ClientCfg contains the information needed to allow datasource connections to be
// proxied to a secure socks proxy.
type ClientCfg struct {
  // Deprecated: ClientCert is the file path to the client certificate.
  ClientCert string
  // Deprecated: ClientKey is the file path to the client key.
  ClientKey string
  // Deprecated: RootCAs is a list of file paths to the root CA certificates.
  RootCAs []string

  ClientCertVal string
  ClientKeyVal  string
  RootCAsVals   []string
  ProxyAddress  string
  ServerName    string
  AllowInsecure bool
}
```