### PR TITLE
Chore: Move last pieces from Grafana's legacydata package into the SDK

### DIFF
--- a/backend/gtime/doc.go
+++ b/backend/gtime/doc.go
@@ -1,0 +1,2 @@
+// gtime provides utilities for parsing time, time ranges and time durations (intervals).
+package gtime

--- a/backend/gtime/time_range.go
+++ b/backend/gtime/time_range.go
@@ -1,0 +1,197 @@
+package gtime
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/jszwedko/go-datemath"
+)
+
+type TimeRange struct {
+	// From the raw start time in time range.
+	From string
+
+	// To the raw end time in time range.
+	To string
+
+	// Now the current time. Should normally only change in tests.
+	Now time.Time
+}
+
+// NewTimeRange creates a new TimeRange of From and To.
+func NewTimeRange(from, to string) TimeRange {
+	return TimeRange{
+		From: from,
+		To:   to,
+		Now:  time.Now(),
+	}
+}
+
+// GetFromAsMsEpoch parses start of time range and returns result in milliseconds epoch or the Unix epoch 0 equivalent if it fails.
+func (tr TimeRange) GetFromAsMsEpoch() int64 {
+	return tr.MustGetFrom().UnixNano() / int64(time.Millisecond)
+}
+
+// GetFromAsSecondsEpoch parses start of time range and returns result in seconds epoch or the Unix epoch 0 equivalent if it fails.
+func (tr TimeRange) GetFromAsSecondsEpoch() int64 {
+	return tr.GetFromAsMsEpoch() / 1000
+}
+
+// GetFromAsTimeUTC parses start of time range and returns result as time.Time in UTC timezone or the Unix epoch 0 equivalent if it fails.
+func (tr TimeRange) GetFromAsTimeUTC() time.Time {
+	return tr.MustGetFrom().UTC()
+}
+
+// GetToAsMsEpoch parses end of time range and returns result in milliseconds epoch or the Unix epoch 0 equivalent if it fails.
+func (tr TimeRange) GetToAsMsEpoch() int64 {
+	return tr.MustGetTo().UnixNano() / int64(time.Millisecond)
+}
+
+// GetToAsSecondsEpoch parses end of time range and returns result in seconds epoch or the Unix epoch 0 equivalent if it fails.
+func (tr TimeRange) GetToAsSecondsEpoch() int64 {
+	return tr.GetToAsMsEpoch() / 1000
+}
+
+// GetToAsTimeUTC parses end of time range and returns result as time.Time in UTC timezone or the Unix epoch 0 equivalent if it fails.
+func (tr TimeRange) GetToAsTimeUTC() time.Time {
+	return tr.MustGetTo().UTC()
+}
+
+// MustGetFrom parses start of time range and returns result as time.Time or the Unix epoch 0 equivalent if it fails.
+func (tr TimeRange) MustGetFrom() time.Time {
+	res, err := tr.ParseFrom()
+	if err != nil {
+		return time.Unix(0, 0)
+	}
+	return res
+}
+
+// MustGetTo parses end of time range and returns result as time.Time or the Unix epoch 0 equivalent if it fails.
+func (tr TimeRange) MustGetTo() time.Time {
+	res, err := tr.ParseTo()
+	if err != nil {
+		return time.Unix(0, 0)
+	}
+	return res
+}
+
+// ParseFrom parses start of time range with optional TimeRangeOption's and returns equivalent or an error.
+func (tr TimeRange) ParseFrom(options ...TimeRangeOption) (time.Time, error) {
+	options = append(options, WithNow(tr.Now))
+
+	pt := newParsableTime(tr.From, options...)
+	return pt.parse()
+}
+
+// ParseTo parses end of time range with optional TimeRangeOption's and returns time.Time or an error.
+func (tr TimeRange) ParseTo(options ...TimeRangeOption) (time.Time, error) {
+	options = append(options, WithRoundUp(), WithNow(tr.Now))
+
+	pt := newParsableTime(tr.To, options...)
+	return pt.parse()
+}
+
+// WithWeekstart time range option to set given weekday as the start of the week.
+func WithWeekstart(weekday time.Weekday) TimeRangeOption {
+	return func(timeRange parsableTime) parsableTime {
+		timeRange.weekstart = &weekday
+		return timeRange
+	}
+}
+
+// WithLocation time range option uses the given location loc as the timezone of the time range if unspecified.
+func WithLocation(loc *time.Location) TimeRangeOption {
+	return func(timeRange parsableTime) parsableTime {
+		timeRange.location = loc
+		return timeRange
+	}
+}
+
+// WithLocation time range option to set the start month of fiscal year.
+func WithFiscalStartMonth(month time.Month) TimeRangeOption {
+	return func(timeRange parsableTime) parsableTime {
+		timeRange.fiscalStartMonth = &month
+		return timeRange
+	}
+}
+
+// WithNow time range option to set the current time as t.
+func WithNow(t time.Time) TimeRangeOption {
+	return func(timeRange parsableTime) parsableTime {
+		timeRange.now = t
+		return timeRange
+	}
+}
+
+// WithRoundUp time range option to set the rounding of time to the end of the period instead of the beginning.
+func WithRoundUp() TimeRangeOption {
+	return func(timeRange parsableTime) parsableTime {
+		timeRange.roundUp = true
+		return timeRange
+	}
+}
+
+type parsableTime struct {
+	time             string
+	now              time.Time
+	location         *time.Location
+	weekstart        *time.Weekday
+	fiscalStartMonth *time.Month
+	roundUp          bool
+}
+
+// TimeRangeOption option for how to parse time ranges.
+type TimeRangeOption func(timeRange parsableTime) parsableTime
+
+func newParsableTime(t string, options ...TimeRangeOption) parsableTime {
+	p := parsableTime{
+		time: t,
+		now:  time.Now(),
+	}
+
+	for _, opt := range options {
+		p = opt(p)
+	}
+
+	return p
+}
+
+func (t parsableTime) parse() (time.Time, error) {
+	// Milliseconds since Unix epoch.
+	if val, err := strconv.ParseInt(t.time, 10, 64); err == nil {
+		return time.UnixMilli(val), nil
+	}
+
+	// Duration relative to current time.
+	if diff, err := time.ParseDuration("-" + t.time); err == nil {
+		return t.now.Add(diff), nil
+	}
+
+	// Advanced time string, mimics the frontend's datemath library.
+	return datemath.ParseAndEvaluate(t.time, t.datemathOptions()...)
+}
+
+func (t parsableTime) datemathOptions() []func(*datemath.Options) {
+	options := []func(*datemath.Options){
+		datemath.WithNow(t.now),
+		datemath.WithRoundUp(t.roundUp),
+	}
+	if t.location != nil {
+		options = append(options, datemath.WithLocation(t.location))
+	}
+	if t.weekstart != nil {
+		options = append(options, datemath.WithStartOfWeek(*t.weekstart))
+	}
+	if t.fiscalStartMonth != nil {
+		loc := time.UTC
+		if t.location != nil {
+			loc = t.location
+		}
+		options = append(options, datemath.WithStartOfFiscalYear(
+			// Year doesn't matter, and Grafana only supports setting the
+			// month that the fiscal year starts in.
+			time.Date(0, *t.fiscalStartMonth, 1, 0, 0, 0, 0, loc),
+		))
+	}
+	return options
+}

--- a/backend/gtime/time_range_test.go
+++ b/backend/gtime/time_range_test.go
@@ -1,0 +1,389 @@
+package gtime
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeRange(t *testing.T) {
+	now := time.Now()
+
+	t.Run("Can parse 5m, now", func(t *testing.T) {
+		tr := TimeRange{
+			From: "5m",
+			To:   "now",
+			Now:  now,
+		}
+
+		t.Run("5m ago ", func(t *testing.T) {
+			fiveMinAgo, err := time.ParseDuration("-5m")
+			require.Nil(t, err)
+			expected := now.Add(fiveMinAgo)
+
+			res, err := tr.ParseFrom()
+			require.Nil(t, err)
+			require.Equal(t, expected.Unix(), res.Unix())
+		})
+
+		t.Run("now ", func(t *testing.T) {
+			res, err := tr.ParseTo()
+			require.Nil(t, err)
+			require.Equal(t, now.Unix(), res.Unix())
+		})
+	})
+
+	t.Run("Can parse 5h, now-10m", func(t *testing.T) {
+		tr := TimeRange{
+			From: "5h",
+			To:   "now-10m",
+			Now:  now,
+		}
+
+		t.Run("5h ago ", func(t *testing.T) {
+			fiveHourAgo, err := time.ParseDuration("-5h")
+			require.Nil(t, err)
+			expected := now.Add(fiveHourAgo)
+
+			res, err := tr.ParseFrom()
+			require.Nil(t, err)
+			require.Equal(t, expected.Unix(), res.Unix())
+		})
+
+		t.Run("now-10m ", func(t *testing.T) {
+			tenMinAgo, err := time.ParseDuration("-10m")
+			require.Nil(t, err)
+			expected := now.Add(tenMinAgo)
+			res, err := tr.ParseTo()
+			require.Nil(t, err)
+			require.Equal(t, expected.Unix(), res.Unix())
+		})
+	})
+
+	now, err := time.Parse(time.RFC3339Nano, "2020-03-26T15:12:56.000Z")
+	require.Nil(t, err)
+	t.Run("Can parse now-1M/M, now-1M/M", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1M/M",
+			To:   "now-1M/M",
+			Now:  now,
+		}
+
+		t.Run("from now-1M/M ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-02-01T00:00:00.000Z")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFrom()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
+		})
+
+		t.Run("to now-1M/M ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-02-29T23:59:59.999Z")
+			require.Nil(t, err)
+
+			res, err := tr.ParseTo()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
+		})
+	})
+
+	t.Run("Can parse now-3d, now+3w", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-3d",
+			To:   "now+3w",
+			Now:  now,
+		}
+
+		t.Run("now-3d ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-03-23T15:12:56.000Z")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFrom()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
+		})
+
+		t.Run("now+3w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-04-16T15:12:56.000Z")
+			require.Nil(t, err)
+
+			res, err := tr.ParseTo()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
+		})
+	})
+
+	t.Run("Can parse now/fy, now/fQ for 1994-02-26T14:00:00.000Z with fiscal year starting in July", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now/fy",
+			To:   "now/fQ",
+			Now:  time.Date(1994, time.February, 26, 14, 0, 0, 0, time.UTC),
+		}
+
+		start, err := tr.ParseFrom(WithFiscalStartMonth(time.July))
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			time.Date(1993, time.July, 1, 0, 0, 0, 0, time.UTC),
+			start,
+		)
+
+		end, err := tr.ParseTo(WithFiscalStartMonth(time.July))
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			time.Date(1994, time.April, 1, 0, 0, 0, 0, time.UTC).Add(-time.Millisecond),
+			end,
+		)
+	})
+
+	t.Run("Can parse 1960-02-01T07:00:00.000Z, 1965-02-03T08:00:00.000Z", func(t *testing.T) {
+		tr := TimeRange{
+			From: "1960-02-01T07:00:00.000Z",
+			To:   "1965-02-03T08:00:00.000Z",
+			Now:  now,
+		}
+
+		t.Run("1960-02-01T07:00:00.000Z ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "1960-02-01T07:00:00.000Z")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFrom()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
+		})
+
+		t.Run("1965-02-03T08:00:00.000Z ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "1965-02-03T08:00:00.000Z")
+			require.Nil(t, err)
+
+			res, err := tr.ParseTo()
+			require.Nil(t, err)
+			require.Equal(t, expected, res)
+		})
+	})
+
+	t.Run("Can parse negative unix epochs", func(t *testing.T) {
+		from := time.Date(1960, 2, 1, 7, 0, 0, 0, time.UTC)
+		to := time.Date(1965, 2, 3, 8, 0, 0, 0, time.UTC)
+		tr := NewTimeRange(strconv.FormatInt(from.UnixNano()/int64(time.Millisecond), 10), strconv.FormatInt(to.UnixNano()/int64(time.Millisecond), 10))
+
+		res, err := tr.ParseFrom()
+		require.Nil(t, err)
+		require.True(t, from.Equal(res))
+
+		res, err = tr.ParseTo()
+		require.Nil(t, err)
+		require.True(t, to.Equal(res))
+	})
+
+	t.Run("can parse unix epochs", func(t *testing.T) {
+		var err error
+		tr := TimeRange{
+			From: "1474973725473",
+			To:   "1474975757930",
+			Now:  now,
+		}
+
+		res, err := tr.ParseFrom()
+		require.Nil(t, err)
+		require.Equal(t, int64(1474973725473), res.UnixNano()/int64(time.Millisecond))
+
+		res, err = tr.ParseTo()
+		require.Nil(t, err)
+		require.Equal(t, int64(1474975757930), res.UnixNano()/int64(time.Millisecond))
+	})
+
+	t.Run("Cannot parse asdf", func(t *testing.T) {
+		var err error
+		tr := TimeRange{
+			From: "asdf",
+			To:   "asdf",
+			Now:  now,
+		}
+
+		_, err = tr.ParseFrom()
+		require.Error(t, err)
+
+		_, err = tr.ParseTo()
+		require.Error(t, err)
+	})
+
+	now, err = time.Parse(time.RFC3339Nano, "2020-07-26T15:12:56.000Z")
+	require.Nil(t, err)
+
+	t.Run("Can parse now-1M/M, now-1M/M with America/Chicago timezone", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1M/M",
+			To:   "now-1M/M",
+			Now:  now,
+		}
+		location, err := time.LoadLocation("America/Chicago")
+		require.Nil(t, err)
+
+		t.Run("from now-1M/M ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-06-01T00:00:00.000-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFrom(WithLocation(location))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+
+		t.Run("to now-1M/M ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-06-30T23:59:59.999-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseTo(WithLocation(location))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+	})
+
+	t.Run("Can parse now-3h, now+2h with America/Chicago timezone", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-3h",
+			To:   "now+2h",
+			Now:  now,
+		}
+		location, err := time.LoadLocation("America/Chicago")
+		require.Nil(t, err)
+
+		t.Run("now-3h ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-26T07:12:56.000-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFrom(WithLocation(location))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+
+		t.Run("now+2h ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-26T12:12:56.000-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseTo(WithLocation(location))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+	})
+
+	t.Run("Can parse now-1w/w, now-1w/w without timezone and week start on Monday", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1w/w",
+			To:   "now-1w/w",
+			Now:  now,
+		}
+		weekstart := time.Monday
+		require.Nil(t, err)
+
+		t.Run("from now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-13T00:00:00.000Z")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFrom(WithWeekstart(weekstart))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+
+		t.Run("to now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T23:59:59.999Z")
+			require.Nil(t, err)
+
+			res, err := tr.ParseTo(WithWeekstart(weekstart))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+	})
+
+	t.Run("Can parse now-1w/w, now-1w/w with America/Chicago timezone and week start on Monday", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1w/w",
+			To:   "now-1w/w",
+			Now:  now,
+		}
+		weekstart := time.Monday
+		location, err := time.LoadLocation("America/Chicago")
+		require.Nil(t, err)
+
+		t.Run("from now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-13T00:00:00.000-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFrom(WithLocation(location), WithWeekstart(weekstart))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+
+		t.Run("to now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T23:59:59.999-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseTo(WithLocation(location), WithWeekstart(weekstart))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+	})
+
+	t.Run("Can parse now-1w/w, now-1w/w with America/Chicago timezone and week start on Sunday", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1w/w",
+			To:   "now-1w/w",
+			Now:  now,
+		}
+		weekstart := time.Sunday
+		location, err := time.LoadLocation("America/Chicago")
+		require.Nil(t, err)
+
+		t.Run("from now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T00:00:00.000-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFrom(WithLocation(location), WithWeekstart(weekstart))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+
+		t.Run("to now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-25T23:59:59.999-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseTo(WithLocation(location), WithWeekstart(weekstart))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+	})
+
+	t.Run("Can parse now-1w/w, now-1w/w with America/Chicago timezone and week start on Saturday", func(t *testing.T) {
+		tr := TimeRange{
+			From: "now-1w/w",
+			To:   "now-1w/w",
+			Now:  now,
+		}
+		weekstart := time.Saturday
+		location, err := time.LoadLocation("America/Chicago")
+		require.Nil(t, err)
+
+		t.Run("from now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-18T00:00:00.000-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseFrom(WithLocation(location), WithWeekstart(weekstart))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+
+		t.Run("to now-1w/w ", func(t *testing.T) {
+			expected, err := time.Parse(time.RFC3339Nano, "2020-07-24T23:59:59.999-05:00")
+			require.Nil(t, err)
+
+			res, err := tr.ParseTo(WithLocation(location), WithWeekstart(weekstart))
+			require.Nil(t, err)
+			require.True(t, expected.Equal(res))
+		})
+	})
+}

--- a/experimental/apis/data/v0alpha1/conversions.go
+++ b/experimental/apis/data/v0alpha1/conversions.go
@@ -1,0 +1,84 @@
+package v0alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
+)
+
+// ToDataSourceQueries returns queries that should be sent to a single datasource
+// This will throw an error if the queries reference multiple instances
+func ToDataSourceQueries(req QueryDataRequest) ([]backend.DataQuery, *DataSourceRef, error) {
+	var dsRef *DataSourceRef
+	var tr *backend.TimeRange
+	if req.From != "" {
+		val := gtime.NewTimeRange(req.From, req.To)
+		tr = &backend.TimeRange{
+			From: val.GetFromAsTimeUTC(),
+			To:   val.GetToAsTimeUTC(),
+		}
+	}
+
+	queries := []backend.DataQuery{}
+	if len(req.Queries) > 0 {
+		dsRef := req.Queries[0].Datasource
+		for _, generic := range req.Queries {
+			if generic.Datasource != nil && dsRef != nil {
+				if dsRef.Type != generic.Datasource.Type {
+					return queries, dsRef, fmt.Errorf("expect same datasource types")
+				}
+				if dsRef.UID != generic.Datasource.UID {
+					return queries, dsRef, fmt.Errorf("expect same datasource UID")
+				}
+			}
+			q, err := toBackendDataQuery(generic, tr)
+			if err != nil {
+				return queries, dsRef, err
+			}
+			queries = append(queries, q)
+		}
+		return queries, dsRef, nil
+	}
+	return queries, dsRef, nil
+}
+
+// Converts a generic query to a backend one
+func toBackendDataQuery(q DataQuery, defaultTimeRange *backend.TimeRange) (backend.DataQuery, error) {
+	var err error
+	bq := backend.DataQuery{
+		RefID:         q.RefID,
+		QueryType:     q.QueryType,
+		MaxDataPoints: q.MaxDataPoints,
+	}
+
+	// Set an explicit time range for the query
+	if q.TimeRange != nil {
+		tr := gtime.NewTimeRange(q.TimeRange.From, q.TimeRange.To)
+		bq.TimeRange = backend.TimeRange{
+			From: tr.GetFromAsTimeUTC(),
+			To:   tr.GetToAsTimeUTC(),
+		}
+	} else if defaultTimeRange != nil {
+		bq.TimeRange = *defaultTimeRange
+	}
+
+	bq.JSON, err = json.Marshal(q)
+	if err != nil {
+		return bq, err
+	}
+	if bq.RefID == "" {
+		bq.RefID = "A"
+	}
+	if bq.MaxDataPoints == 0 {
+		bq.MaxDataPoints = 100
+	}
+	if q.IntervalMS > 0 {
+		bq.Interval = time.Millisecond * time.Duration(q.IntervalMS)
+	} else {
+		bq.Interval = time.Second
+	}
+	return bq, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/invopop/yaml v0.2.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/jszwedko/go-datemath v0.1.1-0.20230526204004-640a500621d6 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jszwedko/go-datemath v0.1.1-0.20230526204004-640a500621d6 h1:SwcnSwBR7X/5EHJQlXBockkJVIMRVt5yKaesBPMtyZQ=
+github.com/jszwedko/go-datemath v0.1.1-0.20230526204004-640a500621d6/go.mod h1:WrYiIuiXUMIvTDAQw97C+9l0CnBmCcvosPjN3XDqS/o=
 github.com/jtolds/gls v4.2.1+incompatible h1:fSuqC+Gmlu6l/ZYAoZzx2pyucC8Xza35fpRVWLVmUEE=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -198,6 +200,8 @@ github.com/unknwon/log v0.0.0-20150304194804-e617c87089d3/go.mod h1:1xEUf2abjfP9
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.15 h1:nuqt+pdC/KqswQKhETJjo7pvn/k4xMUxgW6liI7XpnM=
 github.com/urfave/cli v1.22.15/go.mod h1:wSan1hmo5zeyLGBjRJbzRTNk8gwoYa2B9n4q9dmRIc0=
+github.com/vectordotdev/go-datemath v0.1.1-0.20220323213446-f3954d0b18ae h1:oyiy3uBj1F4O3AaFh7hUGBrJjAssJhKyAbwxtkslxqo=
+github.com/vectordotdev/go-datemath v0.1.1-0.20220323213446-f3954d0b18ae/go.mod h1:PnwzbSst7KD3vpBzzlntZU5gjVa455Uqa5QPiKSYJzQ=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up from https://github.com/grafana/grafana/pull/88772 moving time range utilities to SDK existing gtime package and some conversion logic into experimental/apis/data/v0alpha1 so that we can completely remove the legacydata package in grafana.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
Using latest commit of github.com/jszwedko/go-datemath instead of github.com/vectordotdev/go-datemath - the repository was renamed as far as I understand which is the only change between these two.
