### PR TITLE
SQL: Add default interval and interval_ms macros to sqlutil

### DIFF
--- a/data/sqlutil/macros.go
+++ b/data/sqlutil/macros.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 
 	"golang.org/x/exp/maps"
 )
@@ -21,6 +24,22 @@ type MacroFunc func(*Query, []string) (string, error)
 
 // Macros is a map of macro name to MacroFunc. The name must be regex friendly.
 type Macros map[string]MacroFunc
+
+// Default macro to return interval
+// Example:
+//
+// $__interval => "10m"
+func macroInterval(query *Query, _ []string) (string, error) {
+	return gtime.FormatInterval(query.Interval), nil
+}
+
+// Default macro to return interval in ms
+// Example if $__interval is "10m":
+//
+// $__interval_ms => "600000"
+func macroIntervalMS(query *Query, _ []string) (string, error) {
+	return strconv.FormatInt(query.Interval.Milliseconds(), 10), nil
+}
 
 // Default time filter for SQL based on the query time range.
 // It requires one argument, the time column to filter.
@@ -116,12 +135,14 @@ func macroColumn(query *Query, _ []string) (string, error) {
 }
 
 var DefaultMacros = Macros{
-	"timeFilter": macroTimeFilter,
-	"timeFrom":   macroTimeFrom,
-	"timeGroup":  macroTimeGroup,
-	"timeTo":     macroTimeTo,
-	"table":      macroTable,
-	"column":     macroColumn,
+	"interval":    macroInterval,
+	"interval_ms": macroIntervalMS,
+	"timeFilter":  macroTimeFilter,
+	"timeFrom":    macroTimeFrom,
+	"timeGroup":   macroTimeGroup,
+	"timeTo":      macroTimeTo,
+	"table":       macroTable,
+	"column":      macroColumn,
 }
 
 type macroMatch struct {

--- a/data/sqlutil/macros_test.go
+++ b/data/sqlutil/macros_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -111,6 +112,16 @@ func TestInterpolate(t *testing.T) {
 			output: "select * from bar_world AND baz AND bar_hello",
 		},
 		{
+			name:   "default interval",
+			input:  "select * from foo group by bin(time, $__interval)",
+			output: "select * from foo group by bin(time, 10m)",
+		},
+		{
+			name:   "default interval_ms",
+			input:  "select count(*) / $__interval_ms * 1000 as qps from foo",
+			output: "select count(*) / 600000 * 1000 as qps from foo",
+		},
+		{
 			name:   "default timeFilter",
 			input:  "select * from foo where $__timeFilter(time)",
 			output: "select * from foo where time >= '0001-01-01T00:00:00Z' AND time <= '0001-01-01T00:00:00Z'",
@@ -199,9 +210,10 @@ func TestInterpolate(t *testing.T) {
 	for i, tc := range tests {
 		t.Run(fmt.Sprintf("[%d/%d] %s", i+1, len(tests), tc.name), func(t *testing.T) {
 			query := &Query{
-				RawSQL: tc.input,
-				Table:  tableName,
-				Column: tableColumn,
+				RawSQL:   tc.input,
+				Table:    tableName,
+				Column:   tableColumn,
+				Interval: time.Duration(10 * time.Minute),
 			}
 			interpolatedQuery, err := Interpolate(query, macros)
 			assert.Equal(t, err != nil, tc.wantErr, "wantErr != gotErr")

--- a/data/sqlutil/macros_test.go
+++ b/data/sqlutil/macros_test.go
@@ -213,7 +213,7 @@ func TestInterpolate(t *testing.T) {
 				RawSQL:   tc.input,
 				Table:    tableName,
 				Column:   tableColumn,
-				Interval: time.Duration(10 * time.Minute),
+				Interval: time.Duration(10) * time.Minute,
 			}
 			interpolatedQuery, err := Interpolate(query, macros)
 			assert.Equal(t, err != nil, tc.wantErr, "wantErr != gotErr")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Adds default macros for `$__interval`  and `$__interval_ms` so any sqlds-based data source can get it for free.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-aws-sdk/issues/44

**Special notes for your reviewer**:
Will update sqlds after this is merged.
