### PR TITLE
Nested plugin binaries are output to their respective directories

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -115,17 +115,17 @@ func getBuildBackendCmdInfo(cfg Config) (Config, []string, error) {
 	if err != nil {
 		// Look for a nested backend data source plugin
 		nestedPluginJSONPath := defaultNestedDataSourcePath
-		if exe, err2 := getExecutableNameForPlugin(cfg.OS, cfg.Arch, filepath.Join(pluginJSONPath, nestedPluginJSONPath)); err2 != nil {
+		exe, err2 := getExecutableNameForPlugin(cfg.OS, cfg.Arch, filepath.Join(pluginJSONPath, nestedPluginJSONPath))
+		if err2 != nil {
 			// return the original error
 			return cfg, []string{}, err
+		}
+		// For backwards compatibility, if the executable is in the root directory, strip that information.
+		if strings.HasPrefix(exe, "../") {
+			exePath = exe[3:]
 		} else {
-			// For backwards compatibility, if the executable is in the root directory, strip that information.
-			if strings.HasPrefix(exe, "../") {
-				exePath = exe[3:]
-			} else {
-				// Make sure the executable is in the relevant nested plugin directory.
-				exePath = filepath.Join(nestedPluginJSONPath, exe)
-			}
+			// Make sure the executable is in the relevant nested plugin directory.
+			exePath = filepath.Join(nestedPluginJSONPath, exe)
 		}
 	}
 

--- a/build/common_test.go
+++ b/build/common_test.go
@@ -2,12 +2,13 @@ package build
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_getExecutableNameForPlugin(t *testing.T) {
@@ -83,9 +84,7 @@ func Test_getExecutableNameForPlugin(t *testing.T) {
 				filepath.Join(rootDir, "foo-datasource"): "gpx_foo",
 				filepath.Join(rootDir, "baz-datasource"): "gpx_baz",
 			},
-			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return true
-			},
+			wantErr: assert.Error,
 		},
 	}
 
