### PR TITLE
Add Admission hooks to auto management

### DIFF
--- a/backend/datasource/manage.go
+++ b/backend/datasource/manage.go
@@ -18,9 +18,6 @@ type ManageOpts struct {
 
 	// TracingOpts contains settings for tracing setup.
 	TracingOpts tracing.Opts
-
-	// Stateless admission handler
-	AdmissionHandler backend.AdmissionHandler
 }
 
 // Manage starts serving the data source over gPRC with automatic instance management.
@@ -46,7 +43,7 @@ func Manage(pluginID string, instanceFactory InstanceFactoryFunc, opts ManageOpt
 		CallResourceHandler: handler,
 		QueryDataHandler:    handler,
 		StreamHandler:       handler,
-		AdmissionHandler:    opts.AdmissionHandler,
+		AdmissionHandler:    handler,
 		GRPCSettings:        opts.GRPCSettings,
 	})
 }

--- a/internal/automanagement/manager.go
+++ b/internal/automanagement/manager.go
@@ -92,3 +92,36 @@ func (m *Manager) RunStream(ctx context.Context, req *backend.RunStreamRequest, 
 	}
 	return status.Error(codes.Unimplemented, "unimplemented")
 }
+
+func (m *Manager) ValidateAdmission(ctx context.Context, req *backend.AdmissionRequest) (*backend.ValidationResponse, error) {
+	h, err := m.Get(ctx, req.PluginContext)
+	if err != nil {
+		return nil, err
+	}
+	if ds, ok := h.(backend.AdmissionHandler); ok {
+		return ds.ValidateAdmission(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "unimplemented")
+}
+
+func (m *Manager) MutateAdmission(ctx context.Context, req *backend.AdmissionRequest) (*backend.MutationResponse, error) {
+	h, err := m.Get(ctx, req.PluginContext)
+	if err != nil {
+		return nil, err
+	}
+	if ds, ok := h.(backend.AdmissionHandler); ok {
+		return ds.MutateAdmission(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "unimplemented")
+}
+
+func (m *Manager) ConvertObject(ctx context.Context, req *backend.ConversionRequest) (*backend.ConversionResponse, error) {
+	h, err := m.Get(ctx, req.PluginContext)
+	if err != nil {
+		return nil, err
+	}
+	if ds, ok := h.(backend.AdmissionHandler); ok {
+		return ds.ConvertObject(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "unimplemented")
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

So plugins implementing the hooks `ValidateAdmission`, `MutateAdmission`  (and the still unused `ConvertObject`) are automatically detected.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Following #983

**Special notes for your reviewer**:

If you are curious, I tested this IRL with this plugin https://github.com/grafana/grafana-plugin-examples/pull/311
