### PR TITLE
DataSourceRef: Add apiVersion

### DIFF
--- a/experimental/apis/data/v0alpha1/query.go
+++ b/experimental/apis/data/v0alpha1/query.go
@@ -198,6 +198,8 @@ func (codec *datasourceRefCodec) Decode(ptr unsafe.Pointer, iter *j.Iterator) {
 				q.Type = iter.ReadString()
 			case "uid":
 				q.UID = iter.ReadString()
+			case "apiVersion":
+				q.APIVersion = iter.ReadString()
 			default:
 				_ = iter.Read() // ignore unused properties
 			}
@@ -425,10 +427,11 @@ type DataSourceRef struct {
 	// The datasource plugin type
 	Type string `json:"type"`
 
-	// Datasource UID
+	// Datasource UID (NOTE: name in k8s)
 	UID string `json:"uid,omitempty"`
 
-	// ?? the datasource API version?  (just version, not the group? type | apiVersion?)
+	// The apiserver version
+	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // TimeRange represents a time range for a query and is a property of DataQuery.

--- a/experimental/apis/data/v0alpha1/query.schema.json
+++ b/experimental/apis/data/v0alpha1/query.schema.json
@@ -81,7 +81,11 @@
         },
         "uid": {
           "type": "string",
-          "description": "Datasource UID"
+          "description": "Datasource UID (NOTE: name in k8s)"
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "The apiserver version"
         }
       },
       "additionalProperties": false,

--- a/experimental/apis/data/v0alpha1/query_test.go
+++ b/experimental/apis/data/v0alpha1/query_test.go
@@ -96,10 +96,11 @@ func TestLegacyDataSourceRef(t *testing.T) {
 	}
 
 	wrap := &testWrapper{}
-	err := json.Unmarshal([]byte(`{ "ref": {"type":"ttt", "uid":"UID"}}`), wrap)
+	err := json.Unmarshal([]byte(`{ "ref": {"type":"ttt", "uid":"UID", "apiVersion": "v2"}}`), wrap)
 	require.NoError(t, err)
 	require.Equal(t, "ttt", wrap.Ref.Type)
 	require.Equal(t, "UID", wrap.Ref.UID)
+	require.Equal(t, "v2", wrap.Ref.APIVersion)
 
 	err = json.Unmarshal([]byte(`{ "ref": "name"}`), wrap)
 	require.NoError(t, err)

--- a/experimental/schemabuilder/example/query.panel.schema.json
+++ b/experimental/schemabuilder/example/query.panel.schema.json
@@ -25,13 +25,17 @@
                   "type"
                 ],
                 "properties": {
+                  "apiVersion": {
+                    "description": "The apiserver version",
+                    "type": "string"
+                  },
                   "type": {
                     "description": "The datasource plugin type",
                     "type": "string",
                     "pattern": "^__expr__$"
                   },
                   "uid": {
-                    "description": "Datasource UID",
+                    "description": "Datasource UID (NOTE: name in k8s)",
                     "type": "string"
                   }
                 },
@@ -147,13 +151,17 @@
                   "type"
                 ],
                 "properties": {
+                  "apiVersion": {
+                    "description": "The apiserver version",
+                    "type": "string"
+                  },
                   "type": {
                     "description": "The datasource plugin type",
                     "type": "string",
                     "pattern": "^__expr__$"
                   },
                   "uid": {
-                    "description": "Datasource UID",
+                    "description": "Datasource UID (NOTE: name in k8s)",
                     "type": "string"
                   }
                 },
@@ -309,13 +317,17 @@
                   "type"
                 ],
                 "properties": {
+                  "apiVersion": {
+                    "description": "The apiserver version",
+                    "type": "string"
+                  },
                   "type": {
                     "description": "The datasource plugin type",
                     "type": "string",
                     "pattern": "^__expr__$"
                   },
                   "uid": {
-                    "description": "Datasource UID",
+                    "description": "Datasource UID (NOTE: name in k8s)",
                     "type": "string"
                   }
                 },

--- a/experimental/schemabuilder/example/query.request.schema.json
+++ b/experimental/schemabuilder/example/query.request.schema.json
@@ -35,13 +35,17 @@
                   "type"
                 ],
                 "properties": {
+                  "apiVersion": {
+                    "description": "The apiserver version",
+                    "type": "string"
+                  },
                   "type": {
                     "description": "The datasource plugin type",
                     "type": "string",
                     "pattern": "^__expr__$"
                   },
                   "uid": {
-                    "description": "Datasource UID",
+                    "description": "Datasource UID (NOTE: name in k8s)",
                     "type": "string"
                   }
                 },
@@ -165,13 +169,17 @@
                   "type"
                 ],
                 "properties": {
+                  "apiVersion": {
+                    "description": "The apiserver version",
+                    "type": "string"
+                  },
                   "type": {
                     "description": "The datasource plugin type",
                     "type": "string",
                     "pattern": "^__expr__$"
                   },
                   "uid": {
-                    "description": "Datasource UID",
+                    "description": "Datasource UID (NOTE: name in k8s)",
                     "type": "string"
                   }
                 },
@@ -335,13 +343,17 @@
                   "type"
                 ],
                 "properties": {
+                  "apiVersion": {
+                    "description": "The apiserver version",
+                    "type": "string"
+                  },
                   "type": {
                     "description": "The datasource plugin type",
                     "type": "string",
                     "pattern": "^__expr__$"
                   },
                   "uid": {
-                    "description": "Datasource UID",
+                    "description": "Datasource UID (NOTE: name in k8s)",
                     "type": "string"
                   }
                 },


### PR DESCRIPTION
adding apiversion to datasource ref.

It is still premature to use this -- as it should indicate the query schema to use, but I think better to have it available so we are not constantly butting heads with the chicken vs egg.