@@ -111,7 +110,7 @@ func Test_getExecutableNameForPlugin(t *testing.T) {
 			assert.Equalf(t, tc.expected, got, "getExecutableNameForPlugin(%v, %v, %v)", tc.args.os, tc.args.arch, tc.args.pluginDir)
 
 			numCached := 0
-			executableNameCache.Range(func(key, value any) bool {
+			executableNameCache.Range(func(_, _ any) bool {
 				numCached++
 				return true
 			})
@@ -145,6 +144,7 @@ func Test_getBuildBackendCmdInfo(t *testing.T) {
 				PluginJSONPath: filepath.Join(tmpDir, "foobar-datasource"),
 			},
 			pluginJSONCreate: func(t *testing.T) {
+				t.Helper()
 				createPluginJSON(t, filepath.Join(tmpDir, "foobar-datasource"), "gpx_foo")
 			},
 			expectedCfg: Config{
@@ -165,6 +165,7 @@ func Test_getBuildBackendCmdInfo(t *testing.T) {
 				PluginJSONPath: filepath.Join(tmpDir, "foobar-app"),
 			},
 			pluginJSONCreate: func(t *testing.T) {
+				t.Helper()
 				createPluginJSON(t, filepath.Join(tmpDir, "foobar-app", defaultNestedDataSourcePath), "gpx_foo")
 			},
 			expectedCfg: Config{
@@ -185,6 +186,7 @@ func Test_getBuildBackendCmdInfo(t *testing.T) {
 				PluginJSONPath: filepath.Join(tmpDir, "foobarbaz-app"),
 			},
 			pluginJSONCreate: func(t *testing.T) {
+				t.Helper()
 				createPluginJSON(t, filepath.Join(tmpDir, "foobarbaz-app", defaultNestedDataSourcePath), "../gpx_foobarbaz")
 			},
 			expectedCfg: Config{
@@ -217,6 +219,7 @@ func Test_getBuildBackendCmdInfo(t *testing.T) {
 }
 
 func createPluginJSON(t *testing.T, pluginDir string, executable string) {
+	t.Helper()
 	err := os.MkdirAll(pluginDir, os.ModePerm)
 	require.NoError(t, err)
 	f, err := os.Create(filepath.Join(pluginDir, "plugin.json"))

--- a/build/common_test.go
+++ b/build/common_test.go
@@ -1,0 +1,229 @@
+package build
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func Test_getExecutableNameForPlugin(t *testing.T) {
+	rootDir := t.TempDir()
+	plugins := map[string]string{
+		"foo-datasource": "gpx_foo",
+		"bar-datasource": "gpx_bar",
+		"baz-datasource": "gpx_baz",
+	}
+
+	type args struct {
+		os        string
+		arch      string
+		pluginDir string
+	}
+	tcs := []struct {
+		name          string
+		args          args
+		expected      string
+		expectedCache map[string]string
+		wantErr       assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Valid plugin with executable is found and cached",
+			args: args{
+				os:        "darwin",
+				arch:      "arm64",
+				pluginDir: filepath.Join(rootDir, "foo-datasource"),
+			},
+			expected: "gpx_foo_darwin_arm64",
+			expectedCache: map[string]string{
+				filepath.Join(rootDir, "foo-datasource"): "gpx_foo",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Another valid plugin with executable is found and cached",
+			args: args{
+				os:        "windows",
+				arch:      "amd64",
+				pluginDir: filepath.Join(rootDir, "baz-datasource"),
+			},
+			expected: "gpx_baz_windows_amd64.exe",
+			expectedCache: map[string]string{
+				filepath.Join(rootDir, "foo-datasource"): "gpx_foo",
+				filepath.Join(rootDir, "baz-datasource"): "gpx_baz",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Same plugin with executable is found in cache",
+			args: args{
+				os:        "windows",
+				arch:      "amd64",
+				pluginDir: filepath.Join(rootDir, "baz-datasource"),
+			},
+			expected: "gpx_baz_windows_amd64.exe",
+			expectedCache: map[string]string{
+				filepath.Join(rootDir, "foo-datasource"): "gpx_foo",
+				filepath.Join(rootDir, "baz-datasource"): "gpx_baz",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Non existing plugin returns an error",
+			args: args{
+				os:        "linux",
+				arch:      "amd64",
+				pluginDir: filepath.Join(rootDir, "foobarbaz-datasource"),
+			},
+			expected: "",
+			expectedCache: map[string]string{
+				filepath.Join(rootDir, "foo-datasource"): "gpx_foo",
+				filepath.Join(rootDir, "baz-datasource"): "gpx_baz",
+			},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return true
+			},
+		},
+	}
+
+	for pluginID, executable := range plugins {
+		pluginRootDir := filepath.Join(rootDir, pluginID)
+		err := os.MkdirAll(pluginRootDir, os.ModePerm)
+		require.NoError(t, err)
+		f, err := os.Create(filepath.Join(pluginRootDir, "plugin.json"))
+		require.NoError(t, err)
+
+		_, err = f.WriteString(fmt.Sprintf(`{"executable": %q}`, executable))
+		require.NoError(t, err)
+		err = f.Close()
+		require.NoError(t, err)
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := getExecutableNameForPlugin(tc.args.os, tc.args.arch, tc.args.pluginDir)
+			if !tc.wantErr(t, err, fmt.Sprintf("getExecutableNameForPlugin(%v, %v, %v)", tc.args.os, tc.args.arch, tc.args.pluginDir)) {
+				return
+			}
+			assert.Equalf(t, tc.expected, got, "getExecutableNameForPlugin(%v, %v, %v)", tc.args.os, tc.args.arch, tc.args.pluginDir)
+
+			numCached := 0
+			executableNameCache.Range(func(key, value any) bool {
+				numCached++
+				return true
+			})
+
+			assert.Equal(t, len(tc.expectedCache), numCached)
+			for s, s2 := range tc.expectedCache {
+				val, ok := executableNameCache.Load(s)
+				assert.True(t, ok)
+				assert.Equal(t, s2, val.(string))
+			}
+		})
+	}
+}
+
+func Test_getBuildBackendCmdInfo(t *testing.T) {
+	tmpDir := t.TempDir()
+	tcs := []struct {
+		name             string
+		pluginJSONCreate func(t *testing.T)
+		cfg              Config
+		expectedCfg      Config
+		expectedArgs     []string
+		wantErr          assert.ErrorAssertionFunc
+	}{
+		{
+			name: "Happy path",
+			cfg: Config{
+				OS:             "darwin",
+				Arch:           "arm64",
+				Env:            make(map[string]string),
+				PluginJSONPath: filepath.Join(tmpDir, "foobar-datasource"),
+			},
+			pluginJSONCreate: func(t *testing.T) {
+				createPluginJSON(t, filepath.Join(tmpDir, "foobar-datasource"), "gpx_foo")
+			},
+			expectedCfg: Config{
+				OS:             "darwin",
+				Arch:           "arm64",
+				Env:            map[string]string{"CGO_ENABLED": "0", "GOARCH": "arm64", "GOOS": "darwin"},
+				PluginJSONPath: filepath.Join(tmpDir, "foobar-datasource"),
+			},
+			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, "gpx_foo_darwin_arm64"), "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={\"time\":[0-9\\d]{13},\"repo\":\"https://github.com/grafana/grafana-plugin-sdk-go.git\",\"branch\":\".+\",\"hash\":\"[a-z0-9\\d]{40}\"}' -X 'main.branch=.+' -X 'main.commit=[a-z0-9\\d]{40}'", "./pkg"},
+			wantErr:      assert.NoError,
+		},
+		{
+			name: "Happy path with nested datasource",
+			cfg: Config{
+				OS:             "darwin",
+				Arch:           "arm64",
+				Env:            make(map[string]string),
+				PluginJSONPath: filepath.Join(tmpDir, "foobar-app"),
+			},
+			pluginJSONCreate: func(t *testing.T) {
+				createPluginJSON(t, filepath.Join(tmpDir, "foobar-app", defaultNestedDataSourcePath), "gpx_foo")
+			},
+			expectedCfg: Config{
+				OS:             "darwin",
+				Arch:           "arm64",
+				Env:            map[string]string{"CGO_ENABLED": "0", "GOARCH": "arm64", "GOOS": "darwin"},
+				PluginJSONPath: filepath.Join(tmpDir, "foobar-app"),
+			},
+			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, defaultNestedDataSourcePath, "gpx_foo_darwin_arm64"), "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={\"time\":[0-9\\d]{13},\"repo\":\"https://github.com/grafana/grafana-plugin-sdk-go.git\",\"branch\":\".+\",\"hash\":\"[a-z0-9\\d]{40}\"}' -X 'main.branch=.+' -X 'main.commit=[a-z0-9\\d]{40}'", "./pkg"},
+			wantErr:      assert.NoError,
+		},
+		{
+			name: "Happy path with nested datasource that has executable path in root directory",
+			cfg: Config{
+				OS:             "windows",
+				Arch:           "amd64",
+				Env:            make(map[string]string),
+				PluginJSONPath: filepath.Join(tmpDir, "foobarbaz-app"),
+			},
+			pluginJSONCreate: func(t *testing.T) {
+				createPluginJSON(t, filepath.Join(tmpDir, "foobarbaz-app", defaultNestedDataSourcePath), "../gpx_foobarbaz")
+			},
+			expectedCfg: Config{
+				OS:             "windows",
+				Arch:           "amd64",
+				Env:            map[string]string{"CGO_ENABLED": "0", "GOARCH": "amd64", "GOOS": "windows"},
+				PluginJSONPath: filepath.Join(tmpDir, "foobarbaz-app"),
+			},
+			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, "gpx_foobarbaz_windows_amd64.exe"), "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={\"time\":[0-9\\d]{13},\"repo\":\"https://github.com/grafana/grafana-plugin-sdk-go.git\",\"branch\":\".+\",\"hash\":\"[a-z0-9\\d]{40}\"}' -X 'main.branch=.+' -X 'main.commit=[a-z0-9\\d]{40}'", "./pkg"},
+			wantErr:      assert.NoError,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.pluginJSONCreate(t)
+
+			cfg, args, err := getBuildBackendCmdInfo(tc.cfg)
+			if !tc.wantErr(t, err, fmt.Sprintf("getBuildBackendCmdInfo(%v)", tc.cfg)) {
+				return
+			}
+			assert.Equalf(t, tc.expectedCfg, cfg, "getBuildBackendCmdInfo(%v)", tc.cfg)
+
+			// check if expected build arg regex matches against actual build arg
+			buildArg := strings.Join(args, " ")
+			expectedBuildArg := strings.Join(tc.expectedArgs, " ")
+			assert.Regexp(t, expectedBuildArg, buildArg, "getBuildBackendCmdInfo(%v)", tc.cfg)
+		})
+	}
+}
+
+func createPluginJSON(t *testing.T, pluginDir string, executable string) {
+	err := os.MkdirAll(pluginDir, os.ModePerm)
+	require.NoError(t, err)
+	f, err := os.Create(filepath.Join(pluginDir, "plugin.json"))
+	require.NoError(t, err)
+
+	_, err = f.WriteString(fmt.Sprintf(`{"executable": %q}`, executable))
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+}

