### PR TITLE
slo - capture plugin duration for http based plugins

### DIFF
--- a/experimental/slo/metrics.go
+++ b/experimental/slo/metrics.go
@@ -132,11 +132,8 @@ func sanitizeLabelName(name string) (string, bool) {
 	return out.String(), true
 }
 
-// MetricsKey is a key for storing metrics in the context
-type MetricsKey string
-
 // DurationKey is a key for storing the duration in the context
-const DurationKey MetricsKey = "downstream_duration"
+type DurationKey struct{}
 
 // MetricsWrapper is a wrapper for a plugin that collects metrics
 type MetricsWrapper struct {
@@ -173,7 +170,7 @@ func NewMetricsWrapper(plugin any, s backend.DataSourceInstanceSettings, c ...Co
 
 // QueryData calls the QueryDataHandler and collects metrics
 func (ds *MetricsWrapper) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	ctx = context.WithValue(ctx, DurationKey, &Duration{value: 0})
+	ctx = context.WithValue(ctx, DurationKey{}, &Duration{value: 0})
 	metrics := ds.Metrics.WithEndpoint(EndpointQuery)
 
 	start := time.Now()
@@ -187,7 +184,7 @@ func (ds *MetricsWrapper) QueryData(ctx context.Context, req *backend.QueryDataR
 
 // CheckHealth calls the CheckHealthHandler and collects metrics
 func (ds *MetricsWrapper) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	ctx = context.WithValue(ctx, DurationKey, &Duration{value: 0})
+	ctx = context.WithValue(ctx, DurationKey{}, &Duration{value: 0})
 	metrics := ds.Metrics.WithEndpoint(EndpointHealth)
 
 	start := time.Now()
@@ -201,7 +198,7 @@ func (ds *MetricsWrapper) CheckHealth(ctx context.Context, req *backend.CheckHea
 
 // CallResource calls the CallResourceHandler and collects metrics
 func (ds *MetricsWrapper) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	ctx = context.WithValue(ctx, DurationKey, &Duration{value: 0})
+	ctx = context.WithValue(ctx, DurationKey{}, &Duration{value: 0})
 	metrics := ds.Metrics.WithEndpoint(EndpointResource)
 
 	start := time.Now()
@@ -215,7 +212,7 @@ func (ds *MetricsWrapper) CallResource(ctx context.Context, req *backend.CallRes
 
 func collectDuration(ctx context.Context, start time.Time, metrics Collector) {
 	totalDuration := time.Since(start).Seconds()
-	downstreamDuration := ctx.Value(DurationKey)
+	downstreamDuration := ctx.Value(DurationKey{})
 	if downstreamDuration != nil {
 		d := downstreamDuration.(*Duration)
 		pluginDuration := totalDuration - d.value

--- a/experimental/slo/metrics.go
+++ b/experimental/slo/metrics.go
@@ -131,7 +131,7 @@ const DurationKey MetricsKey = "downstream_duration"
 // MetricsWrapper is a wrapper for a plugin that collects metrics
 type MetricsWrapper struct {
 	Name               string
-	ID                 string
+	Type               string
 	healthcheckHandler backend.CheckHealthHandler
 	queryDataHandler   backend.QueryDataHandler
 	resourceHandler    backend.CallResourceHandler
@@ -142,8 +142,8 @@ type MetricsWrapper struct {
 func NewMetricsWrapper(plugin any, s backend.DataSourceInstanceSettings) *MetricsWrapper {
 	wrapper := &MetricsWrapper{
 		Name:    s.Name,
-		ID:      s.UID,
-		Metrics: NewMetrics(s.Name, s.UID),
+		Type:    s.Type,
+		Metrics: NewMetrics(s.Name, s.Type),
 	}
 	if h, ok := plugin.(backend.CheckHealthHandler); ok {
 		wrapper.healthcheckHandler = h

--- a/experimental/slo/metrics.go
+++ b/experimental/slo/metrics.go
@@ -53,7 +53,7 @@ var durationMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
 
 // NewMetrics creates a new Metrics instance
 func NewMetrics(dsName, dsType string) Metrics {
-	dsName, ok := SanitizeLabelName(dsName)
+	dsName, ok := sanitizeLabelName(dsName)
 	if !ok {
 		backend.Logger.Warn("Failed to sanitize datasource name for prometheus label", dsName)
 	}
@@ -73,7 +73,7 @@ func (m *Metrics) CollectDuration(source Source, status Status, statusCode int, 
 // SanitizeLabelName removes all invalid chars from the label name.
 // If the label name is empty or contains only invalid chars, it will return false indicating it was not sanitized.
 // copied from https://github.com/grafana/grafana/blob/main/pkg/infra/metrics/metricutil/utils.go#L14
-func SanitizeLabelName(name string) (string, bool) {
+func sanitizeLabelName(name string) (string, bool) {
 	if len(name) == 0 {
 		backend.Logger.Warn(fmt.Sprintf("label name cannot be empty: %s", name))
 		return "", false
@@ -181,4 +181,12 @@ func collectDuration(ctx context.Context, start time.Time, metrics Metrics) {
 		pluginDuration := totalDuration - d.Value
 		metrics.CollectDuration(d.Source, d.Status, d.StatusCode, pluginDuration)
 	}
+}
+
+func SanitizeLabelName(name string) (string, error) {
+	s, ok := sanitizeLabelName(name)
+	if ok {
+		return s, nil
+	}
+	return "", fmt.Errorf("failed to sanitize label name %s", name)
 }

--- a/experimental/slo/metrics.go
+++ b/experimental/slo/metrics.go
@@ -1,0 +1,184 @@
+package slo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics is an abstraction for collecting metrics
+type Metrics struct {
+	DSName   string
+	DSType   string
+	Endpoint Endpoint
+}
+
+// Duration is stored in the Context and used to collect metrics
+type Duration struct {
+	Value      float64
+	Status     Status
+	Source     Source
+	StatusCode int
+}
+
+// Status is the status of the request
+type Status string
+
+// Endpoint is the endpoint of the request (health, query, resource)
+type Endpoint string
+
+// Source is the source of the error (downstream, plugin)
+type Source string
+
+const (
+	StatusOK         Status   = "ok"
+	StatusError      Status   = "error"
+	EndpointHealth   Endpoint = "health"
+	EndpointQuery    Endpoint = "query"
+	EndpointResource Endpoint = "resource"
+	SourceDownstream Source   = "downstream"
+	SourcePlugin     Source   = "plugin"
+)
+
+var durationMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "plugins",
+	Name:      "plugin_request_duration_seconds",
+	Help:      "Duration of plugin execution",
+}, []string{"datasource_name", "datasource_type", "source", "endpoint", "status", "status_code"})
+
+// NewMetrics creates a new Metrics instance
+func NewMetrics(dsName, dsType string, endpoint Endpoint) Metrics {
+	dsName, ok := sanitizeLabelName(dsName)
+	if !ok {
+		backend.Logger.Warn("Failed to sanitize datasource name for prometheus label", dsName)
+	}
+	return Metrics{DSName: dsName, DSType: dsType, Endpoint: endpoint}
+}
+
+// WithEndpoint returns a new Metrics instance with the given endpoint
+func (m *Metrics) WithEndpoint(endpoint Endpoint) Metrics {
+	return Metrics{DSName: m.DSName, DSType: m.DSType, Endpoint: endpoint}
+}
+
+// CollectDuration collects the duration as a metric
+func (m *Metrics) CollectDuration(source Source, status Status, statusCode int, duration float64) {
+	durationMetric.WithLabelValues(m.DSName, m.DSType, string(source), string(m.Endpoint), string(status), fmt.Sprint(statusCode)).Observe(duration)
+}
+
+// sanitizeLabelName removes all invalid chars from the label name.
+// If the label name is empty or contains only invalid chars, it will return false indicating it was not sanitized.
+// copied from https://github.com/grafana/grafana/blob/main/pkg/infra/metrics/metricutil/utils.go#L14
+func sanitizeLabelName(name string) (string, bool) {
+	if len(name) == 0 {
+		backend.Logger.Warn(fmt.Sprintf("label name cannot be empty: %s", name))
+		return "", false
+	}
+
+	out := strings.Builder{}
+	for i, b := range name {
+		if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9' && i > 0) {
+			out.WriteRune(b)
+		} else if b == ' ' {
+			out.WriteRune('_')
+		}
+	}
+
+	if out.Len() == 0 {
+		backend.Logger.Warn(fmt.Sprintf("label name only contains invalid chars: %q", name))
+		return "", false
+	}
+
+	return out.String(), true
+}
+
+// MetricsKey is a key for storing metrics in the context
+type MetricsKey string
+
+// DurationKey is a key for storing the duration in the context
+const DurationKey MetricsKey = "downstream_duration"
+
+// MetricsWrapper is a wrapper for a plugin that collects metrics
+type MetricsWrapper struct {
+	Name               string
+	ID                 string
+	healthcheckHandler backend.CheckHealthHandler
+	queryDataHandler   backend.QueryDataHandler
+	resourceHandler    backend.CallResourceHandler
+	Metrics            Metrics
+}
+
+// NewMetricsWrapper creates a new MetricsWrapper instance
+func NewMetricsWrapper(plugin any, s backend.DataSourceInstanceSettings) *MetricsWrapper {
+	wrapper := &MetricsWrapper{
+		Name:    s.Name,
+		ID:      s.UID,
+		Metrics: NewMetrics(s.Name, s.UID, EndpointHealth),
+	}
+	if h, ok := plugin.(backend.CheckHealthHandler); ok {
+		wrapper.healthcheckHandler = h
+	}
+	if q, ok := plugin.(backend.QueryDataHandler); ok {
+		wrapper.queryDataHandler = q
+	}
+	if r, ok := plugin.(backend.CallResourceHandler); ok {
+		wrapper.resourceHandler = r
+	}
+	return wrapper
+}
+
+// QueryData calls the QueryDataHandler and collects metrics
+func (ds *MetricsWrapper) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	ctx = context.WithValue(ctx, DurationKey, &Duration{Value: 0})
+	metrics := NewMetrics(ds.Name, ds.ID, EndpointQuery)
+
+	start := time.Now()
+
+	defer func() {
+		collectDuration(ctx, start, metrics)
+	}()
+
+	return ds.queryDataHandler.QueryData(ctx, req)
+}
+
+// CheckHealth calls the CheckHealthHandler and collects metrics
+func (ds *MetricsWrapper) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	ctx = context.WithValue(ctx, DurationKey, &Duration{Value: 0})
+	metrics := NewMetrics(ds.Name, ds.ID, EndpointHealth)
+
+	start := time.Now()
+
+	defer func() {
+		collectDuration(ctx, start, metrics)
+	}()
+
+	return ds.healthcheckHandler.CheckHealth(ctx, req)
+}
+
+// CallResource calls the CallResourceHandler and collects metrics
+func (ds *MetricsWrapper) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	ctx = context.WithValue(ctx, DurationKey, &Duration{Value: 0})
+	metrics := NewMetrics(ds.Name, ds.ID, EndpointResource)
+
+	start := time.Now()
+
+	defer func() {
+		collectDuration(ctx, start, metrics)
+	}()
+
+	return ds.resourceHandler.CallResource(ctx, req, sender)
+}
+
+func collectDuration(ctx context.Context, start time.Time, metrics Metrics) {
+	totalDuration := time.Since(start).Seconds()
+	downstreamDuration := ctx.Value(DurationKey)
+	if downstreamDuration != nil {
+		d := downstreamDuration.(*Duration)
+		pluginDuration := totalDuration - d.Value
+		metrics.CollectDuration(d.Source, d.Status, d.StatusCode, pluginDuration)
+	}
+}

--- a/experimental/slo/metrics.go
+++ b/experimental/slo/metrics.go
@@ -74,7 +74,7 @@ const (
 var durationMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace: "plugins",
 	Name:      "plugin_request_duration_seconds",
-	Help:      "Duration of plugin execution",
+	Help:      "Duration of plugin execution excluding any downstream call duration",
 }, []string{"datasource_name", "datasource_type", "source", "endpoint", "status", "status_code"})
 
 // NewMetrics creates a new Metrics instance

--- a/experimental/slo/metrics.go
+++ b/experimental/slo/metrics.go
@@ -53,7 +53,7 @@ var durationMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
 
 // NewMetrics creates a new Metrics instance
 func NewMetrics(dsName, dsType string) Metrics {
-	dsName, ok := sanitizeLabelName(dsName)
+	dsName, ok := SanitizeLabelName(dsName)
 	if !ok {
 		backend.Logger.Warn("Failed to sanitize datasource name for prometheus label", dsName)
 	}
@@ -70,10 +70,10 @@ func (m *Metrics) CollectDuration(source Source, status Status, statusCode int, 
 	durationMetric.WithLabelValues(m.DSName, m.DSType, string(source), string(m.Endpoint), string(status), fmt.Sprint(statusCode)).Observe(duration)
 }
 
-// sanitizeLabelName removes all invalid chars from the label name.
+// SanitizeLabelName removes all invalid chars from the label name.
 // If the label name is empty or contains only invalid chars, it will return false indicating it was not sanitized.
 // copied from https://github.com/grafana/grafana/blob/main/pkg/infra/metrics/metricutil/utils.go#L14
-func sanitizeLabelName(name string) (string, bool) {
+func SanitizeLabelName(name string) (string, bool) {
 	if len(name) == 0 {
 		backend.Logger.Warn(fmt.Sprintf("label name cannot be empty: %s", name))
 		return "", false

--- a/experimental/slo/metrics_test.go
+++ b/experimental/slo/metrics_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func TestCheckHealthWithMetrics(t *testing.T) {
-	ds, err := test.NewTestDS()
+	ds, err := test.NewDS()
 	assert.Equal(t, nil, err)
 	req := health()
-	collector := &test.TestCollector{}
+	collector := &test.Collector{}
 	wrapper := slo.NewMetricsWrapper(ds, *req.PluginContext.DataSourceInstanceSettings, collector)
 
 	res, err := wrapper.CheckHealth(context.Background(), req)
@@ -25,10 +25,10 @@ func TestCheckHealthWithMetrics(t *testing.T) {
 }
 
 func TestQueryWithMetrics(t *testing.T) {
-	ds, err := test.NewTestDS()
+	ds, err := test.NewDS()
 	assert.Equal(t, nil, err)
 	req := query()
-	collector := &test.TestCollector{}
+	collector := &test.Collector{}
 	wrapper := slo.NewMetricsWrapper(ds, *req.PluginContext.DataSourceInstanceSettings, collector)
 
 	_, err = wrapper.QueryData(context.Background(), req)
@@ -38,10 +38,10 @@ func TestQueryWithMetrics(t *testing.T) {
 }
 
 func TestResourceWithMetrics(t *testing.T) {
-	ds, err := test.NewTestDS()
+	ds, err := test.NewDS()
 	assert.Equal(t, nil, err)
 	req := resource()
-	collector := &test.TestCollector{}
+	collector := &test.Collector{}
 	wrapper := slo.NewMetricsWrapper(ds, *req.PluginContext.DataSourceInstanceSettings, collector)
 
 	err = wrapper.CallResource(context.Background(), req, nil)

--- a/experimental/slo/metrics_test.go
+++ b/experimental/slo/metrics_test.go
@@ -20,11 +20,10 @@ func TestCheckHealthWithMetrics(t *testing.T) {
 	collector := &TestCollector{}
 	wrapper := slo.NewMetricsWrapper(ds, settings, collector)
 
-	ctx := context.Background()
-	res, err := wrapper.CheckHealth(ctx, req)
+	res, err := wrapper.CheckHealth(context.Background(), req)
+
 	assert.Equal(t, nil, err)
 	assert.Equal(t, backend.HealthStatusOk, res.Status)
-
 	assert.True(t, collector.duration > 0)
 }
 

--- a/experimental/slo/metrics_test.go
+++ b/experimental/slo/metrics_test.go
@@ -2,138 +2,80 @@ package slo_test
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/slo"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/slo/test"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckHealthWithMetrics(t *testing.T) {
-	ds := NewTestDS(t)
-	req, settings := setupHealthRequest()
-	collector := &TestCollector{}
-	wrapper := slo.NewMetricsWrapper(ds, settings, collector)
+	ds, err := test.NewTestDS()
+	assert.Equal(t, nil, err)
+	req := health()
+	collector := &test.TestCollector{}
+	wrapper := slo.NewMetricsWrapper(ds, *req.PluginContext.DataSourceInstanceSettings, collector)
 
 	res, err := wrapper.CheckHealth(context.Background(), req)
 
 	assert.Equal(t, nil, err)
 	assert.Equal(t, backend.HealthStatusOk, res.Status)
-	assert.True(t, collector.duration > 0)
+	assert.True(t, collector.Duration > 0)
 }
 
 func TestQueryWithMetrics(t *testing.T) {
-	ds := NewTestDS(t)
-	req, settings := setupQueryRequest()
-	collector := &TestCollector{}
-	wrapper := slo.NewMetricsWrapper(ds, settings, collector)
+	ds, err := test.NewTestDS()
+	assert.Equal(t, nil, err)
+	req := query()
+	collector := &test.TestCollector{}
+	wrapper := slo.NewMetricsWrapper(ds, *req.PluginContext.DataSourceInstanceSettings, collector)
 
-	_, err := wrapper.QueryData(context.Background(), req)
+	_, err = wrapper.QueryData(context.Background(), req)
 
 	assert.Equal(t, nil, err)
-	assert.True(t, collector.duration > 0)
+	assert.True(t, collector.Duration > 0)
 }
 
 func TestResourceWithMetrics(t *testing.T) {
-	ds := NewTestDS(t)
-	req, settings := setupResourceRequest()
-	collector := &TestCollector{}
-	wrapper := slo.NewMetricsWrapper(ds, settings, collector)
+	ds, err := test.NewTestDS()
+	assert.Equal(t, nil, err)
+	req := resource()
+	collector := &test.TestCollector{}
+	wrapper := slo.NewMetricsWrapper(ds, *req.PluginContext.DataSourceInstanceSettings, collector)
 
-	err := wrapper.CallResource(context.Background(), req, nil)
+	err = wrapper.CallResource(context.Background(), req, nil)
 
 	assert.Equal(t, nil, err)
-	assert.True(t, collector.duration > 0)
+	assert.True(t, collector.Duration > 0)
 }
 
-func NewTestDS(t *testing.T) *TestDS {
-	t.Helper()
-	client, clientErr := slo.NewClient()
-	assert.Equal(t, nil, clientErr)
-	return &TestDS{
-		client: client,
-	}
-}
-
-type TestDS struct {
-	client *http.Client
-}
-
-func (m TestDS) QueryData(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	err := callGet(ctx, m)
-	if err != nil {
-		return nil, err
-	}
-	return &backend.QueryDataResponse{}, nil
-}
-
-func (m TestDS) CheckHealth(ctx context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	err := callGet(ctx, m)
-	if err != nil {
-		return nil, err
-	}
-	return &backend.CheckHealthResult{
-		Status: backend.HealthStatusOk,
-	}, nil
-}
-
-func (m TestDS) CallResource(ctx context.Context, _ *backend.CallResourceRequest, _ backend.CallResourceResponseSender) error {
-	err := callGet(ctx, m)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func callGet(ctx context.Context, m TestDS) error {
-	r, err := http.NewRequestWithContext(ctx, "GET", "https://httpbin.org/get", nil)
-	if err != nil {
-		return err
-	}
-	res, err := m.client.Do(r)
-	if err != nil {
-		return err
-	}
-	defer res.Body.Close()
-	return nil
-}
-
-func setupHealthRequest() (*backend.CheckHealthRequest, backend.DataSourceInstanceSettings) {
-	settings := backend.DataSourceInstanceSettings{Name: "foo", UID: "uid", Type: "type", JSONData: []byte(`{}`), DecryptedSecureJSONData: map[string]string{}}
+func health() *backend.CheckHealthRequest {
 	return &backend.CheckHealthRequest{
-		PluginContext: backend.PluginContext{
-			DataSourceInstanceSettings: &settings,
-		},
-	}, settings
+		PluginContext: pluginCtx(),
+	}
 }
 
-func setupQueryRequest() (*backend.QueryDataRequest, backend.DataSourceInstanceSettings) {
-	settings := backend.DataSourceInstanceSettings{Name: "foo", UID: "uid", Type: "type", JSONData: []byte(`{}`), DecryptedSecureJSONData: map[string]string{}}
+func query() *backend.QueryDataRequest {
 	return &backend.QueryDataRequest{
-		PluginContext: backend.PluginContext{
-			DataSourceInstanceSettings: &settings,
-		},
-	}, settings
+		PluginContext: pluginCtx(),
+	}
 }
 
-func setupResourceRequest() (*backend.CallResourceRequest, backend.DataSourceInstanceSettings) {
-	settings := backend.DataSourceInstanceSettings{Name: "foo", UID: "uid", Type: "type", JSONData: []byte(`{}`), DecryptedSecureJSONData: map[string]string{}}
+func resource() *backend.CallResourceRequest {
 	return &backend.CallResourceRequest{
-		PluginContext: backend.PluginContext{
-			DataSourceInstanceSettings: &settings,
+		PluginContext: pluginCtx(),
+	}
+}
+
+func pluginCtx() backend.PluginContext {
+	return backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+			Name:                    "foo",
+			UID:                     "uid",
+			Type:                    "type",
+			JSONData:                []byte(`{}`),
+			DecryptedSecureJSONData: map[string]string{},
 		},
-	}, settings
-}
-
-type TestCollector struct {
-	duration float64
-}
-
-func (c *TestCollector) WithEndpoint(_ slo.Endpoint) slo.Collector {
-	return c
-}
-
-func (c *TestCollector) CollectDuration(_ slo.Source, _ slo.Status, _ int, duration float64) {
-	c.duration = duration
+	}
 }

--- a/experimental/slo/metrics_test.go
+++ b/experimental/slo/metrics_test.go
@@ -60,7 +60,7 @@ type TestDS struct {
 	client *http.Client
 }
 
-func (m TestDS) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+func (m TestDS) QueryData(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	err := callGet(ctx, m)
 	if err != nil {
 		return nil, err
@@ -68,7 +68,7 @@ func (m TestDS) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*
 	return &backend.QueryDataResponse{}, nil
 }
 
-func (m TestDS) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+func (m TestDS) CheckHealth(ctx context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	err := callGet(ctx, m)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (m TestDS) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest
 	}, nil
 }
 
-func (m TestDS) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+func (m TestDS) CallResource(ctx context.Context, _ *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
 	err := callGet(ctx, m)
 	if err != nil {
 		return err
@@ -130,7 +130,7 @@ type TestCollector struct {
 	duration float64
 }
 
-func (c *TestCollector) WithEndpoint(endpoint slo.Endpoint) slo.Collector {
+func (c *TestCollector) WithEndpoint(_ slo.Endpoint) slo.Collector {
 	return c
 }
 

--- a/experimental/slo/metrics_test.go
+++ b/experimental/slo/metrics_test.go
@@ -78,7 +78,7 @@ func (m TestDS) CheckHealth(ctx context.Context, _ *backend.CheckHealthRequest) 
 	}, nil
 }
 
-func (m TestDS) CallResource(ctx context.Context, _ *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+func (m TestDS) CallResource(ctx context.Context, _ *backend.CallResourceRequest, _ backend.CallResourceResponseSender) error {
 	err := callGet(ctx, m)
 	if err != nil {
 		return err

--- a/experimental/slo/metrics_test.go
+++ b/experimental/slo/metrics_test.go
@@ -1,0 +1,73 @@
+package slo_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/slo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckHealthWithMetrics(t *testing.T) {
+	client, clientErr := slo.NewClient()
+	assert.Equal(t, nil, clientErr)
+	ds := TestDS{
+		client: client,
+	}
+	req, settings := setupRequest()
+	collector := &TestCollector{}
+	wrapper := slo.NewMetricsWrapper(ds, settings, collector)
+
+	ctx := context.Background()
+	res, err := wrapper.CheckHealth(ctx, req)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, backend.HealthStatusOk, res.Status)
+
+	assert.True(t, collector.duration > 0)
+}
+
+type TestDS struct {
+	client *http.Client
+}
+
+func (m TestDS) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	return nil, nil
+}
+
+func (m TestDS) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	r, err := http.NewRequestWithContext(ctx, "GET", "https://httpbin.org/get", nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := m.client.Do(r)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	return &backend.CheckHealthResult{
+		Status: backend.HealthStatusOk,
+	}, nil
+}
+
+func setupRequest() (*backend.CheckHealthRequest, backend.DataSourceInstanceSettings) {
+	settings := backend.DataSourceInstanceSettings{Name: "foo", UID: "uid", Type: "type", JSONData: []byte(`{}`), DecryptedSecureJSONData: map[string]string{}}
+	return &backend.CheckHealthRequest{
+		PluginContext: backend.PluginContext{
+			DataSourceInstanceSettings: &settings,
+		},
+	}, settings
+}
+
+type TestCollector struct {
+	duration float64
+}
+
+func (c *TestCollector) WithEndpoint(endpoint slo.Endpoint) slo.Collector {
+	return c
+}
+
+func (c *TestCollector) CollectDuration(_ slo.Source, _ slo.Status, _ int, duration float64) {
+	c.duration = duration
+}

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -7,20 +7,24 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
-// MiddlewareName is the middleware name used by DurationMiddleware.
-const MiddlewareName = "Duration"
+var Logger = log.DefaultLogger
+
+// DataSourceSLOMiddlewareName is the middleware name used by DurationMiddleware.
+const DataSourceSLOMiddlewareName = "Duration"
 
 // Middleware applies the duration to the context.
 func Middleware() httpclient.Middleware {
-	return httpclient.NamedMiddlewareFunc(MiddlewareName, RoundTripper)
+	return httpclient.NamedMiddlewareFunc(DataSourceSLOMiddlewareName, RoundTripper)
 }
 
 // AddMiddleware adds the middleware to the http client options.
 func AddMiddleware(ctx context.Context, s *backend.DataSourceInstanceSettings) (httpclient.Options, error) {
 	opts, err := s.HTTPClientOptions(ctx)
 	if err != nil {
+		Logger.Error("failed to get datasource info", "error", err)
 		return opts, err
 	}
 	opts.Middlewares = append(opts.Middlewares, Middleware())

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -17,6 +17,7 @@ func Middleware() httpclient.Middleware {
 	return httpclient.NamedMiddlewareFunc(MiddlewareName, RoundTripper)
 }
 
+// AddMiddleware adds the middleware to the http client options.
 func AddMiddleware(ctx context.Context, s *backend.DataSourceInstanceSettings) (httpclient.Options, error) {
 	opts, err := s.HTTPClientOptions(ctx)
 	if err != nil {
@@ -26,7 +27,7 @@ func AddMiddleware(ctx context.Context, s *backend.DataSourceInstanceSettings) (
 	return opts, nil
 }
 
-// DurationRoundTripper captures the duration of the request in the context
+// RoundTripper captures the duration of the request in the context
 func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
 	return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		var duration *Duration

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -42,10 +42,10 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 		start := time.Now()
 
 		ctx := req.Context()
-		val := ctx.Value(DurationKey)
+		val := ctx.Value(DurationKey{})
 		if val == nil {
 			duration = &Duration{value: 0}
-			ctx = context.WithValue(ctx, DurationKey, duration)
+			ctx = context.WithValue(ctx, DurationKey{}, duration)
 			*req = *req.WithContext(ctx)
 		} else {
 			duration = val.(*Duration)

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -12,8 +12,8 @@ import (
 
 var Logger = log.DefaultLogger
 
-// DataSourceSLOMiddlewareName is the middleware name used by DurationMiddleware.
-const DataSourceSLOMiddlewareName = "Duration"
+// DataSourceSLOMiddlewareName is the middleware name used by Middleware.
+const DataSourceSLOMiddlewareName = "slo"
 
 // Middleware applies the duration to the context.
 func Middleware() httpclient.Middleware {

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -14,9 +14,7 @@ const DurationMiddlewareName = "Duration"
 
 // DurationMiddleware applies the duration to the context.
 func DurationMiddleware() httpclient.Middleware {
-	return httpclient.NamedMiddlewareFunc(DurationMiddlewareName, func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
-		return DurationRoundTripper(opts, next)
-	})
+	return httpclient.NamedMiddlewareFunc(DurationMiddlewareName, DurationRoundTripper)
 }
 
 func AddDurationMiddleware(ctx context.Context, s *backend.DataSourceInstanceSettings) (httpclient.Options, error) {

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -48,7 +48,7 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 			// so we always have to add the value to the context in the QueryData method
 			duration = &Duration{Value: 0}
 			ctx = context.WithValue(ctx, DurationKey, duration)
-			req = req.WithContext(ctx)
+			*req = *req.WithContext(ctx)
 		} else {
 			duration = val.(*Duration)
 		}

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -44,7 +44,7 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 		ctx := req.Context()
 		val := ctx.Value(DurationKey)
 		if val == nil {
-			duration = &Duration{Value: 0}
+			duration = &Duration{value: 0}
 			ctx = context.WithValue(ctx, DurationKey, duration)
 			*req = *req.WithContext(ctx)
 		} else {

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -71,3 +71,17 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 func FromStatus(status backend.Status) backend.ErrorSource {
 	return backend.ErrorSourceFromHTTPStatus(int(status))
 }
+
+// NewClient wraps the existing http client constructor and adds the duration middleware
+func NewClient(opts ...httpclient.Options) (*http.Client, error) {
+	if len(opts) == 0 {
+		opts = append(opts, httpclient.Options{
+			Middlewares: httpclient.DefaultMiddlewares(),
+		})
+	}
+	if len(opts[0].Middlewares) == 0 {
+		opts[0].Middlewares = httpclient.DefaultMiddlewares()
+	}
+	opts[0].Middlewares = append(opts[0].Middlewares, Middleware())
+	return httpclient.New(opts...)
+}

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -1,102 +1,90 @@
 package slo
 
 import (
-	"errors"
-	"fmt"
+	"context"
 	"net/http"
-	"strings"
-	"syscall"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var Logger = log.DefaultLogger
+// DurationMiddlewareName is the middleware name used by DurationMiddleware.
+const DurationMiddlewareName = "Duration"
 
-var duration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "plugins",
-	Name:      "plugin_external_requests_duration_seconds",
-	Help:      "Duration of requests to external services",
-}, []string{"datasource_name", "datasource_type", "error_source"})
-
-const DataSourceSLOMiddlewareName = "slo"
-
-// Middleware captures duration of requests to external services and the source of errors
-func Middleware() httpclient.Middleware {
-	return httpclient.NamedMiddlewareFunc(DataSourceSLOMiddlewareName, RoundTripper)
+// DurationMiddleware applies the duration to the context.
+func DurationMiddleware() httpclient.Middleware {
+	return httpclient.NamedMiddlewareFunc(DurationMiddlewareName, func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+		return DurationRoundTripper(opts, next)
+	})
 }
 
-// RoundTripper captures duration of requests to external services and the source of errors
-func RoundTripper(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
-	name, kind, err := getDSInfo(opts)
+func AddDurationMiddleware(ctx context.Context, s *backend.DataSourceInstanceSettings) (httpclient.Options, error) {
+	opts, err := s.HTTPClientOptions(ctx)
 	if err != nil {
-		Logger.Error("failed to get datasource info", "error", err)
-		return next
+		return opts, err
 	}
+	opts.Middlewares = append(opts.Middlewares, DurationMiddleware())
+	return opts, nil
+}
+
+// DurationRoundTripper captures the duration of the request in the context
+func DurationRoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
 	return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var duration *Duration
+		var httpErr error
+		var source = SourceDownstream
+		var statusCode int
+
 		start := time.Now()
-		var errorSource = "none"
+
+		ctx := req.Context()
+		val := ctx.Value(DurationKey)
+		if val == nil {
+			// TODO: this doesn't seem to change the context upstream
+			// so we always have to add the value to the context in the QueryData method
+			duration = &Duration{Value: 0}
+			ctx = context.WithValue(ctx, DurationKey, duration)
+			req = req.WithContext(ctx)
+		} else {
+			duration = val.(*Duration)
+		}
 
 		defer func() {
-			duration.WithLabelValues(name, kind, errorSource).Observe(time.Since(start).Seconds())
+			duration.Value += time.Since(start).Seconds()
+			if duration.Status == "" {
+				duration.Status = "ok"
+			}
+			if httpErr != nil {
+				duration.Status = "error"
+			}
+			if statusCode >= 400 {
+				duration.Status = "error"
+			}
+
+			// If the status code is now ok, but the previous status code was 401 or 403, mark it as ok
+			// assuming a successful re-authentication ( token refresh, etc )
+			if statusCode < 400 && (duration.StatusCode == 401 || duration.StatusCode == 403) {
+				duration.Status = "ok"
+			}
+
+			duration.StatusCode = statusCode
+			duration.Source = source
 		}()
 
 		res, err := next.RoundTrip(req)
-		if res != nil && res.StatusCode >= 400 {
-			errorSource = string(backend.ErrorSourceFromHTTPStatus(res.StatusCode))
+		if err != nil {
+			httpErr = err
 		}
-		if errors.Is(err, syscall.ECONNREFUSED) {
-			errorSource = string(backend.ErrorSourceDownstream)
+		if res != nil {
+			statusCode = res.StatusCode
+			source = Source(FromStatus(backend.Status(res.StatusCode)))
 		}
 		return res, err
 	})
 }
 
-func getDSInfo(opts httpclient.Options) (string, string, error) {
-	datasourceName, exists := opts.Labels["datasource_name"]
-	if !exists {
-		return "", "", errors.New("datasource_name label not found")
-	}
-
-	datasourceName, err := SanitizeLabelName(datasourceName)
-	// if the datasource named cannot be turned into a prometheus
-	// label we will skip instrumenting these metrics.
-	if err != nil {
-		return "", "", err
-	}
-
-	datasourceType, exists := opts.Labels["datasource_type"]
-	if !exists {
-		return "", "", errors.New("datasource_type label not found")
-	}
-
-	return datasourceName, datasourceType, nil
-}
-
-// SanitizeLabelName removes all invalid chars from the label name.
-// If the label name is empty or contains only invalid chars, it
-// will return an error.
-func SanitizeLabelName(name string) (string, error) {
-	if len(name) == 0 {
-		return "", errors.New("label name cannot be empty")
-	}
-
-	out := strings.Builder{}
-	for i, b := range name {
-		if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9' && i > 0) {
-			out.WriteRune(b)
-		} else if b == ' ' {
-			out.WriteRune('_')
-		}
-	}
-
-	if out.Len() == 0 {
-		return "", fmt.Errorf("label name only contains invalid chars: %q", name)
-	}
-
-	return out.String(), nil
+// FromStatus returns the error source from backend status
+func FromStatus(status backend.Status) backend.ErrorSource {
+	return backend.ErrorSourceFromHTTPStatus(int(status))
 }

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -54,25 +54,7 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 		}
 
 		defer func() {
-			duration.Value += time.Since(start).Seconds()
-			if duration.Status == "" {
-				duration.Status = "ok"
-			}
-			if httpErr != nil {
-				duration.Status = "error"
-			}
-			if statusCode >= 400 {
-				duration.Status = "error"
-			}
-
-			// If the status code is now ok, but the previous status code was 401 or 403, mark it as ok
-			// assuming a successful re-authentication ( token refresh, etc )
-			if statusCode < 400 && (duration.StatusCode == 401 || duration.StatusCode == 403) {
-				duration.Status = "ok"
-			}
-
-			duration.StatusCode = statusCode
-			duration.Source = source
+			duration.Add(time.Since(start).Seconds(), source, statusCode, httpErr)
 		}()
 
 		res, err := next.RoundTrip(req)

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -9,25 +9,25 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 )
 
-// DurationMiddlewareName is the middleware name used by DurationMiddleware.
-const DurationMiddlewareName = "Duration"
+// MiddlewareName is the middleware name used by DurationMiddleware.
+const MiddlewareName = "Duration"
 
-// DurationMiddleware applies the duration to the context.
-func DurationMiddleware() httpclient.Middleware {
-	return httpclient.NamedMiddlewareFunc(DurationMiddlewareName, DurationRoundTripper)
+// Middleware applies the duration to the context.
+func Middleware() httpclient.Middleware {
+	return httpclient.NamedMiddlewareFunc(MiddlewareName, RoundTripper)
 }
 
-func AddDurationMiddleware(ctx context.Context, s *backend.DataSourceInstanceSettings) (httpclient.Options, error) {
+func AddMiddleware(ctx context.Context, s *backend.DataSourceInstanceSettings) (httpclient.Options, error) {
 	opts, err := s.HTTPClientOptions(ctx)
 	if err != nil {
 		return opts, err
 	}
-	opts.Middlewares = append(opts.Middlewares, DurationMiddleware())
+	opts.Middlewares = append(opts.Middlewares, Middleware())
 	return opts, nil
 }
 
 // DurationRoundTripper captures the duration of the request in the context
-func DurationRoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
+func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
 	return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		var duration *Duration
 		var httpErr error

--- a/experimental/slo/slo_middleware.go
+++ b/experimental/slo/slo_middleware.go
@@ -44,8 +44,6 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 		ctx := req.Context()
 		val := ctx.Value(DurationKey)
 		if val == nil {
-			// TODO: this doesn't seem to change the context upstream
-			// so we always have to add the value to the context in the QueryData method
 			duration = &Duration{Value: 0}
 			ctx = context.WithValue(ctx, DurationKey, duration)
 			*req = *req.WithContext(ctx)

--- a/experimental/slo/slo_middleware_test.go
+++ b/experimental/slo/slo_middleware_test.go
@@ -22,9 +22,9 @@ func TestAddDuration(t *testing.T) {
 }
 
 func TestAddDurationExists(t *testing.T) {
-	duration := &slo.Duration{Value: 1}
+	duration := slo.NewDuration(1)
 	//nolint:bodyclose
-	next := MockRoundTripper{assert: assertDuration(t, duration.Value)}
+	next := MockRoundTripper{assert: assertDuration(t, duration.Value())}
 	fn := slo.RoundTripper(httpclient.Options{}, next)
 
 	req := &http.Request{}
@@ -38,7 +38,7 @@ func TestAddDurationExists(t *testing.T) {
 	err = res.Body.Close()
 	assert.Equal(t, err, nil)
 
-	assert.True(t, duration.Value > 1)
+	assert.True(t, duration.Value() > 1)
 }
 
 type MockRoundTripper struct {
@@ -55,7 +55,7 @@ func assertDuration(t *testing.T, want float64) func(req *http.Request) (*http.R
 		ctx := req.Context()
 		val := ctx.Value(slo.DurationKey)
 		assert.NotNil(t, val)
-		assert.Equal(t, want, val.(*slo.Duration).Value)
+		assert.Equal(t, want, val.(*slo.Duration).Value())
 
 		res := &http.Response{Body: http.NoBody}
 		return res, nil

--- a/experimental/slo/slo_middleware_test.go
+++ b/experimental/slo/slo_middleware_test.go
@@ -41,6 +41,7 @@ func (m MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func assertDuration(t *testing.T, want float64) func(req *http.Request) (*http.Response, error) {
+	t.Helper()
 	return func(req *http.Request) (*http.Response, error) {
 		ctx := req.Context()
 		val := ctx.Value(slo.DurationKey)

--- a/experimental/slo/slo_middleware_test.go
+++ b/experimental/slo/slo_middleware_test.go
@@ -47,6 +47,9 @@ func assertDuration(t *testing.T, want float64) func(req *http.Request) (*http.R
 		val := ctx.Value(slo.DurationKey)
 		assert.NotNil(t, val)
 		assert.Equal(t, want, val.(*slo.Duration).Value)
-		return nil, nil
+
+		res := &http.Response{Body: http.NoBody}
+		defer res.Body.Close()
+		return res, nil
 	}
 }

--- a/experimental/slo/slo_middleware_test.go
+++ b/experimental/slo/slo_middleware_test.go
@@ -1,0 +1,51 @@
+package slo_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/slo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddDuration(t *testing.T) {
+	next := MockRoundTripper{assert: assertDuration(t, 0)}
+	fn := slo.RoundTripper(httpclient.Options{}, next)
+	_, err := fn.RoundTrip(&http.Request{})
+	assert.Equal(t, err, nil)
+}
+
+func TestAddDurationExists(t *testing.T) {
+	duration := &slo.Duration{Value: 1}
+	next := MockRoundTripper{assert: assertDuration(t, duration.Value)}
+	fn := slo.RoundTripper(httpclient.Options{}, next)
+
+	req := &http.Request{}
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, slo.DurationKey, duration)
+	*req = *req.WithContext(ctx)
+
+	_, err := fn.RoundTrip(req)
+	assert.Equal(t, err, nil)
+	assert.True(t, duration.Value > 1)
+}
+
+type MockRoundTripper struct {
+	assert func(*http.Request) (*http.Response, error)
+}
+
+func (m MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.assert(req)
+}
+
+func assertDuration(t *testing.T, want float64) func(req *http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		ctx := req.Context()
+		val := ctx.Value(slo.DurationKey)
+		assert.NotNil(t, val)
+		assert.Equal(t, want, val.(*slo.Duration).Value)
+		return nil, nil
+	}
+}

--- a/experimental/slo/slo_middleware_test.go
+++ b/experimental/slo/slo_middleware_test.go
@@ -29,7 +29,7 @@ func TestAddDurationExists(t *testing.T) {
 
 	req := &http.Request{}
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, slo.DurationKey, duration)
+	ctx = context.WithValue(ctx, slo.DurationKey{}, duration)
 	*req = *req.WithContext(ctx)
 
 	res, err := fn.RoundTrip(req)
@@ -53,7 +53,7 @@ func assertDuration(t *testing.T, want float64) func(req *http.Request) (*http.R
 	t.Helper()
 	return func(req *http.Request) (*http.Response, error) {
 		ctx := req.Context()
-		val := ctx.Value(slo.DurationKey)
+		val := ctx.Value(slo.DurationKey{})
 		assert.NotNil(t, val)
 		assert.Equal(t, want, val.(*slo.Duration).Value())
 

--- a/experimental/slo/slo_middleware_test.go
+++ b/experimental/slo/slo_middleware_test.go
@@ -13,7 +13,10 @@ import (
 func TestAddDuration(t *testing.T) {
 	next := MockRoundTripper{assert: assertDuration(t, 0)}
 	fn := slo.RoundTripper(httpclient.Options{}, next)
-	_, err := fn.RoundTrip(&http.Request{})
+	res, err := fn.RoundTrip(&http.Request{})
+	assert.Equal(t, err, nil)
+
+	err = res.Body.Close()
 	assert.Equal(t, err, nil)
 }
 
@@ -27,8 +30,12 @@ func TestAddDurationExists(t *testing.T) {
 	ctx = context.WithValue(ctx, slo.DurationKey, duration)
 	*req = *req.WithContext(ctx)
 
-	_, err := fn.RoundTrip(req)
+	res, err := fn.RoundTrip(req)
 	assert.Equal(t, err, nil)
+
+	err = res.Body.Close()
+	assert.Equal(t, err, nil)
+
 	assert.True(t, duration.Value > 1)
 }
 
@@ -49,7 +56,6 @@ func assertDuration(t *testing.T, want float64) func(req *http.Request) (*http.R
 		assert.Equal(t, want, val.(*slo.Duration).Value)
 
 		res := &http.Response{Body: http.NoBody}
-		defer res.Body.Close()
 		return res, nil
 	}
 }

--- a/experimental/slo/slo_middleware_test.go
+++ b/experimental/slo/slo_middleware_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAddDuration(t *testing.T) {
+	//nolint:bodyclose
 	next := MockRoundTripper{assert: assertDuration(t, 0)}
 	fn := slo.RoundTripper(httpclient.Options{}, next)
 	res, err := fn.RoundTrip(&http.Request{})
@@ -22,6 +23,7 @@ func TestAddDuration(t *testing.T) {
 
 func TestAddDurationExists(t *testing.T) {
 	duration := &slo.Duration{Value: 1}
+	//nolint:bodyclose
 	next := MockRoundTripper{assert: assertDuration(t, duration.Value)}
 	fn := slo.RoundTripper(httpclient.Options{}, next)
 

--- a/experimental/slo/test/test_collector.go
+++ b/experimental/slo/test/test_collector.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/slo"
+)
+
+type TestCollector struct {
+	Duration float64
+}
+
+func (c *TestCollector) WithEndpoint(_ slo.Endpoint) slo.Collector {
+	return c
+}
+
+func (c *TestCollector) CollectDuration(_ slo.Source, _ slo.Status, _ int, duration float64) {
+	c.Duration = duration
+}

--- a/experimental/slo/test/test_collector.go
+++ b/experimental/slo/test/test_collector.go
@@ -4,14 +4,14 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/slo"
 )
 
-type TestCollector struct {
+type Collector struct {
 	Duration float64
 }
 
-func (c *TestCollector) WithEndpoint(_ slo.Endpoint) slo.Collector {
+func (c *Collector) WithEndpoint(_ slo.Endpoint) slo.Collector {
 	return c
 }
 
-func (c *TestCollector) CollectDuration(_ slo.Source, _ slo.Status, _ int, duration float64) {
+func (c *Collector) CollectDuration(_ slo.Source, _ slo.Status, _ int, duration float64) {
 	c.Duration = duration
 }

--- a/experimental/slo/test/test_datasource.go
+++ b/experimental/slo/test/test_datasource.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/slo"
+)
+
+func NewTestDS() (*TestDS, error) {
+	client, clientErr := slo.NewClient()
+	return &TestDS{
+		client: client,
+	}, clientErr
+}
+
+type TestDS struct {
+	client *http.Client
+}
+
+func (m TestDS) QueryData(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	err := callGet(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+	return &backend.QueryDataResponse{}, nil
+}
+
+func (m TestDS) CheckHealth(ctx context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	err := callGet(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+	return &backend.CheckHealthResult{
+		Status: backend.HealthStatusOk,
+	}, nil
+}
+
+func (m TestDS) CallResource(ctx context.Context, _ *backend.CallResourceRequest, _ backend.CallResourceResponseSender) error {
+	err := callGet(ctx, m)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func callGet(ctx context.Context, m TestDS) error {
+	r, err := http.NewRequestWithContext(ctx, "GET", "https://httpbin.org/get", nil)
+	if err != nil {
+		return err
+	}
+	res, err := m.client.Do(r)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	return nil
+}

--- a/experimental/slo/test/test_datasource.go
+++ b/experimental/slo/test/test_datasource.go
@@ -8,18 +8,18 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/slo"
 )
 
-func NewTestDS() (*TestDS, error) {
+func NewDS() (*DS, error) {
 	client, clientErr := slo.NewClient()
-	return &TestDS{
+	return &DS{
 		client: client,
 	}, clientErr
 }
 
-type TestDS struct {
+type DS struct {
 	client *http.Client
 }
 
-func (m TestDS) QueryData(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+func (m DS) QueryData(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	err := callGet(ctx, m)
 	if err != nil {
 		return nil, err
@@ -27,7 +27,7 @@ func (m TestDS) QueryData(ctx context.Context, _ *backend.QueryDataRequest) (*ba
 	return &backend.QueryDataResponse{}, nil
 }
 
-func (m TestDS) CheckHealth(ctx context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+func (m DS) CheckHealth(ctx context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	err := callGet(ctx, m)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func (m TestDS) CheckHealth(ctx context.Context, _ *backend.CheckHealthRequest) 
 	}, nil
 }
 
-func (m TestDS) CallResource(ctx context.Context, _ *backend.CallResourceRequest, _ backend.CallResourceResponseSender) error {
+func (m DS) CallResource(ctx context.Context, _ *backend.CallResourceRequest, _ backend.CallResourceResponseSender) error {
 	err := callGet(ctx, m)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func (m TestDS) CallResource(ctx context.Context, _ *backend.CallResourceRequest
 	return nil
 }
 
-func callGet(ctx context.Context, m TestDS) error {
+func callGet(ctx context.Context, m DS) error {
 	r, err := http.NewRequestWithContext(ctx, "GET", "https://httpbin.org/get", nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to capture execution time of plugin requests for SLO duration.

Changes here based on our last slo discussion.  The original plan was to capture 2 separate histogram metrics, then try to subtract them.  The recommendation by the prometheus team was not to do that, but to instead calculate before storing the metric.

How it works:

1. Middleware will capture the overall duration of a request that is spent making external calls and store it in the context.
2. The MetricsWrapper will initialize the Duration in the context or a request and calculate the plugin duration (overall duration - downstream duration)

This requires minimal changes in the plugin:
1.  Add the Metrics Middleware (or @marefr should we just add this to the existing middeware chain?)
2. Add the MetricsWrapper during plugin instantiation (though again, it seems we could just always do it from the sdk when instantiating a plugin? )
