### PR TITLE
Set proxy options from context

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -237,6 +237,15 @@ func propagateTenantIDIfPresent(ctx context.Context) context.Context {
 	return ctx
 }
 
+func (s *DataSourceInstanceSettings) ProxyOptionsFromContext(ctx context.Context) (*proxy.Options, error) {
+	cfg := GrafanaConfigFromContext(ctx)
+	p, err := cfg.proxy()
+	if err != nil {
+		return nil, err
+	}
+	return s.ProxyOptions(p.clientCfg)
+}
+
 func (s *DataSourceInstanceSettings) ProxyOptions(clientCfg *proxy.ClientCfg) (*proxy.Options, error) {
 	opts := &proxy.Options{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Simplifies the PDC route for non-HTTP datasources who want to configure a proxy connection on their datasource instance.