--- a/build/common_test.go
+++ b/build/common_test.go
@@ -153,7 +153,7 @@ func Test_getBuildBackendCmdInfo(t *testing.T) {
 				Env:            map[string]string{"CGO_ENABLED": "0", "GOARCH": "arm64", "GOOS": "darwin"},
 				PluginJSONPath: filepath.Join(tmpDir, "foobar-datasource"),
 			},
-			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, "gpx_foo_darwin_arm64"), "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={\"time\":[0-9\\d]{13},\"repo\":\"https://github.com/grafana/grafana-plugin-sdk-go.git\",\"branch\":\".+\",\"hash\":\"[a-z0-9\\d]{40}\"}' -X 'main.branch=.+' -X 'main.commit=[a-z0-9\\d]{40}'", "./pkg"},
+			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, "gpx_foo_darwin_arm64"), "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={.*}' -X 'main.branch=.+' -X 'main.commit=[a-z0-9\\d]{40}'", "./pkg"},
 			wantErr:      assert.NoError,
 		},
 		{
@@ -174,7 +174,7 @@ func Test_getBuildBackendCmdInfo(t *testing.T) {
 				Env:            map[string]string{"CGO_ENABLED": "0", "GOARCH": "arm64", "GOOS": "darwin"},
 				PluginJSONPath: filepath.Join(tmpDir, "foobar-app"),
 			},
-			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, defaultNestedDataSourcePath, "gpx_foo_darwin_arm64"), "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={\"time\":[0-9\\d]{13},\"repo\":\"https://github.com/grafana/grafana-plugin-sdk-go.git\",\"branch\":\".+\",\"hash\":\"[a-z0-9\\d]{40}\"}' -X 'main.branch=.+' -X 'main.commit=[a-z0-9\\d]{40}'", "./pkg"},
+			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, defaultNestedDataSourcePath, "gpx_foo_darwin_arm64"), "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={.*}' -X 'main.branch=.+' -X 'main.commit=[a-z0-9\\d]{40}'", "./pkg"},
 			wantErr:      assert.NoError,
 		},
 		{
@@ -195,7 +195,7 @@ func Test_getBuildBackendCmdInfo(t *testing.T) {
 				Env:            map[string]string{"CGO_ENABLED": "0", "GOARCH": "amd64", "GOOS": "windows"},
 				PluginJSONPath: filepath.Join(tmpDir, "foobarbaz-app"),
 			},
-			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, "gpx_foobarbaz_windows_amd64.exe"), "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={\"time\":[0-9\\d]{13},\"repo\":\"https://github.com/grafana/grafana-plugin-sdk-go.git\",\"branch\":\".+\",\"hash\":\"[a-z0-9\\d]{40}\"}' -X 'main.branch=.+' -X 'main.commit=[a-z0-9\\d]{40}'", "./pkg"},
+			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, "gpx_foobarbaz_windows_amd64.exe"), "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={.*}' -X 'main.branch=.+' -X 'main.commit=[a-z0-9\\d]{40}'", "./pkg"},
 			wantErr:      assert.NoError,
 		},
 	}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -27,6 +28,8 @@ func GetStringValueFromJSON(fpath string, key string) (string, error) {
 	return name, nil
 }
 
