### PR TITLE
DataQueryClient: Handle kube-style error responses

### DIFF
--- a/experimental/apis/data/v0alpha1/client_test.go
+++ b/experimental/apis/data/v0alpha1/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
@@ -18,7 +19,45 @@ func TestClientWithBadURL(t *testing.T) {
 	require.Equal(t, 404, code)
 }
 
+const errResp = `
+{
+	"kind": "Status",
+	"apiVersion": "v1",
+	"metadata": {},
+	"status": "Failure",
+	"message": "missing variable query for result",
+	"code": 500
+}
+`
+
 func TestQueryClient(t *testing.T) {
+	respondWithError := false
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if respondWithError {
+			rw.WriteHeader(http.StatusInternalServerError)
+			rw.Write([]byte(errResp))
+		}
+		rw.WriteHeader(http.StatusOK)
+		rw.Write([]byte("{}"))
+	}))
+	defer srv.Close()
+
+	t.Run("converts kube error responses to errors", func(t *testing.T) {
+		respondWithError = true
+		defer func() {
+			respondWithError = false
+		}()
+
+		client := v0alpha1.NewQueryDataClient(srv.URL+"/api/ds/query", nil, nil)
+		code, _, err := client.QueryData(context.Background(), v0alpha1.QueryDataRequest{})
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Failure(500): missing variable query for result")
+		require.Equal(t, 500, code)
+	})
+}
+
+func TestQueryClient_Integration(t *testing.T) {
 	t.Skip()
 
 	client := v0alpha1.NewQueryDataClient("http://localhost:3000/api/ds/query", nil,

--- a/experimental/apis/data/v0alpha1/client_test.go
+++ b/experimental/apis/data/v0alpha1/client_test.go
@@ -35,10 +35,12 @@ func TestQueryClient(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if respondWithError {
 			rw.WriteHeader(http.StatusInternalServerError)
-			rw.Write([]byte(errResp))
+			_, err := rw.Write([]byte(errResp))
+			require.NoError(t, err)
 		}
 		rw.WriteHeader(http.StatusOK)
-		rw.Write([]byte("{}"))
+		_, err := rw.Write([]byte("{}"))
+		require.NoError(t, err)
 	}))
 	defer srv.Close()
 

--- a/experimental/apis/data/v0alpha1/errors.go
+++ b/experimental/apis/data/v0alpha1/errors.go
@@ -1,0 +1,29 @@
+package v0alpha1
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Represents the state of some operation.
+type Status struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// Status is a textual represenation of the state.
+	Status string `json:"status"`
+	// Message is a human-readable description of the state. It should not be parsed.
+	Message string `json:"message"`
+	// Code is a numeric code describing the state, such as an HTTP status code.
+	Code int `json:"code"`
+}
+
+// Error produces a Go error from a status. It assumes the status represents failure.
+func (s Status) Error() error {
+	return errors.New(s.String())
+}
+
+// String implements stringer
+func (s Status) String() string {
+	return fmt.Sprintf("%s(%d): %s", s.Status, s.Code, s.Message)
+}

--- a/experimental/apis/data/v0alpha1/errors.go
+++ b/experimental/apis/data/v0alpha1/errors.go
@@ -10,7 +10,7 @@ type Status struct {
 	TypeMeta   `json:",inline"`
 	ObjectMeta `json:"metadata,omitempty"`
 
-	// Status is a textual represenation of the state.
+	// Status is a textual representation of the state.
 	Status string `json:"status"`
 	// Message is a human-readable description of the state. It should not be parsed.
 	Message string `json:"message"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Ds/query often responds with a kube-style error structure. Currently we try to deserialize that into a QueryDataResponse, which fails to deserialize due to some custom marshalling logic. This causes errors to be not usable, they usually contain lots of raw bytes of the response and not the actual error message from the server.

This PR attempts to deserialize the response into something meaningful and return an error capturing the issue. If it cannot, it falls back to the original behavior.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:
