### PR TITLE
httpadapter: Deprecate PluginConfigFromContext and UserFromContext

### DIFF
--- a/backend/admission_adapter.go
+++ b/backend/admission_adapter.go
@@ -20,6 +20,8 @@ func newAdmissionSDKAdapter(handler AdmissionHandler) *admissionSDKAdapter {
 func (a *admissionSDKAdapter) ValidateAdmission(ctx context.Context, req *pluginv2.AdmissionRequest) (*pluginv2.ValidationResponse, error) {
 	ctx = propagateTenantIDIfPresent(ctx)
 	parsedReq := FromProto().AdmissionRequest(req)
+	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
+	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	resp, err := a.handler.ValidateAdmission(ctx, parsedReq)
 	if err != nil {
 		return nil, err
@@ -30,6 +32,8 @@ func (a *admissionSDKAdapter) ValidateAdmission(ctx context.Context, req *plugin
 func (a *admissionSDKAdapter) MutateAdmission(ctx context.Context, req *pluginv2.AdmissionRequest) (*pluginv2.MutationResponse, error) {
 	ctx = propagateTenantIDIfPresent(ctx)
 	parsedReq := FromProto().AdmissionRequest(req)
+	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
+	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	resp, err := a.handler.MutateAdmission(ctx, parsedReq)
 	if err != nil {
 		return nil, err
@@ -40,6 +44,8 @@ func (a *admissionSDKAdapter) MutateAdmission(ctx context.Context, req *pluginv2
 func (a *admissionSDKAdapter) ConvertObject(ctx context.Context, req *pluginv2.ConversionRequest) (*pluginv2.ConversionResponse, error) {
 	ctx = propagateTenantIDIfPresent(ctx)
 	parsedReq := FromProto().ConversionRequest(req)
+	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
+	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	resp, err := a.handler.ConvertObject(ctx, parsedReq)
 	if err != nil {
 		return nil, err

--- a/backend/common.go
+++ b/backend/common.go
@@ -219,6 +219,46 @@ func setCustomOptionsFromHTTPSettings(opts *httpclient.Options, httpSettings *HT
 	}
 }
 
+type pluginConfigKey struct{}
+
+// WithPluginContext adds pluginCtx to ctx.
+//
+// Note: Used internally by SDK so you normally don't need to use/call this,
+// unless in tests and such.
+func WithPluginContext(ctx context.Context, pluginCtx PluginContext) context.Context {
+	return context.WithValue(ctx, pluginConfigKey{}, pluginCtx)
+}
+
+// PluginConfigFromContext returns [PluginContext] from context if available, otherwise empty [PluginContext].
+func PluginConfigFromContext(ctx context.Context) PluginContext {
+	v := ctx.Value(pluginConfigKey{})
+	if v == nil {
+		return PluginContext{}
+	}
+
+	return v.(PluginContext)
+}
+
+type userKey struct{}
+
+// WithPluginContext adds user to ctx.
+//
+// Note: Used internally by SDK so you normally don't need to use/call this,
+// unless in tests and such.
+func WithUser(ctx context.Context, user *User) context.Context {
+	return context.WithValue(ctx, userKey{}, user)
+}
+
+// UserFromContext returns [User] from context if available, otherwise nil.
+func UserFromContext(ctx context.Context) *User {
+	v := ctx.Value(userKey{})
+	if v == nil {
+		return nil
+	}
+
+	return v.(*User)
+}
+
 // JSONDataFromHTTPClientOptions extracts JSON data from CustomOptions of httpclient.Options.
 func JSONDataFromHTTPClientOptions(opts httpclient.Options) (res map[string]interface{}) {
 	if opts.CustomOptions == nil {

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -47,6 +47,8 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(req.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().QueryDataRequest(req)
+	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
+	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointQueryData)
 	ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)

--- a/backend/datasource/serve_example_test.go
+++ b/backend/datasource/serve_example_test.go
@@ -97,7 +97,7 @@ func (ds *testDataSource) QueryData(ctx context.Context, req *backend.QueryDataR
 
 func (ds *testDataSource) handleTest(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	pluginContext := httpadapter.PluginConfigFromContext(ctx)
+	pluginContext := backend.PluginConfigFromContext(ctx)
 	settings, err := ds.getSettings(ctx, pluginContext)
 	if err != nil {
 		rw.WriteHeader(500)

--- a/backend/diagnostics_adapter.go
+++ b/backend/diagnostics_adapter.go
@@ -49,6 +49,8 @@ func (a *diagnosticsSDKAdapter) CheckHealth(ctx context.Context, protoReq *plugi
 		ctx = propagateTenantIDIfPresent(ctx)
 		ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 		parsedReq := FromProto().CheckHealthRequest(protoReq)
+		ctx = WithPluginContext(ctx, parsedReq.PluginContext)
+		ctx = WithUser(ctx, parsedReq.PluginContext.User)
 		ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
 		ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointCheckHealth)
 		ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)

--- a/backend/resource/httpadapter/handler.go
+++ b/backend/resource/httpadapter/handler.go
@@ -29,8 +29,11 @@ func (h *httpResourceHandler) CallResource(ctx context.Context, req *backend.Cal
 		reqBodyReader = bytes.NewReader(req.Body)
 	}
 
-	ctx = withPluginContext(ctx, req.PluginContext)
-	ctx = withUser(ctx, req.PluginContext.User)
+	// Shouldn't be needed since adapter adds this, but doesn't hurt to
+	// be on the safe side in case someone depends on this/using this in a
+	// test for example.
+	ctx = backend.WithPluginContext(ctx, req.PluginContext)
+	ctx = backend.WithUser(ctx, req.PluginContext.User)
 	reqURL, err := url.Parse(req.URL)
 	if err != nil {
 		return err
@@ -61,34 +64,18 @@ func (h *httpResourceHandler) CallResource(ctx context.Context, req *backend.Cal
 	return nil
 }
 
-type pluginConfigKey struct{}
-
-func withPluginContext(ctx context.Context, pluginCtx backend.PluginContext) context.Context {
-	return context.WithValue(ctx, pluginConfigKey{}, pluginCtx)
-}
-
 // PluginConfigFromContext returns backend.PluginConfig from context.
+//
+// Deprecated: PluginConfigFromContext exists for historical compatibility
+// and might be removed in a future version. Please migrate to [backend.PluginConfigFromContext].
 func PluginConfigFromContext(ctx context.Context) backend.PluginContext {
-	v := ctx.Value(pluginConfigKey{})
-	if v == nil {
-		return backend.PluginContext{}
-	}
-
-	return v.(backend.PluginContext)
-}
-
-type userKey struct{}
-
-func withUser(ctx context.Context, cfg *backend.User) context.Context {
-	return context.WithValue(ctx, userKey{}, cfg)
+	return backend.PluginConfigFromContext(ctx)
 }
 
 // UserFromContext returns backend.User from context.
+//
+// Deprecated: UserFromContext exists for historical compatibility
+// and might be removed in a future version. Please migrate to [backend.UserFromContext].
 func UserFromContext(ctx context.Context) *backend.User {
-	v := ctx.Value(userKey{})
-	if v == nil {
-		return nil
-	}
-
-	return v.(*backend.User)
+	return backend.UserFromContext(ctx)
 }

--- a/backend/resource/httpadapter/handler_test.go
+++ b/backend/resource/httpadapter/handler_test.go
@@ -99,7 +99,7 @@ func TestHttpResourceHandler(t *testing.T) {
 
 		t.Run("Should be able to get plugin config from request context", func(t *testing.T) {
 			require.NotNil(t, httpHandler.req)
-			actualPluginCtx := PluginConfigFromContext(httpHandler.req.Context())
+			actualPluginCtx := backend.PluginConfigFromContext(httpHandler.req.Context())
 			require.NotNil(t, actualPluginCtx)
 			require.Equal(t, req.PluginContext.OrgID, actualPluginCtx.OrgID)
 			require.Equal(t, req.PluginContext.PluginID, actualPluginCtx.PluginID)
@@ -112,7 +112,7 @@ func TestHttpResourceHandler(t *testing.T) {
 			require.Equal(t, req.PluginContext.DataSourceInstanceSettings.BasicAuthEnabled, actualPluginCtx.DataSourceInstanceSettings.BasicAuthEnabled)
 			require.Equal(t, req.PluginContext.DataSourceInstanceSettings.BasicAuthUser, actualPluginCtx.DataSourceInstanceSettings.BasicAuthUser)
 
-			user := UserFromContext(httpHandler.req.Context())
+			user := backend.UserFromContext(httpHandler.req.Context())
 			require.NotNil(t, user)
 			require.Equal(t, req.PluginContext.User.Name, "foobar")
 			require.Equal(t, req.PluginContext.User.Login, "foo@bar.com")

--- a/backend/resource_adapter.go
+++ b/backend/resource_adapter.go
@@ -38,6 +38,8 @@ func (a *resourceSDKAdapter) CallResource(protoReq *pluginv2.CallResourceRequest
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().CallResourceRequest(protoReq)
+	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
+	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointCallResource)
 	ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)

--- a/backend/stream_adapter.go
+++ b/backend/stream_adapter.go
@@ -27,6 +27,8 @@ func (a *streamSDKAdapter) SubscribeStream(ctx context.Context, protoReq *plugin
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().SubscribeStreamRequest(protoReq)
+	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
+	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointSubscribeStream)
 	resp, err := a.streamHandler.SubscribeStream(ctx, parsedReq)
 	if err != nil {
@@ -42,6 +44,8 @@ func (a *streamSDKAdapter) PublishStream(ctx context.Context, protoReq *pluginv2
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().PublishStreamRequest(protoReq)
+	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
+	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointPublishStream)
 	resp, err := a.streamHandler.PublishStream(ctx, parsedReq)
 	if err != nil {
@@ -66,6 +70,8 @@ func (a *streamSDKAdapter) RunStream(protoReq *pluginv2.RunStreamRequest, protoS
 	ctx = propagateTenantIDIfPresent(ctx)
 	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().RunStreamRequest(protoReq)
+	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
+	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext, endpointRunStream)
 	ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)
 	sender := NewStreamSender(&runStreamServer{protoSrv: protoSrv})


### PR DESCRIPTION
Extracted from #1016 

Deprecates `httpadapter.PluginConfigFromContext` and `httpadapter.UserFromContext` and expose them in the backend package. Could be convenient in middlewares and not having to pass this information down each method call, ref https://github.com/grafana/grafana-plugin-sdk-go/issues/579#issuecomment-1406406256
