### PR TITLE
Tracing: Helper function to retrieve trace ID from context

### DIFF
--- a/backend/tracing/tracing.go
+++ b/backend/tracing/tracing.go
@@ -1,6 +1,7 @@
 package tracing
 
 import (
+	"context"
 	"sync"
 
 	"go.opentelemetry.io/otel"
@@ -39,4 +40,13 @@ func DefaultTracer() trace.Tracer {
 // This method should only be called once during the plugin's initialization, and it's not safe for concurrent use.
 func InitDefaultTracer(tracer trace.Tracer) {
 	defaultTracer = &contextualTracer{tracer: tracer}
+}
+
+func TraceIDFromContext(ctx context.Context, requireSampled bool) string {
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if !spanCtx.HasTraceID() || !spanCtx.IsValid() || (requireSampled && !spanCtx.IsSampled()) {
+		return ""
+	}
+
+	return spanCtx.TraceID().String()
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
This is in support of work to decouple the Elasticsearch backend from Grafana core.

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/oss-plugin-partnerships/issues/999
