### PR TITLE
Arrow: Expose frame to arrow.Table utility function

### DIFF
--- a/data/arrow.go
+++ b/data/arrow.go
@@ -62,7 +62,10 @@ func (f *Frame) MarshalArrow() ([]byte, error) {
 	return fb.Buff.Bytes(), nil
 }
 
-// Allocate an arrow table for the frame data
+// FrameToArrowTable creates a new arrow.Table from a data frame
+// To release the allocated memory be sure to call:
+//
+//	defer table.Release()
 func FrameToArrowTable(f *Frame) (arrow.Table, error) {
 	if _, err := f.RowLen(); err != nil {
 		return nil, err


### PR DESCRIPTION
The SDK currently will return a frame as arrow byte array -- this is fine for IPC, however when wanting to work directly with arrow (and convert to parquet!) access to the raw arrow/Table helps a lot.

This PR refactors the current marshal logic to expose the typed response not just `[]byte`