+// GetExecutableFromPluginJSON returns the executable name from a plugin.json file in the provided directory.
+// If no plugin.json file is found at the root, it will look in a directory named "datasource".
 func GetExecutableFromPluginJSON(dir string) (string, error) {
 	exe, err := GetStringValueFromJSON(path.Join(dir, "plugin.json"), "executable")
 	if err != nil {
@@ -36,7 +39,7 @@ func GetExecutableFromPluginJSON(dir string) (string, error) {
 			if strings.HasPrefix(exe, "../") {
 				return exe[3:], nil
 			}
-			return exe, nil
+			return "", errors.New("datasource should reference executable in root folder")
 		}
 	}
 	return exe, err

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -22,7 +22,7 @@ func TestGetExecutableFromPluginJSON(t *testing.T) {
 		err           bool
 	}{
 		{
-			name: "Can retrieve executable from a plugin.json found in provided directory",
+			name: "Can retrieve executable field from a plugin.json found in provided directory",
 			args: args{
 				pluginDir: "foobar-datasource",
 			},
@@ -31,30 +31,31 @@ func TestGetExecutableFromPluginJSON(t *testing.T) {
 			expected:      "gpx_foo",
 		},
 		{
-			name: "Can retrieve executable from plugin.json found in nested 'datasource' directory (when not found in root of provided directory)",
-			args: args{
-				pluginDir: "foobar-app",
-			},
-			pluginJSONDir: filepath.Join("foobar-app", "datasource"),
-			executable:    "gpx_foo",
-			expected:      "gpx_foo",
-		},
-		{
-			name: "Cannot retrieve executable when no plugin.json in root or nested 'datasource' directory",
-			args: args{
-				pluginDir: "foobar-app",
-			},
-			pluginJSONDir: filepath.Join("foobar-app", "foobar-datasource"),
-			err:           true,
-		},
-		{
-			name: "Should remove path information from executable field of nested 'datasource' plugin.json",
+			name: "Can retrieve executable field of nested 'datasource' plugin.json as long as the executable path is in the root directory",
 			args: args{
 				pluginDir: "foobar-app",
 			},
 			pluginJSONDir: filepath.Join("foobar-app", "datasource"),
 			executable:    "../gpx_foo",
 			expected:      "gpx_foo",
+		},
+		{
+			name: "Cannot retrieve executable field of nested 'datasource' plugin.json when executable path is not in the root directory",
+			args: args{
+				pluginDir: "foobar-app",
+			},
+			pluginJSONDir: filepath.Join("foobar-app", "datasource"),
+			executable:    "gpx_foo",
+			err:           true,
+		},
+		{
+			name: "Cannot retrieve executable when no plugin.json found in root or nested 'datasource' directory",
+			args: args{
+				pluginDir: "foobar-app",
+			},
+			pluginJSONDir: filepath.Join("foobar-app", "foobar-datasource"),
+			executable:    "gpx_foo",
+			err:           true,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently it is expected that any nested datasource binary is placed in the root of the plugin dist. This forces the `executable` path of the nested plugin to contain relative path information so that the binary can be found when loaded by Grafana.

This is problematic as it makes it impossible to run these nested plugins on Windows as the path information is UNIX style. Considering the binary belongs to the nested plugin - it should live in the nested plugin's directory so that it is clear what the binary is associated with. 

This PR makes it possible to do so while also keeping existing plugins backwards compatible. Therefore plugins with path information in the nested plugin executable `../$binaryName` will continue to work.

**Special notes for your reviewer**:
- In cases where there is backend app plugin with a nested backend datasource plugin, this will ensure that all binaries don't have to live in the same directory.
- For the plugin CDN, if we ever wanted to upload all files, this change will make this much easier to reason about.