### PR TITLE
Tracing: Allow OTEL env variables to override resource attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/grafana/otel-profiling-go v0.5.1
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.7
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.6.1
 	github.com/invopop/jsonschema v0.12.0 // for schema codgen+extraction
@@ -72,7 +73,6 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/invopop/yaml v0.2.0 // indirect

--- a/internal/tracerprovider/tracerprovider.go
+++ b/internal/tracerprovider/tracerprovider.go
@@ -49,6 +49,7 @@ func newOtelTracerProvider(exp tracesdk.SpanExporter, sampler tracesdk.Sampler, 
 	res, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(customAttributes...),
+		resource.WithFromEnv(),
 		resource.WithProcessRuntimeDescription(),
 		resource.WithTelemetrySDK(),
 	)


### PR DESCRIPTION
Allow `OTEL_RESOURCE_ATTRIBUTES` and `OTEL_SERVICE_NAME` environment variables to override any resource attributes already set. See https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration for details.

This might be weird/cause unexpected result if especially `OTEL_SERVICE_NAME` is used in Grafana and being forwarded to backend plugins, however this should disappear whenever `pluginsSkipHostEnvVars` feature toggle is removed/host environment variables are not automatically forwarded.

So when is this useful? When backend plugins are started by other clients than Grafana.

Related https://github.com/grafana/grafana/pull/85937