### PR TITLE
Remove restriction for executable relative file path for nested datasource plugins

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -33,10 +33,10 @@ func GetExecutableFromPluginJSON(dir string) (string, error) {
 		// In app plugins, the exe may be nested
 		exe, err2 := GetStringValueFromJSON(path.Join(dir, "datasource", "plugin.json"), "executable")
 		if err2 == nil {
-			if !strings.HasPrefix(exe, "../") {
-				return "", fmt.Errorf("datasource should reference executable in root folder")
+			if strings.HasPrefix(exe, "../") {
+				return exe[3:], nil
 			}
-			return exe[3:], nil
+			return exe, nil
 		}
 	}
 	return exe, err

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,0 +1,83 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetExecutableFromPluginJSON(t *testing.T) {
+	type args struct {
+		pluginDir string
+	}
+	tcs := []struct {
+		name          string
+		args          args
+		executable    string
+		pluginJSONDir string
+		expected      string
+		err           bool
+	}{
+		{
+			name: "Can retrieve executable from a plugin.json found in provided directory",
+			args: args{
+				pluginDir: "foobar-datasource",
+			},
+			pluginJSONDir: "foobar-datasource",
+			executable:    "gpx_foo",
+			expected:      "gpx_foo",
+		},
+		{
+			name: "Can retrieve executable from plugin.json found in nested 'datasource' directory (when not found in root of provided directory)",
+			args: args{
+				pluginDir: "foobar-app",
+			},
+			pluginJSONDir: filepath.Join("foobar-app", "datasource"),
+			executable:    "gpx_foo",
+			expected:      "gpx_foo",
+		},
+		{
+			name: "Cannot retrieve executable when no plugin.json in root or nested 'datasource' directory",
+			args: args{
+				pluginDir: "foobar-app",
+			},
+			pluginJSONDir: filepath.Join("foobar-app", "foobar-datasource"),
+			err:           true,
+		},
+		{
+			name: "Should remove path information from executable field of nested 'datasource' plugin.json",
+			args: args{
+				pluginDir: "foobar-app",
+			},
+			pluginJSONDir: filepath.Join("foobar-app", "datasource"),
+			executable:    "../gpx_foo",
+			expected:      "gpx_foo",
+		},
+	}
+
+	for _, tc := range tcs {
+		rootDir := t.TempDir()
+		pluginRootDir := filepath.Join(rootDir, tc.pluginJSONDir)
+		err := os.MkdirAll(pluginRootDir, os.ModePerm)
+		require.NoError(t, err)
+		f, err := os.Create(filepath.Join(pluginRootDir, "plugin.json"))
+		require.NoError(t, err)
+
+		_, err = f.WriteString(fmt.Sprintf(`{"executable": %q}`, tc.executable))
+		require.NoError(t, err)
+		err = f.Close()
+		require.NoError(t, err)
+
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GetExecutableFromPluginJSON(filepath.Join(rootDir, tc.args.pluginDir))
+			if tc.err {
+				require.Error(t, err)
+				return
+			}
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
For datasource plugins that are nested within an app, today they are required to specify their executable plugin.json field as a file path in parent plugin's folder. ([Zabbix](https://github.com/grafana/grafana-zabbix/blob/main/src/datasource/plugin.json#L9), [Twinmaker](https://github.com/grafana/grafana-iot-twinmaker-app/blob/main/src/datasource/plugin.json#L10)). I don't think we need to be so restrictive, especially since it causes [issues with reading these paths on Windows](https://github.com/grafana/grafana/issues/83416).

Now you can either specify the nested executable field as `../gpx_foo` or `gpx_foo` - both of which will have the same effect. The plan once this PR is merged is that we can remove path information from plugins that are using it - which will fix the issue of building on Windows.

Which issue(s) this PR fixes:
Fixes https://github.com/grafana/grafana-plugin-sdk-go/issues/980.

Special notes for your reviewer:
There's also a test for backwards compatibility.
