### PR TITLE
Nested backend binaries should live in respective directories

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -28,6 +28,18 @@ mage -v build
 
 The `-v` flag can be used to show verbose output when running Mage targets.
 
+### Nested plugins
+If you are developing an app plugin that contains a backend data source plugin, you can use the `build` target to build the data source plugin. 
+The data source plugin.json should have the `backend` field set to `true` and the `executable` field set to the name of the binary, prefixed with "gpx_". The 
+`executable` field does not support file paths, nor should not include the file extension.
+
+```json
+{
+  "backend": true,
+  "executable": "gpx_foo-datasource"
+}
+```
+
 ### Testing
 
 ```bash

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -28,18 +28,6 @@ mage -v build
 
 The `-v` flag can be used to show verbose output when running Mage targets.
 
-### Nested plugins
-If you are developing an app plugin that contains a backend data source plugin, you can use the `build` target to build the data source plugin. 
-The data source plugin.json should have the `backend` field set to `true` and the `executable` field set to the name of the binary, prefixed with "gpx_". The 
-`executable` field does not support file paths, nor should not include the file extension.
-
-```json
-{
-  "backend": true,
-  "executable": "gpx_foo-datasource"
-}
-```
-
 ### Testing
 
 ```bash

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
+	"path/filepath"
 )
 
 func GetStringValueFromJSON(fpath string, key string) (string, error) {
@@ -32,12 +32,10 @@ func GetExecutableFromPluginJSON(dir string) (string, error) {
 	if err != nil {
 		// In app plugins, the exe may be nested
 		exe, err2 := GetStringValueFromJSON(path.Join(dir, "datasource", "plugin.json"), "executable")
-		if err2 == nil {
-			if !strings.HasPrefix(exe, "../") {
-				return "", fmt.Errorf("datasource should reference executable in root folder")
-			}
-			return exe[3:], nil
+		if err2 != nil {
+			return "", err
 		}
+		return filepath.Join("datasource", exe), nil
 	}
 	return exe, err
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -27,15 +27,18 @@ func GetStringValueFromJSON(fpath string, key string) (string, error) {
 	return name, nil
 }
 
+// GetExecutableFromPluginJSON retrieves the executable from a plugin.json file in the provided directory.
+// If the executable is not found in the root of the directory, it will look in a nested 'datasource' directory.
+// If an executable value is found, it will call filepath.Base on the value to ensure that the executable is returned without any path information.
 func GetExecutableFromPluginJSON(dir string) (string, error) {
 	exe, err := GetStringValueFromJSON(path.Join(dir, "plugin.json"), "executable")
 	if err != nil {
-		// In app plugins, the exe may be nested
+		// In app plugins, the nested plugin executable may be nested in a datasource directory
 		exe, err2 := GetStringValueFromJSON(path.Join(dir, "datasource", "plugin.json"), "executable")
 		if err2 != nil {
 			return "", err
 		}
-		return filepath.Join("datasource", exe), nil
+		return filepath.Join("datasource", filepath.Base(exe)), nil
 	}
-	return exe, err
+	return filepath.Base(exe), err
 }

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -47,6 +47,15 @@ func TestGetExecutableFromPluginJSON(t *testing.T) {
 			pluginJSONDir: filepath.Join("foobar-app", "foobar-datasource"),
 			err:           true,
 		},
+		{
+			name: "Can support relative paths in executable field of plugin.json (for backwards compatibility)",
+			args: args{
+				pluginDir: "foobar-app",
+			},
+			pluginJSONDir: filepath.Join("foobar-app", "datasource"),
+			executable:    "../gpx_foo",
+			expected:      "gpx_foo",
+		},
 	}
 
 	for _, tc := range tcs {

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -48,13 +48,13 @@ func TestGetExecutableFromPluginJSON(t *testing.T) {
 			err:           true,
 		},
 		{
-			name: "Can support relative paths in executable field of plugin.json (for backwards compatibility)",
+			name: "Should remove path information from executable field",
 			args: args{
 				pluginDir: "foobar-app",
 			},
 			pluginJSONDir: filepath.Join("foobar-app", "datasource"),
 			executable:    "../gpx_foo",
-			expected:      "gpx_foo",
+			expected:      "datasource/gpx_foo",
 		},
 	}
 

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,0 +1,74 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetExecutableFromPluginJSON(t *testing.T) {
+	type args struct {
+		pluginDir string
+	}
+	tcs := []struct {
+		name          string
+		args          args
+		executable    string
+		pluginJSONDir string
+		expected      string
+		err           bool
+	}{
+		{
+			name: "Can retrieve executable from a plugin.json found in provided directory",
+			args: args{
+				pluginDir: "foobar-datasource",
+			},
+			pluginJSONDir: "foobar-datasource",
+			executable:    "gpx_foo",
+			expected:      "gpx_foo",
+		},
+		{
+			name: "Can retrieve executable from plugin.json found in nested 'datasource' directory (when not found in root of provided directory)",
+			args: args{
+				pluginDir: "foobar-app",
+			},
+			pluginJSONDir: filepath.Join("foobar-app", "datasource"),
+			executable:    "gpx_foo",
+			expected:      filepath.Join("datasource", "gpx_foo"),
+		},
+		{
+			name: "Cannot retrieve executable when no plugin.json in root or nested 'datasource' directory",
+			args: args{
+				pluginDir: "foobar-app",
+			},
+			pluginJSONDir: filepath.Join("foobar-app", "foobar-datasource"),
+			err:           true,
+		},
+	}
+
+	for _, tc := range tcs {
+		rootDir := t.TempDir()
+		pluginRootDir := filepath.Join(rootDir, tc.pluginJSONDir)
+		err := os.MkdirAll(pluginRootDir, os.ModePerm)
+		require.NoError(t, err)
+		f, err := os.Create(filepath.Join(pluginRootDir, "plugin.json"))
+		require.NoError(t, err)
+
+		_, err = f.WriteString(fmt.Sprintf(`{"executable": %q}`, tc.executable))
+		require.NoError(t, err)
+		err = f.Close()
+		require.NoError(t, err)
+
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GetExecutableFromPluginJSON(filepath.Join(rootDir, tc.args.pluginDir))
+			if tc.err {
+				require.Error(t, err)
+				return
+			}
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
If working with an app that bundles a backend datasource - the current build process will place the binaries in the root directory as this is enforced by the code (see error `datasource should reference executable in root folder`). This requires developers to treat the `executable` plugin.json field as a file path ([Zabbix](https://github.com/grafana/grafana-zabbix/blob/main/src/datasource/plugin.json#L9), [Twinmaker](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/datasource/plugin.json#L10)). This is problematic for running on Windows as it requires Grafana to handle UNIX style file paths as Windows style.

Instead it should be possible to just build the binaries in the nested folders. For example:

Before:
```json
{
  "executable": "../gpx_foobar-datasource",
}
```

```
./plugin.json
./module.js
./gpx_foobar-datasource_darwin_arm64
./datasource/plugin.json
./datasource/module.js
```

After:
```json
{
  "executable": "gpx_foobar-datasource",
}
```

```
./plugin.json
./module.js
./datasource/plugin.json
./datasource/module.js
./datasource/gpx_foobar-datasource_darwin_arm64
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana-plugin-sdk-go/issues/980

**Special notes for your reviewer**:
There's also a test for backwards compatibility.