### PR TITLE
SQL: Apply longer macros before shorter macros

### DIFF
--- a/data/sqlutil/macros_test.go
+++ b/data/sqlutil/macros_test.go
@@ -58,8 +58,8 @@ func TestInterpolate(t *testing.T) {
 		},
 		{
 			name:   "this macro name's substring is another macro",
-			input:  "select * from $__fooBaz()",
-			output: "select * from qux",
+			input:  "select $__foo, $__fooBaz from foo",
+			output: "select baz, qux from foo",
 		},
 		{
 			name:   "multiple instances of same macro",
@@ -75,11 +75,6 @@ func TestInterpolate(t *testing.T) {
 			name:   "macro without parenthesis",
 			input:  "select * from $__foo",
 			output: "select * from baz",
-		},
-		{
-			name:   "macro that is a substring of another macro",
-			input:  "select $__foo, $__fooBaz from foo",
-			output: "select baz, qux from foo",
 		},
 		{
 			name:   "macro without params",

--- a/data/sqlutil/macros_test.go
+++ b/data/sqlutil/macros_test.go
@@ -77,6 +77,11 @@ func TestInterpolate(t *testing.T) {
 			output: "select * from baz",
 		},
 		{
+			name:   "macro that is a substring of another macro",
+			input:  "select $__foo, $__fooBaz from foo",
+			output: "select baz, qux from foo",
+		},
+		{
 			name:   "macro without params",
 			input:  "select * from $__params()",
 			output: "select * from bar",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Applying macros is not deterministic using `sqlutil.Interpolate` if one macro is a substring of another one. E.g. a query such as `select '$__interval', $__interval_ms` could potentially apply the `$__interval` macro in place of `$__interval_ms` and `$__invertal_ms` would not be applied. For example, if `$__interval` evaluates to `"1s"`, then the query would incorrectly be `select '1s', 1s_ms`

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
