### PR TITLE
Chore: fix lint issues in tests

### DIFF
--- a/backend/app/instance_provider_test.go
+++ b/backend/app/instance_provider_test.go
@@ -19,7 +19,7 @@ func TestInstanceProvider(t *testing.T) {
 	type testInstance struct {
 		value string
 	}
-	ip := NewInstanceProvider(func(ctx context.Context, settings backend.AppInstanceSettings) (instancemgmt.Instance, error) {
+	ip := NewInstanceProvider(func(_ context.Context, _ backend.AppInstanceSettings) (instancemgmt.Instance, error) {
 		return testInstance{value: "what an app"}, nil
 	})
 

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -34,7 +34,7 @@ func newFakeDataHandlerWithOAuth() *fakeDataHandlerWithOAuth {
 		panic("httpclient new: " + err.Error())
 	}
 
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -117,7 +117,7 @@ func TestQueryData(t *testing.T) {
 
 	t.Run("When tenant information is attached to incoming context, it is propagated from adapter to handler", func(t *testing.T) {
 		tid := "123456"
-		a := newDataSDKAdapter(QueryDataHandlerFunc(func(ctx context.Context, req *QueryDataRequest) (*QueryDataResponse, error) {
+		a := newDataSDKAdapter(QueryDataHandlerFunc(func(ctx context.Context, _ *QueryDataRequest) (*QueryDataResponse, error) {
 			require.Equal(t, tid, tenant.IDFromContext(ctx))
 			return NewQueryDataResponse(), nil
 		}))

--- a/backend/datasource/instance_provider_test.go
+++ b/backend/datasource/instance_provider_test.go
@@ -14,7 +14,7 @@ func TestInstanceProvider(t *testing.T) {
 	type testInstance struct {
 		value string
 	}
-	ip := NewInstanceProvider(func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+	ip := NewInstanceProvider(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		return testInstance{value: "hello"}, nil
 	})
 

--- a/backend/datasource/query_type_mux_example_test.go
+++ b/backend/datasource/query_type_mux_example_test.go
@@ -9,11 +9,11 @@ import (
 
 func ExampleQueryTypeMux() {
 	mux := datasource.NewQueryTypeMux()
-	mux.HandleFunc("queryTypeA", func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	mux.HandleFunc("queryTypeA", func(_ context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 		// handle queryTypeA
 		return nil, nil
 	})
-	mux.HandleFunc("queryTypeB", func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	mux.HandleFunc("queryTypeB", func(_ context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 		// handle queryTypeB
 		return nil, nil
 	})

--- a/backend/datasource/query_type_mux_test.go
+++ b/backend/datasource/query_type_mux_test.go
@@ -52,7 +52,7 @@ func TestQueryTypeMux(t *testing.T) {
 
 	t.Run("When overriding fallback handler should call fallback handler", func(t *testing.T) {
 		errBoom := errors.New("BOOM")
-		mux.HandleFunc("", func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		mux.HandleFunc("", func(_ context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 			return nil, errBoom
 		})
 		res, err = mux.QueryData(context.Background(), &backend.QueryDataRequest{

--- a/backend/diagnostics_adapter_test.go
+++ b/backend/diagnostics_adapter_test.go
@@ -128,7 +128,7 @@ func TestCheckHealth(t *testing.T) {
 
 	t.Run("When tenant information is attached to incoming context, it is propagated from adapter to handler", func(t *testing.T) {
 		tid := "123456"
-		a := newDiagnosticsSDKAdapter(nil, CheckHealthHandlerFunc(func(ctx context.Context, req *CheckHealthRequest) (*CheckHealthResult, error) {
+		a := newDiagnosticsSDKAdapter(nil, CheckHealthHandlerFunc(func(ctx context.Context, _ *CheckHealthRequest) (*CheckHealthResult, error) {
 			require.Equal(t, tid, tenant.IDFromContext(ctx))
 			return &CheckHealthResult{}, nil
 		}))

--- a/backend/httpclient/contextual_middleware_example_test.go
+++ b/backend/httpclient/contextual_middleware_example_test.go
@@ -17,7 +17,7 @@ func ExampleWithContextualMiddleware() {
 
 	parent := context.Background()
 	ctx := httpclient.WithContextualMiddleware(parent,
-		httpclient.MiddlewareFunc(func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+		httpclient.MiddlewareFunc(func(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
 			return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				req.Header.Set("X-Custom-Header", "val")
 

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -108,7 +108,7 @@ func GetTLSConfig(opts ...Options) (*tls.Config, error) {
 	tlsOpts := clientOpts.TLS
 
 	config := &tls.Config{
-		// #nosec
+		// nolint:gosec
 		InsecureSkipVerify: tlsOpts.InsecureSkipVerify,
 		ServerName:         tlsOpts.ServerName,
 	}

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -107,8 +107,8 @@ func GetTLSConfig(opts ...Options) (*tls.Config, error) {
 
 	tlsOpts := clientOpts.TLS
 
-	// #nosec
 	config := &tls.Config{
+		// #nosec
 		InsecureSkipVerify: tlsOpts.InsecureSkipVerify,
 		ServerName:         tlsOpts.ServerName,
 	}

--- a/backend/httpclient/http_client_example_test.go
+++ b/backend/httpclient/http_client_example_test.go
@@ -14,7 +14,7 @@ func ExampleNew() {
 			Timeout: 5 * time.Second,
 		},
 		Middlewares: []httpclient.Middleware{
-			httpclient.MiddlewareFunc(func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+			httpclient.MiddlewareFunc(func(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
 				return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 					log.Println("Before outgoing request")
 					res, err := next.RoundTrip(req)
@@ -45,7 +45,7 @@ func ExampleGetTransport() {
 			Timeout: 5 * time.Second,
 		},
 		Middlewares: []httpclient.Middleware{
-			httpclient.MiddlewareFunc(func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+			httpclient.MiddlewareFunc(func(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
 				return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 					log.Println("Before outgoing request")
 					res, err := next.RoundTrip(req)

--- a/backend/httpclient/http_client_test.go
+++ b/backend/httpclient/http_client_test.go
@@ -48,7 +48,7 @@ func TestNewClient(t *testing.T) {
 
 	t.Run("New() with non-empty opts should use default middleware", func(t *testing.T) {
 		usedMiddlewares := []Middleware{}
-		client, err := New(Options{ConfigureMiddleware: func(opts Options, existingMiddleware []Middleware) []Middleware {
+		client, err := New(Options{ConfigureMiddleware: func(_ Options, existingMiddleware []Middleware) []Middleware {
 			usedMiddlewares = existingMiddleware
 			return existingMiddleware
 		}})
@@ -67,7 +67,7 @@ func TestNewClient(t *testing.T) {
 		usedMiddlewares := []Middleware{}
 		client, err := New(Options{
 			Middlewares: []Middleware{ctx.createMiddleware("mw1"), ctx.createMiddleware("mw2"), ctx.createMiddleware("mw3")},
-			ConfigureMiddleware: func(opts Options, existingMiddleware []Middleware) []Middleware {
+			ConfigureMiddleware: func(_ Options, existingMiddleware []Middleware) []Middleware {
 				middlewares := existingMiddleware
 				for i, j := 0, len(existingMiddleware)-1; i < j; i, j = i+1, j-1 {
 					middlewares[i], middlewares[j] = middlewares[j], middlewares[i]
@@ -99,7 +99,7 @@ func TestNewClient(t *testing.T) {
 			ctx := &testContext{}
 			_, err := New(Options{
 				Middlewares: []Middleware{ctx.createMiddleware("mw1")},
-				ConfigureMiddleware: func(opts Options, existingMiddleware []Middleware) []Middleware {
+				ConfigureMiddleware: func(_ Options, existingMiddleware []Middleware) []Middleware {
 					return append(existingMiddleware, ctx.createMiddleware("mw1"))
 				},
 			})
@@ -163,14 +163,14 @@ type testContext struct {
 }
 
 func (c *testContext) createRoundTripper(name string) http.RoundTripper {
-	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	return RoundTripperFunc(func(_ *http.Request) (*http.Response, error) {
 		c.callChain = append(c.callChain, name)
 		return &http.Response{StatusCode: http.StatusOK}, nil
 	})
 }
 
 func (c *testContext) createMiddleware(name string) Middleware {
-	return NamedMiddlewareFunc(name, func(opts Options, next http.RoundTripper) http.RoundTripper {
+	return NamedMiddlewareFunc(name, func(_ Options, next http.RoundTripper) http.RoundTripper {
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			c.callChain = append(c.callChain, fmt.Sprintf("before %s", name))
 			res, err := next.RoundTrip(req)

--- a/backend/httpclient/provider.go
+++ b/backend/httpclient/provider.go
@@ -75,7 +75,7 @@ func (p *Provider) New(opts ...Options) (*http.Client, error) {
 	clientOpts := p.createClientOptions(opts...)
 
 	var configuredTransport *http.Transport
-	clientOpts.ConfigureTransport = configureTransportChain(clientOpts.ConfigureTransport, func(opts Options, transport *http.Transport) {
+	clientOpts.ConfigureTransport = configureTransportChain(clientOpts.ConfigureTransport, func(_ Options, transport *http.Transport) {
 		configuredTransport = transport
 	})
 
@@ -108,7 +108,7 @@ func (p *Provider) GetTransport(opts ...Options) (http.RoundTripper, error) {
 	clientOpts := p.createClientOptions(opts...)
 
 	var configuredTransport *http.Transport
-	clientOpts.ConfigureTransport = configureTransportChain(clientOpts.ConfigureTransport, func(opts Options, transport *http.Transport) {
+	clientOpts.ConfigureTransport = configureTransportChain(clientOpts.ConfigureTransport, func(_ Options, transport *http.Transport) {
 		configuredTransport = transport
 	})
 

--- a/backend/httpclient/provider_example_test.go
+++ b/backend/httpclient/provider_example_test.go
@@ -21,7 +21,7 @@ func ExampleProvider_New() {
 			Timeout: 5 * time.Second,
 		},
 		Middlewares: []httpclient.Middleware{
-			httpclient.MiddlewareFunc(func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+			httpclient.MiddlewareFunc(func(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
 				return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 					log.Println("Before outgoing request")
 					res, err := next.RoundTrip(req)
@@ -54,7 +54,7 @@ func ExampleProvider_GetTransport() {
 			Timeout: 5 * time.Second,
 		},
 		Middlewares: []httpclient.Middleware{
-			httpclient.MiddlewareFunc(func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+			httpclient.MiddlewareFunc(func(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
 				return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 					log.Println("Before outgoing request")
 					res, err := next.RoundTrip(req)

--- a/backend/httpclient/provider_test.go
+++ b/backend/httpclient/provider_test.go
@@ -214,21 +214,21 @@ func newProviderTestContext(t *testing.T, opts ...ProviderOptions) *providerTest
 		providerOpts = ProviderOptions{}
 	}
 
-	providerOpts.ConfigureMiddleware = func(opts Options, existingMiddleware []Middleware) []Middleware {
+	providerOpts.ConfigureMiddleware = func(_ Options, existingMiddleware []Middleware) []Middleware {
 		ctx.configureMiddlewareCount++
 		ctx.usedMiddlewares = make([]Middleware, len(existingMiddleware))
 		copy(ctx.usedMiddlewares, existingMiddleware)
 		return existingMiddleware
 	}
-	providerOpts.ConfigureClient = func(opts Options, client *http.Client) {
+	providerOpts.ConfigureClient = func(_ Options, client *http.Client) {
 		ctx.configureClientCount++
 		ctx.client = client
 	}
-	providerOpts.ConfigureTransport = func(opts Options, transport *http.Transport) {
+	providerOpts.ConfigureTransport = func(_ Options, transport *http.Transport) {
 		ctx.configureTransportCount++
 		ctx.transport = transport
 	}
-	providerOpts.ConfigureTLSConfig = func(opts Options, config *tls.Config) {
+	providerOpts.ConfigureTLSConfig = func(_ Options, config *tls.Config) {
 		ctx.configureTLSConfigCount++
 		ctx.tlsConfig = config
 	}

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -8,7 +8,7 @@ import (
 const ResponseLimitMiddlewareName = "response-limit"
 
 func ResponseLimitMiddleware(limit int64) Middleware {
-	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
+	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(_ Options, next http.RoundTripper) http.RoundTripper {
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			res, err := next.RoundTrip(req)
 			if err != nil {

--- a/backend/log_test.go
+++ b/backend/log_test.go
@@ -36,7 +36,7 @@ func TestContextualLogger(t *testing.T) {
 	pCtx := &pluginv2.PluginContext{PluginId: pluginID}
 	t.Run("DataSDKAdapter", func(t *testing.T) {
 		run := make(chan struct{}, 1)
-		a := newDataSDKAdapter(QueryDataHandlerFunc(func(ctx context.Context, req *QueryDataRequest) (*QueryDataResponse, error) {
+		a := newDataSDKAdapter(QueryDataHandlerFunc(func(ctx context.Context, _ *QueryDataRequest) (*QueryDataResponse, error) {
 			checkCtxLogger(ctx, t, map[string]any{"endpoint": "queryData", "pluginID": pluginID})
 			run <- struct{}{}
 			return NewQueryDataResponse(), nil
@@ -50,7 +50,7 @@ func TestContextualLogger(t *testing.T) {
 
 	t.Run("DiagnosticsSDKAdapter", func(t *testing.T) {
 		run := make(chan struct{}, 1)
-		a := newDiagnosticsSDKAdapter(prometheus.DefaultGatherer, CheckHealthHandlerFunc(func(ctx context.Context, req *CheckHealthRequest) (*CheckHealthResult, error) {
+		a := newDiagnosticsSDKAdapter(prometheus.DefaultGatherer, CheckHealthHandlerFunc(func(ctx context.Context, _ *CheckHealthRequest) (*CheckHealthResult, error) {
 			checkCtxLogger(ctx, t, map[string]any{"endpoint": "checkHealth", "pluginID": pluginID})
 			run <- struct{}{}
 			return &CheckHealthResult{}, nil
@@ -64,7 +64,7 @@ func TestContextualLogger(t *testing.T) {
 
 	t.Run("ResourceSDKAdapter", func(t *testing.T) {
 		run := make(chan struct{}, 1)
-		a := newResourceSDKAdapter(CallResourceHandlerFunc(func(ctx context.Context, req *CallResourceRequest, sender CallResourceResponseSender) error {
+		a := newResourceSDKAdapter(CallResourceHandlerFunc(func(ctx context.Context, _ *CallResourceRequest, _ CallResourceResponseSender) error {
 			checkCtxLogger(ctx, t, map[string]any{"endpoint": "callResource", "pluginID": pluginID})
 			run <- struct{}{}
 			return nil
@@ -81,17 +81,17 @@ func TestContextualLogger(t *testing.T) {
 		publishStreamRun := make(chan struct{}, 1)
 		runStreamRun := make(chan struct{}, 1)
 		a := newStreamSDKAdapter(&streamAdapter{
-			subscribeStreamFunc: func(ctx context.Context, request *SubscribeStreamRequest) (*SubscribeStreamResponse, error) {
+			subscribeStreamFunc: func(ctx context.Context, _ *SubscribeStreamRequest) (*SubscribeStreamResponse, error) {
 				checkCtxLogger(ctx, t, map[string]any{"endpoint": "subscribeStream", "pluginID": pluginID})
 				subscribeStreamRun <- struct{}{}
 				return &SubscribeStreamResponse{}, nil
 			},
-			publishStreamFunc: func(ctx context.Context, request *PublishStreamRequest) (*PublishStreamResponse, error) {
+			publishStreamFunc: func(ctx context.Context, _ *PublishStreamRequest) (*PublishStreamResponse, error) {
 				checkCtxLogger(ctx, t, map[string]any{"endpoint": "publishStream", "pluginID": pluginID})
 				publishStreamRun <- struct{}{}
 				return &PublishStreamResponse{}, nil
 			},
-			runStreamFunc: func(ctx context.Context, request *RunStreamRequest, sender *StreamSender) error {
+			runStreamFunc: func(ctx context.Context, _ *RunStreamRequest, _ *StreamSender) error {
 				checkCtxLogger(ctx, t, map[string]any{"endpoint": "runStream", "pluginID": pluginID})
 				runStreamRun <- struct{}{}
 				return nil

--- a/backend/resource/httpadapter/doc_test.go
+++ b/backend/resource/httpadapter/doc_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Example() {
-	handler := New(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	handler := New(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		_, err := rw.Write([]byte("Hello world!"))
 		if err != nil {
 			return
@@ -21,7 +21,7 @@ func Example() {
 
 func Example_serve_mux() {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/hello", func(rw http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/hello", func(rw http.ResponseWriter, _ *http.Request) {
 		_, err := rw.Write([]byte("Hello world!"))
 		if err != nil {
 			return

--- a/backend/resource/httpadapter/handler_test.go
+++ b/backend/resource/httpadapter/handler_test.go
@@ -181,7 +181,7 @@ func TestServeMuxHandler(t *testing.T) {
 		testSender := newTestCallResourceResponseSender()
 		mux := http.NewServeMux()
 		handlerWasCalled := false
-		mux.HandleFunc("/test", func(rw http.ResponseWriter, req *http.Request) {
+		mux.HandleFunc("/test", func(_ http.ResponseWriter, _ *http.Request) {
 			handlerWasCalled = true
 		})
 		resourceHandler := New(mux)

--- a/backend/resource_adapter_test.go
+++ b/backend/resource_adapter_test.go
@@ -158,7 +158,7 @@ func TestCallResource(t *testing.T) {
 
 	t.Run("When tenant information is attached to incoming context, it is propagated from adapter to handler", func(t *testing.T) {
 		tid := "123456"
-		a := newResourceSDKAdapter(CallResourceHandlerFunc(func(ctx context.Context, req *CallResourceRequest, sender CallResourceResponseSender) error {
+		a := newResourceSDKAdapter(CallResourceHandlerFunc(func(ctx context.Context, _ *CallResourceRequest, _ CallResourceResponseSender) error {
 			require.Equal(t, tid, tenant.IDFromContext(ctx))
 			return nil
 		}))

--- a/backend/stream_adapter_test.go
+++ b/backend/stream_adapter_test.go
@@ -15,7 +15,7 @@ func TestSubscribeStream(t *testing.T) {
 	t.Run("When tenant information is attached to incoming context, it is propagated from adapter to handler", func(t *testing.T) {
 		tid := "123456"
 		a := newStreamSDKAdapter(&streamAdapter{
-			subscribeStreamFunc: func(ctx context.Context, request *SubscribeStreamRequest) (*SubscribeStreamResponse, error) {
+			subscribeStreamFunc: func(ctx context.Context, _ *SubscribeStreamRequest) (*SubscribeStreamResponse, error) {
 				require.Equal(t, tid, tenant.IDFromContext(ctx))
 				return &SubscribeStreamResponse{}, nil
 			},
@@ -36,7 +36,7 @@ func TestPublishStream(t *testing.T) {
 	t.Run("When tenant information is attached to incoming context, it is propagated from adapter to handler", func(t *testing.T) {
 		tid := "123456"
 		a := newStreamSDKAdapter(&streamAdapter{
-			publishStreamFunc: func(ctx context.Context, request *PublishStreamRequest) (*PublishStreamResponse, error) {
+			publishStreamFunc: func(ctx context.Context, _ *PublishStreamRequest) (*PublishStreamResponse, error) {
 				require.Equal(t, tid, tenant.IDFromContext(ctx))
 				return &PublishStreamResponse{}, nil
 			},
@@ -57,7 +57,7 @@ func TestRunStream(t *testing.T) {
 	t.Run("When tenant information is attached to incoming context, it is propagated from adapter to handler", func(t *testing.T) {
 		tid := "123456"
 		a := newStreamSDKAdapter(&streamAdapter{
-			runStreamFunc: func(ctx context.Context, req *RunStreamRequest, sender *StreamSender) error {
+			runStreamFunc: func(ctx context.Context, _ *RunStreamRequest, _ *StreamSender) error {
 				require.Equal(t, tid, tenant.IDFromContext(ctx))
 				return nil
 			},

--- a/build/utils/copy_test.go
+++ b/build/utils/copy_test.go
@@ -79,7 +79,7 @@ func compareDirs(t *testing.T, src, dst string) {
 
 	require.Equal(t, sfi.Mode(), dfi.Mode())
 
-	err = filepath.Walk(src, func(srcPath string, info os.FileInfo, err error) error {
+	err = filepath.Walk(src, func(srcPath string, _ os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/data/framestruct/converter_test.go
+++ b/data/framestruct/converter_test.go
@@ -788,7 +788,7 @@ func TestToDataframe(t *testing.T) {
 	})
 
 	// This test fails when run with -race when it's not threadsafe
-	t.Run("it is threadsafe", func(t *testing.T) {
+	t.Run("it is threadsafe", func(_ *testing.T) {
 		start := make(chan struct{})
 		end := make(chan struct{})
 
@@ -889,7 +889,7 @@ func TestOptions(t *testing.T) {
 			"Thing1": "1",
 		}
 
-		toError := func(i interface{}) (interface{}, error) {
+		toError := func(_ interface{}) (interface{}, error) {
 			return nil, errors.New("something bad")
 		}
 

--- a/experimental/e2e/fixture/fixture_test.go
+++ b/experimental/e2e/fixture/fixture_test.go
@@ -90,7 +90,7 @@ func TestFixtureMatch(t *testing.T) {
 		store := newFakeStorage()
 		_ = store.Load()
 		f := fixture.NewFixture(store)
-		f.WithMatcher(func(res *http.Request) *http.Response {
+		f.WithMatcher(func(_ *http.Request) *http.Response {
 			return nil
 		})
 		res := f.Match(store.entries[0].Request) // nolint:bodyclose

--- a/experimental/macros/time_macros.go
+++ b/experimental/macros/time_macros.go
@@ -9,14 +9,14 @@ import (
 )
 
 func FromMacro(inputString string, timeRange backend.TimeRange) (string, error) {
-	res, err := applyMacro("$$from", inputString, func(query string, args []string) (string, error) {
+	res, err := applyMacro("$$from", inputString, func(_ string, args []string) (string, error) {
 		return expandTimeMacro(timeRange.From, args)
 	})
 	return res, err
 }
 
 func ToMacro(inputString string, timeRange backend.TimeRange) (string, error) {
-	res, err := applyMacro("$$to", inputString, func(query string, args []string) (string, error) {
+	res, err := applyMacro("$$to", inputString, func(_ string, args []string) (string, error) {
 		return expandTimeMacro(timeRange.To, args)
 	})
 	return res, err

--- a/experimental/mock/roundtripper_test.go
+++ b/experimental/mock/roundtripper_test.go
@@ -164,7 +164,7 @@ func TestRoundTripper_RoundTrip(t *testing.T) {
 		{
 			name: "should skip GetResponse when nil values returned",
 			rt: &mock.RoundTripper{
-				GetResponse: func(req *http.Request) (*http.Response, error) {
+				GetResponse: func(_ *http.Request) (*http.Response, error) {
 					return nil, nil
 				},
 				Body: "default body",

--- a/internal/tenant/tenanttest/tenant_test.go
+++ b/internal/tenant/tenanttest/tenant_test.go
@@ -30,7 +30,7 @@ func TestTenantWithPluginInstanceManagement(t *testing.T) {
 	t.Log("addr:", addr)
 
 	factoryInvocations := 0
-	factory := datasource.InstanceFactoryFunc(func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+	factory := datasource.InstanceFactoryFunc(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		factoryInvocations++
 		return &testPlugin{}, nil
 	})


### PR DESCRIPTION
Before:
```
mage lint
WARN [config_reader] The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`.
WARN [config_reader] The configuration option `linters.errcheck.ignore` is deprecated, please use `linters.errcheck.exclude-functions`.
build/utils/copy_test.go:82:48: unused-parameter: parameter 'info' seems to be unused, consider removing or renaming it as _ (revive)
	err = filepath.Walk(src, func(srcPath string, info os.FileInfo, err error) error {
	                                              ^
data/framestruct/converter_test.go:791:33: unused-parameter: parameter 't' seems to be unused, consider removing or renaming it as _ (revive)
	t.Run("it is threadsafe", func(t *testing.T) {
	                               ^
data/framestruct/converter_test.go:892:19: unused-parameter: parameter 'i' seems to be unused, consider removing or renaming it as _ (revive)
		toError := func(i interface{}) (interface{}, error) {
		                ^
backend/httpclient/http_client.go:112:23: G402: TLS InsecureSkipVerify may be true. (gosec)
		InsecureSkipVerify: tlsOpts.InsecureSkipVerify,
		                    ^
backend/httpclient/http_client_test.go:51:56: unused-parameter: parameter 'opts' seems to be unused, consider removing or renaming it as _ (revive)
		client, err := New(Options{ConfigureMiddleware: func(opts Options, existingMiddleware []Middleware) []Middleware {
...
```

After
```
mage lint
WARN [config_reader] The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`.
WARN [config_reader] The configuration option `linters.errcheck.ignore` is deprecated, please use `linters.errcheck.exclude-functions`.
```