### PR TITLE
Instrumentation: Improve automatic instrumentation by the SDK to include handler/request logs, metrics and traces

### DIFF
--- a/backend/adapter_utils.go
+++ b/backend/adapter_utils.go
@@ -35,7 +35,7 @@ func wrapHandler(ctx context.Context, pluginCtx PluginContext, next handlerWrapp
 }
 
 func setupHandlerContext(ctx context.Context, pluginCtx PluginContext) context.Context {
-	ctx = InitErrorSource(ctx)
+	ctx = initErrorSource(ctx)
 	ctx = WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
 	ctx = WithPluginContext(ctx, pluginCtx)
 	ctx = WithUser(ctx, pluginCtx.User)
@@ -48,8 +48,8 @@ func errorWrapper(next handlerWrapperFunc) handlerWrapperFunc {
 	return func(ctx context.Context) (RequestStatus, error) {
 		status, err := next(ctx)
 
-		if errWithSource, ok := err.(ErrorWithSource); ok {
-			if innerErr := WithErrorSource(ctx, errWithSource.ErrorSource()); innerErr != nil {
+		if err != nil && IsDownstreamError(err) {
+			if innerErr := WithDownstreamErrorSource(ctx); innerErr != nil {
 				return RequestStatusError, fmt.Errorf("failed to set downstream status source: %w", errors.Join(innerErr, err))
 			}
 		}
@@ -75,7 +75,7 @@ func metricWrapper(next handlerWrapperFunc) handlerWrapperFunc {
 		endpoint := EndpointFromContext(ctx)
 		status, err := next(ctx)
 
-		pluginRequestCounter.WithLabelValues(endpoint.String(), status.String(), string(ErrorSourceFromContext(ctx))).Inc()
+		pluginRequestCounter.WithLabelValues(endpoint.String(), status.String(), string(errorSourceFromContext(ctx))).Inc()
 
 		return status, err
 	}
@@ -106,7 +106,7 @@ func tracingWrapper(next handlerWrapperFunc) handlerWrapperFunc {
 
 		span.SetAttributes(
 			attribute.String("request_status", status.String()),
-			attribute.String("status_source", string(ErrorSourceFromContext(ctx))),
+			attribute.String("status_source", string(errorSourceFromContext(ctx))),
 		)
 
 		if err != nil {
@@ -131,7 +131,7 @@ func logWrapper(next handlerWrapperFunc) handlerWrapperFunc {
 			logParams = append(logParams, "error", err)
 		}
 
-		logParams = append(logParams, "statusSource", string(ErrorSourceFromContext(ctx)))
+		logParams = append(logParams, "statusSource", string(errorSourceFromContext(ctx)))
 
 		ctxLogger := Logger.FromContext(ctx)
 		logFunc := ctxLogger.Debug

--- a/backend/adapter_utils.go
+++ b/backend/adapter_utils.go
@@ -1,0 +1,39 @@
+package backend
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+)
+
+func setupContext(ctx context.Context, endpoint Endpoint) context.Context {
+	ctx = WithEndpoint(ctx, endpoint)
+	ctx = propagateTenantIDIfPresent(ctx)
+
+	return ctx
+}
+
+func withHeaderMiddleware(ctx context.Context, headers http.Header) context.Context {
+	if len(headers) > 0 {
+		ctx = httpclient.WithContextualMiddleware(ctx,
+			httpclient.MiddlewareFunc(func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
+				if !opts.ForwardHTTPHeaders {
+					return next
+				}
+
+				return httpclient.RoundTripperFunc(func(qreq *http.Request) (*http.Response, error) {
+					// Only set a header if it is not already set.
+					for k, v := range headers {
+						if qreq.Header.Get(k) == "" {
+							for _, vv := range v {
+								qreq.Header.Add(k, vv)
+							}
+						}
+					}
+					return next.RoundTrip(qreq)
+				})
+			}))
+	}
+	return ctx
+}

--- a/backend/adapter_utils.go
+++ b/backend/adapter_utils.go
@@ -3,15 +3,62 @@ package backend
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 )
+
+type handlerWrapperFunc func(ctx context.Context) (RequestStatus, error)
 
 func setupContext(ctx context.Context, endpoint Endpoint) context.Context {
 	ctx = WithEndpoint(ctx, endpoint)
 	ctx = propagateTenantIDIfPresent(ctx)
 
 	return ctx
+}
+
+func wrapHandler(ctx context.Context, pluginCtx PluginContext, next handlerWrapperFunc) error {
+	ctx = setupHandlerContext(ctx, pluginCtx)
+	wrapper := logWrapper(next)
+	_, err := wrapper(ctx)
+	return err
+}
+
+func setupHandlerContext(ctx context.Context, pluginCtx PluginContext) context.Context {
+	ctx = WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
+	ctx = WithPluginContext(ctx, pluginCtx)
+	ctx = WithUser(ctx, pluginCtx.User)
+	ctx = withContextualLogAttributes(ctx, pluginCtx)
+	ctx = WithUserAgent(ctx, pluginCtx.UserAgent)
+	return ctx
+}
+
+func logWrapper(next handlerWrapperFunc) handlerWrapperFunc {
+	return func(ctx context.Context) (RequestStatus, error) {
+		start := time.Now()
+		status, err := next(ctx)
+
+		logParams := []any{
+			"status", status.String(),
+			"duration", time.Since(start),
+		}
+
+		if err != nil {
+			logParams = append(logParams, "error", err)
+		}
+
+		// logParams = append(logParams, "statusSource", pluginrequestmeta.StatusSourceFromContext(ctx))
+
+		ctxLogger := Logger.FromContext(ctx)
+		logFunc := ctxLogger.Debug
+		if status > RequestStatusOK {
+			logFunc = ctxLogger.Error
+		}
+
+		logFunc("Plugin Request Completed", logParams...)
+
+		return status, err
+	}
 }
 
 func withHeaderMiddleware(ctx context.Context, headers http.Header) context.Context {

--- a/backend/adapter_utils.go
+++ b/backend/adapter_utils.go
@@ -124,7 +124,7 @@ func logWrapper(next handlerWrapperFunc) handlerWrapperFunc {
 
 		logParams := []any{
 			"status", status.String(),
-			"duration", time.Since(start),
+			"duration", time.Since(start).String(),
 		}
 
 		if err != nil {

--- a/backend/adapter_utils_test.go
+++ b/backend/adapter_utils_test.go
@@ -1,0 +1,37 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorWrapper(t *testing.T) {
+	t.Run("No downstream error should not set downstream error source in context", func(t *testing.T) {
+		ctx := InitErrorSource(context.Background())
+
+		actualErr := errors.New("BOOM")
+		wrapper := errorWrapper(func(_ context.Context) (RequestStatus, error) {
+			return RequestStatusError, actualErr
+		})
+		status, err := wrapper(ctx)
+		require.ErrorIs(t, err, actualErr)
+		require.Equal(t, RequestStatusError, status)
+		require.Equal(t, DefaultErrorSource, ErrorSourceFromContext(ctx))
+	})
+
+	t.Run("Downstream error should set downstream error source in context", func(t *testing.T) {
+		ctx := InitErrorSource(context.Background())
+
+		actualErr := errors.New("BOOM")
+		wrapper := errorWrapper(func(_ context.Context) (RequestStatus, error) {
+			return RequestStatusError, DownstreamError(actualErr)
+		})
+		status, err := wrapper(ctx)
+		require.ErrorIs(t, err, actualErr)
+		require.Equal(t, RequestStatusError, status)
+		require.Equal(t, ErrorSourceDownstream, ErrorSourceFromContext(ctx))
+	})
+}

--- a/backend/adapter_utils_test.go
+++ b/backend/adapter_utils_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestErrorWrapper(t *testing.T) {
 	t.Run("No downstream error should not set downstream error source in context", func(t *testing.T) {
-		ctx := InitErrorSource(context.Background())
+		ctx := initErrorSource(context.Background())
 
 		actualErr := errors.New("BOOM")
 		wrapper := errorWrapper(func(_ context.Context) (RequestStatus, error) {
@@ -19,11 +19,11 @@ func TestErrorWrapper(t *testing.T) {
 		status, err := wrapper(ctx)
 		require.ErrorIs(t, err, actualErr)
 		require.Equal(t, RequestStatusError, status)
-		require.Equal(t, DefaultErrorSource, ErrorSourceFromContext(ctx))
+		require.Equal(t, DefaultErrorSource, errorSourceFromContext(ctx))
 	})
 
 	t.Run("Downstream error should set downstream error source in context", func(t *testing.T) {
-		ctx := InitErrorSource(context.Background())
+		ctx := initErrorSource(context.Background())
 
 		actualErr := errors.New("BOOM")
 		wrapper := errorWrapper(func(_ context.Context) (RequestStatus, error) {
@@ -32,6 +32,6 @@ func TestErrorWrapper(t *testing.T) {
 		status, err := wrapper(ctx)
 		require.ErrorIs(t, err, actualErr)
 		require.Equal(t, RequestStatusError, status)
-		require.Equal(t, ErrorSourceDownstream, ErrorSourceFromContext(ctx))
+		require.Equal(t, ErrorSourceDownstream, errorSourceFromContext(ctx))
 	})
 }

--- a/backend/admission_adapter.go
+++ b/backend/admission_adapter.go
@@ -20,44 +20,50 @@ func newAdmissionSDKAdapter(handler AdmissionHandler) *admissionSDKAdapter {
 func (a *admissionSDKAdapter) ValidateAdmission(ctx context.Context, req *pluginv2.AdmissionRequest) (*pluginv2.ValidationResponse, error) {
 	ctx = setupContext(ctx, EndpointValidateAdmission)
 	parsedReq := FromProto().AdmissionRequest(req)
-	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
-	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
-	ctx = WithUser(ctx, parsedReq.PluginContext.User)
-	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext)
-	ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)
-	resp, err := a.handler.ValidateAdmission(ctx, parsedReq)
+
+	var resp *ValidationResponse
+	err := wrapHandler(ctx, parsedReq.PluginContext, func(ctx context.Context) (RequestStatus, error) {
+		var innerErr error
+		resp, innerErr = a.handler.ValidateAdmission(ctx, parsedReq)
+		return RequestStatusFromError(innerErr), innerErr
+	})
 	if err != nil {
 		return nil, err
 	}
+
 	return ToProto().ValidationResponse(resp), nil
 }
 
 func (a *admissionSDKAdapter) MutateAdmission(ctx context.Context, req *pluginv2.AdmissionRequest) (*pluginv2.MutationResponse, error) {
 	ctx = setupContext(ctx, EndpointMutateAdmission)
 	parsedReq := FromProto().AdmissionRequest(req)
-	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
-	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
-	ctx = WithUser(ctx, parsedReq.PluginContext.User)
-	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext)
-	ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)
-	resp, err := a.handler.MutateAdmission(ctx, parsedReq)
+
+	var resp *MutationResponse
+	err := wrapHandler(ctx, parsedReq.PluginContext, func(ctx context.Context) (RequestStatus, error) {
+		var innerErr error
+		resp, innerErr = a.handler.MutateAdmission(ctx, parsedReq)
+		return RequestStatusFromError(innerErr), innerErr
+	})
 	if err != nil {
 		return nil, err
 	}
+
 	return ToProto().MutationResponse(resp), nil
 }
 
 func (a *admissionSDKAdapter) ConvertObject(ctx context.Context, req *pluginv2.ConversionRequest) (*pluginv2.ConversionResponse, error) {
 	ctx = setupContext(ctx, EndpointConvertObject)
 	parsedReq := FromProto().ConversionRequest(req)
-	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
-	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
-	ctx = WithUser(ctx, parsedReq.PluginContext.User)
-	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext)
-	ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)
-	resp, err := a.handler.ConvertObject(ctx, parsedReq)
+
+	var resp *ConversionResponse
+	err := wrapHandler(ctx, parsedReq.PluginContext, func(ctx context.Context) (RequestStatus, error) {
+		var innerErr error
+		resp, innerErr = a.handler.ConvertObject(ctx, parsedReq)
+		return RequestStatusFromError(innerErr), innerErr
+	})
 	if err != nil {
 		return nil, err
 	}
+
 	return ToProto().ConversionResponse(resp), nil
 }

--- a/backend/admission_adapter.go
+++ b/backend/admission_adapter.go
@@ -18,10 +18,9 @@ func newAdmissionSDKAdapter(handler AdmissionHandler) *admissionSDKAdapter {
 }
 
 func (a *admissionSDKAdapter) ValidateAdmission(ctx context.Context, req *pluginv2.AdmissionRequest) (*pluginv2.ValidationResponse, error) {
-	ctx = WithEndpoint(ctx, EndpointValidateAdmission)
-	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(req.PluginContext.GrafanaConfig))
+	ctx = setupContext(ctx, EndpointValidateAdmission)
 	parsedReq := FromProto().AdmissionRequest(req)
+	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
 	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
 	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext)
@@ -34,10 +33,9 @@ func (a *admissionSDKAdapter) ValidateAdmission(ctx context.Context, req *plugin
 }
 
 func (a *admissionSDKAdapter) MutateAdmission(ctx context.Context, req *pluginv2.AdmissionRequest) (*pluginv2.MutationResponse, error) {
-	ctx = WithEndpoint(ctx, EndpointMutateAdmission)
-	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(req.PluginContext.GrafanaConfig))
+	ctx = setupContext(ctx, EndpointMutateAdmission)
 	parsedReq := FromProto().AdmissionRequest(req)
+	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
 	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
 	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext)
@@ -50,10 +48,9 @@ func (a *admissionSDKAdapter) MutateAdmission(ctx context.Context, req *pluginv2
 }
 
 func (a *admissionSDKAdapter) ConvertObject(ctx context.Context, req *pluginv2.ConversionRequest) (*pluginv2.ConversionResponse, error) {
-	ctx = WithEndpoint(ctx, EndpointConvertObject)
-	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(req.PluginContext.GrafanaConfig))
+	ctx = setupContext(ctx, EndpointConvertObject)
 	parsedReq := FromProto().ConversionRequest(req)
+	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
 	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
 	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext)

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -193,10 +193,6 @@ func (t ConvertToProtobuf) QueryDataRequest(req *QueryDataRequest) *pluginv2.Que
 // It will set the RefID on the frames to the RefID key in Responses if a Frame's
 // RefId property is an empty string.
 func (t ConvertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.QueryDataResponse, error) {
-	if res == nil {
-		return nil, nil
-	}
-
 	pQDR := &pluginv2.QueryDataResponse{
 		Responses: make(map[string]*pluginv2.DataResponse, len(res.Responses)),
 	}

--- a/backend/convert_to_protobuf.go
+++ b/backend/convert_to_protobuf.go
@@ -193,6 +193,10 @@ func (t ConvertToProtobuf) QueryDataRequest(req *QueryDataRequest) *pluginv2.Que
 // It will set the RefID on the frames to the RefID key in Responses if a Frame's
 // RefId property is an empty string.
 func (t ConvertToProtobuf) QueryDataResponse(res *QueryDataResponse) (*pluginv2.QueryDataResponse, error) {
+	if res == nil {
+		return nil, nil
+	}
+
 	pQDR := &pluginv2.QueryDataResponse{
 		Responses: make(map[string]*pluginv2.DataResponse, len(res.Responses)),
 	}

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -2,9 +2,7 @@ package backend
 
 import (
 	"context"
-	"net/http"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 )
 
@@ -19,35 +17,10 @@ func newDataSDKAdapter(handler QueryDataHandler) *dataSDKAdapter {
 	}
 }
 
-func withHeaderMiddleware(ctx context.Context, headers http.Header) context.Context {
-	if len(headers) > 0 {
-		ctx = httpclient.WithContextualMiddleware(ctx,
-			httpclient.MiddlewareFunc(func(opts httpclient.Options, next http.RoundTripper) http.RoundTripper {
-				if !opts.ForwardHTTPHeaders {
-					return next
-				}
-
-				return httpclient.RoundTripperFunc(func(qreq *http.Request) (*http.Response, error) {
-					// Only set a header if it is not already set.
-					for k, v := range headers {
-						if qreq.Header.Get(k) == "" {
-							for _, vv := range v {
-								qreq.Header.Add(k, vv)
-							}
-						}
-					}
-					return next.RoundTrip(qreq)
-				})
-			}))
-	}
-	return ctx
-}
-
 func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataRequest) (*pluginv2.QueryDataResponse, error) {
-	ctx = WithEndpoint(ctx, EndpointQueryData)
-	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(req.PluginContext.GrafanaConfig))
+	ctx = setupContext(ctx, EndpointQueryData)
 	parsedReq := FromProto().QueryDataRequest(req)
+	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
 	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
 	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -142,11 +142,6 @@ func TestQueryData(t *testing.T) {
 			expErrorSource    ErrorSource
 		}{
 			{
-				name:              `no error should be "plugin" error source`,
-				queryDataResponse: nil,
-				expErrorSource:    ErrorSourcePlugin,
-			},
-			{
 				name: `single downstream error should be "downstream" error source`,
 				queryDataResponse: &QueryDataResponse{
 					Responses: map[string]DataResponse{

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -196,7 +196,7 @@ func TestQueryData(t *testing.T) {
 					PluginContext: &pluginv2.PluginContext{},
 				})
 				require.NoError(t, err)
-				ss := ErrorSourceFromContext(actualCtx)
+				ss := errorSourceFromContext(actualCtx)
 				require.Equal(t, tc.expErrorSource, ss)
 			})
 		}

--- a/backend/diagnostics_adapter.go
+++ b/backend/diagnostics_adapter.go
@@ -45,21 +45,22 @@ func (a *diagnosticsSDKAdapter) CollectMetrics(_ context.Context, _ *pluginv2.Co
 }
 
 func (a *diagnosticsSDKAdapter) CheckHealth(ctx context.Context, protoReq *pluginv2.CheckHealthRequest) (*pluginv2.CheckHealthResponse, error) {
-	ctx = setupContext(ctx, EndpointCheckHealth)
-
 	if a.checkHealthHandler != nil {
+		ctx = setupContext(ctx, EndpointCheckHealth)
 		parsedReq := FromProto().CheckHealthRequest(protoReq)
-		ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
-		ctx = WithPluginContext(ctx, parsedReq.PluginContext)
-		ctx = WithUser(ctx, parsedReq.PluginContext.User)
-		ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
-		ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext)
-		ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)
-		res, err := a.checkHealthHandler.CheckHealth(ctx, parsedReq)
+
+		var resp *CheckHealthResult
+		err := wrapHandler(ctx, parsedReq.PluginContext, func(ctx context.Context) (RequestStatus, error) {
+			ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
+			var innerErr error
+			resp, innerErr = a.checkHealthHandler.CheckHealth(ctx, parsedReq)
+			return RequestStatusFromError(innerErr), innerErr
+		})
 		if err != nil {
 			return nil, err
 		}
-		return ToProto().CheckHealthResponse(res), nil
+
+		return ToProto().CheckHealthResponse(resp), nil
 	}
 
 	return &pluginv2.CheckHealthResponse{

--- a/backend/diagnostics_adapter.go
+++ b/backend/diagnostics_adapter.go
@@ -45,11 +45,11 @@ func (a *diagnosticsSDKAdapter) CollectMetrics(_ context.Context, _ *pluginv2.Co
 }
 
 func (a *diagnosticsSDKAdapter) CheckHealth(ctx context.Context, protoReq *pluginv2.CheckHealthRequest) (*pluginv2.CheckHealthResponse, error) {
+	ctx = setupContext(ctx, EndpointCheckHealth)
+
 	if a.checkHealthHandler != nil {
-		ctx = WithEndpoint(ctx, EndpointCheckHealth)
-		ctx = propagateTenantIDIfPresent(ctx)
-		ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 		parsedReq := FromProto().CheckHealthRequest(protoReq)
+		ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
 		ctx = WithPluginContext(ctx, parsedReq.PluginContext)
 		ctx = WithUser(ctx, parsedReq.PluginContext.User)
 		ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())

--- a/backend/endpoint.go
+++ b/backend/endpoint.go
@@ -10,6 +10,10 @@ func (e Endpoint) IsEmpty() bool {
 	return e == ""
 }
 
+func (e Endpoint) String() string {
+	return string(e)
+}
+
 type endpointCtxKeyType struct{}
 
 var endpointCtxKey = endpointCtxKeyType{}

--- a/backend/error_source.go
+++ b/backend/error_source.go
@@ -1,16 +1,27 @@
 package backend
 
-import "net/http"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
 
 // ErrorSource type defines the source of the error
 type ErrorSource string
 
 const (
-	ErrorSourcePlugin     ErrorSource = "plugin"
+	// ErrorSourcePlugin error originates from plugin.
+	ErrorSourcePlugin ErrorSource = "plugin"
+
+	// ErrorSourceDownstream error originates from downstream service.
 	ErrorSourceDownstream ErrorSource = "downstream"
+
+	// DefaultErrorSource is the default [ErrorSource] that should be used when it is not explicitly set.
+	DefaultErrorSource ErrorSource = ErrorSourcePlugin
 )
 
-// ErrorSourceFromStatus returns an ErrorSource based on provided HTTP status code.
+// ErrorSourceFromStatus returns an [ErrorSource] based on provided HTTP status code.
 func ErrorSourceFromHTTPStatus(statusCode int) ErrorSource {
 	switch statusCode {
 	case http.StatusMethodNotAllowed,
@@ -27,4 +38,78 @@ func ErrorSourceFromHTTPStatus(statusCode int) ErrorSource {
 	}
 
 	return ErrorSourceDownstream
+}
+
+type ErrorWithSource interface {
+	ErrorSource() ErrorSource
+}
+
+type errorWithSource struct {
+	source ErrorSource
+	err    error
+}
+
+func DownstreamError(err error) error {
+	return &errorWithSource{
+		source: ErrorSourceDownstream,
+		err:    err,
+	}
+}
+
+func DownstreamErrorf(format string, a ...any) error {
+	return &errorWithSource{
+		source: ErrorSourceDownstream,
+		err:    fmt.Errorf(format, a...),
+	}
+}
+
+func (e errorWithSource) ErrorSource() ErrorSource {
+	return e.source
+}
+
+func (e errorWithSource) Error() string {
+	return fmt.Errorf("%s error: %w", e.source, e.err).Error()
+}
+
+func (e errorWithSource) Unwrap() error {
+	return e.err
+}
+
+type errorSourceCtxKey struct{}
+
+// ErrorSourceFromContext returns the error source stored in the context.
+// If no error source is stored in the context, [DefaultErrorSource] is returned.
+func ErrorSourceFromContext(ctx context.Context) ErrorSource {
+	value, ok := ctx.Value(errorSourceCtxKey{}).(*ErrorSource)
+	if ok {
+		return *value
+	}
+	return DefaultErrorSource
+}
+
+// InitErrorSource initialize the status source for the context.
+func InitErrorSource(ctx context.Context) context.Context {
+	s := DefaultErrorSource
+	return context.WithValue(ctx, errorSourceCtxKey{}, &s)
+}
+
+// WithErrorSource mutates the provided context by setting the error source to
+// s. If the provided context does not have a error source, the context
+// will not be mutated and an error returned. This means that [InitErrorSource]
+// has to be called before this function.
+func WithErrorSource(ctx context.Context, s ErrorSource) error {
+	v, ok := ctx.Value(errorSourceCtxKey{}).(*ErrorSource)
+	if !ok {
+		return errors.New("the provided context does not have a status source")
+	}
+	*v = s
+	return nil
+}
+
+// WithDownstreamErrorSource mutates the provided context by setting the error source to
+// [ErrorSourceDownstream]. If the provided context does not have a error source, the context
+// will not be mutated and an error returned. This means that [InitErrorSource] has to be
+// called before this function.
+func WithDownstreamErrorSource(ctx context.Context) error {
+	return WithErrorSource(ctx, ErrorSourceDownstream)
 }

--- a/backend/error_source.go
+++ b/backend/error_source.go
@@ -57,6 +57,7 @@ func IsDownstreamError(err error) bool {
 		ErrorSource() ErrorSource
 	}
 
+	// nolint:errorlint
 	if errWithSource, ok := err.(errorWithSource); ok && errWithSource.ErrorSource() == ErrorSourceDownstream {
 		return true
 	}

--- a/backend/request_status.go
+++ b/backend/request_status.go
@@ -1,0 +1,103 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
+)
+
+type RequestStatus int
+
+const (
+	RequestStatusOK RequestStatus = iota
+	RequestStatusCancelled
+	RequestStatusError
+)
+
+func (status RequestStatus) String() string {
+	names := [...]string{"ok", "cancelled", "error"}
+	if status < RequestStatusOK || status > RequestStatusError {
+		return ""
+	}
+
+	return names[status]
+}
+
+func RequestStatusFromError(err error) RequestStatus {
+	status := RequestStatusOK
+	if err != nil {
+		status = RequestStatusError
+		if errors.Is(err, context.Canceled) || grpcstatus.Code(err) == grpccodes.Canceled {
+			status = RequestStatusCancelled
+		}
+	}
+
+	return status
+}
+
+func RequestStatusFromErrorString(errString string) RequestStatus {
+	status := RequestStatusOK
+	if errString != "" {
+		status = RequestStatusError
+		if strings.Contains(errString, context.Canceled.Error()) || strings.Contains(errString, "code = Canceled") {
+			status = RequestStatusCancelled
+		}
+	}
+
+	return status
+}
+
+func RequestStatusFromQueryDataResponse(res *QueryDataResponse, err error) RequestStatus {
+	if err != nil {
+		return RequestStatusFromError(err)
+	}
+
+	status := RequestStatusOK
+
+	if res != nil {
+		for _, dr := range res.Responses {
+			if dr.Error != nil {
+				s := RequestStatusFromError(dr.Error)
+				if s > status {
+					status = s
+				}
+
+				if status == RequestStatusError {
+					break
+				}
+			}
+		}
+	}
+
+	return status
+}
+
+func RequestStatusFromProtoQueryDataResponse(res *pluginv2.QueryDataResponse, err error) RequestStatus {
+	if err != nil {
+		return RequestStatusFromError(err)
+	}
+
+	status := RequestStatusOK
+
+	if res != nil {
+		for _, dr := range res.Responses {
+			if dr.Error != "" {
+				s := RequestStatusFromErrorString(dr.Error)
+				if s > status {
+					status = s
+				}
+
+				if status == RequestStatusError {
+					break
+				}
+			}
+		}
+	}
+
+	return status
+}

--- a/backend/request_status_test.go
+++ b/backend/request_status_test.go
@@ -1,0 +1,180 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+func TestRequestStatus(t *testing.T) {
+	tcs := []struct {
+		s             RequestStatus
+		expectedLabel string
+	}{
+		{
+			s:             RequestStatusOK,
+			expectedLabel: "ok",
+		},
+		{
+			s:             RequestStatusError,
+			expectedLabel: "error",
+		},
+		{
+			s:             RequestStatusCancelled,
+			expectedLabel: "cancelled",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.s.String(), func(t *testing.T) {
+			require.Equal(t, tc.expectedLabel, tc.s.String())
+			require.Equal(t, tc.expectedLabel, fmt.Sprint(tc.s))
+		})
+	}
+}
+
+func TestRequestStatusFromError(t *testing.T) {
+	tcs := []struct {
+		desc           string
+		err            error
+		expectedStatus RequestStatus
+	}{
+		{
+			desc:           "no error should be status ok",
+			err:            nil,
+			expectedStatus: RequestStatusOK,
+		},
+		{
+			desc:           "error should be status error",
+			err:            errors.New("boom"),
+			expectedStatus: RequestStatusError,
+		},
+		{
+			desc:           "context canceled should be status cancelled",
+			err:            context.Canceled,
+			expectedStatus: RequestStatusCancelled,
+		},
+		{
+			desc:           "gRPC canceled should be status cancelled",
+			err:            status.Error(codes.Canceled, "canceled"),
+			expectedStatus: RequestStatusCancelled,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			status := RequestStatusFromError(tc.err)
+			require.Equal(t, tc.expectedStatus, status)
+		})
+	}
+}
+
+func TestRequestStatusFromQueryDataResponse(t *testing.T) {
+	responseWithoutError := NewQueryDataResponse()
+	responseWithoutError.Responses["A"] = DataResponse{
+		Frames: data.Frames{data.NewFrame("test")},
+	}
+
+	responseWithError := NewQueryDataResponse()
+	responseWithError.Responses["A"] = DataResponse{
+		Error: errors.New("boom"),
+	}
+	responseWithMultipleErrors := NewQueryDataResponse()
+	responseWithMultipleErrors.Responses["A"] = DataResponse{
+		Error: context.Canceled,
+	}
+	responseWithMultipleErrors.Responses["B"] = DataResponse{
+		Frames: data.Frames{data.NewFrame("test")},
+	}
+	responseWithMultipleErrors.Responses["C"] = DataResponse{
+		Error: errors.New("boom"),
+	}
+
+	tcs := []struct {
+		desc           string
+		resp           *QueryDataResponse
+		err            error
+		expectedStatus RequestStatus
+	}{
+		{
+			desc:           "no error should be status ok",
+			err:            nil,
+			expectedStatus: RequestStatusOK,
+		},
+		{
+			desc:           "error should be status error",
+			err:            errors.New("boom"),
+			expectedStatus: RequestStatusError,
+		},
+		{
+			desc:           "context canceled should be status cancelled",
+			err:            context.Canceled,
+			expectedStatus: RequestStatusCancelled,
+		},
+		{
+			desc:           "response without error should be status ok",
+			resp:           responseWithoutError,
+			expectedStatus: RequestStatusOK,
+		},
+		{
+			desc:           "response with error should be status error",
+			resp:           responseWithError,
+			expectedStatus: RequestStatusError,
+		},
+		{
+			desc:           "response with multiple error should pick the highest status cancelled",
+			resp:           responseWithMultipleErrors,
+			expectedStatus: RequestStatusError,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			status := RequestStatusFromQueryDataResponse(tc.resp, tc.err)
+			require.Equal(t, tc.expectedStatus, status)
+		})
+	}
+}
+
+func TestRequestStatusFromErrorString(t *testing.T) {
+	tcs := []struct {
+		desc           string
+		err            string
+		expectedStatus RequestStatus
+	}{
+		{
+			desc:           "no error should be status ok",
+			err:            "",
+			expectedStatus: RequestStatusOK,
+		},
+		{
+			desc:           "error should be status error",
+			err:            errors.New("boom").Error(),
+			expectedStatus: RequestStatusError,
+		},
+		{
+			desc:           "context canceled should be status cancelled",
+			err:            context.Canceled.Error(),
+			expectedStatus: RequestStatusCancelled,
+		},
+		{
+			desc:           "gRPC canceled should be status cancelled",
+			err:            status.Error(codes.Canceled, "canceled").Error(),
+			expectedStatus: RequestStatusCancelled,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			status := RequestStatusFromErrorString(tc.err)
+			require.Equal(t, tc.expectedStatus, status)
+		})
+	}
+}

--- a/backend/resource_adapter.go
+++ b/backend/resource_adapter.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
@@ -31,11 +32,10 @@ func (a *resourceSDKAdapter) CallResource(protoReq *pluginv2.CallResourceRequest
 	ctx := protoSrv.Context()
 	ctx = setupContext(ctx, EndpointCallResource)
 	parsedReq := FromProto().CallResourceRequest(protoReq)
-	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
-	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
-	ctx = WithUser(ctx, parsedReq.PluginContext.User)
-	ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
-	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext)
-	ctx = WithUserAgent(ctx, parsedReq.PluginContext.UserAgent)
-	return a.callResourceHandler.CallResource(ctx, parsedReq, fn)
+
+	return wrapHandler(ctx, parsedReq.PluginContext, func(ctx context.Context) (RequestStatus, error) {
+		ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())
+		err := a.callResourceHandler.CallResource(ctx, parsedReq, fn)
+		return RequestStatusFromError(err), err
+	})
 }

--- a/backend/resource_adapter.go
+++ b/backend/resource_adapter.go
@@ -29,10 +29,9 @@ func (a *resourceSDKAdapter) CallResource(protoReq *pluginv2.CallResourceRequest
 	})
 
 	ctx := protoSrv.Context()
-	ctx = WithEndpoint(ctx, EndpointCallResource)
-	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
+	ctx = setupContext(ctx, EndpointCallResource)
 	parsedReq := FromProto().CallResourceRequest(protoReq)
+	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
 	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
 	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withHeaderMiddleware(ctx, parsedReq.GetHTTPHeaders())

--- a/backend/stream_adapter.go
+++ b/backend/stream_adapter.go
@@ -21,13 +21,13 @@ func newStreamSDKAdapter(handler StreamHandler) *streamSDKAdapter {
 }
 
 func (a *streamSDKAdapter) SubscribeStream(ctx context.Context, protoReq *pluginv2.SubscribeStreamRequest) (*pluginv2.SubscribeStreamResponse, error) {
+	ctx = setupContext(ctx, EndpointSubscribeStream)
+
 	if a.streamHandler == nil {
 		return nil, status.Error(codes.Unimplemented, "not implemented")
 	}
-	ctx = WithEndpoint(ctx, EndpointSubscribeStream)
-	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().SubscribeStreamRequest(protoReq)
+	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
 	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
 	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext)
@@ -39,13 +39,13 @@ func (a *streamSDKAdapter) SubscribeStream(ctx context.Context, protoReq *plugin
 }
 
 func (a *streamSDKAdapter) PublishStream(ctx context.Context, protoReq *pluginv2.PublishStreamRequest) (*pluginv2.PublishStreamResponse, error) {
+	ctx = setupContext(ctx, EndpointPublishStream)
+
 	if a.streamHandler == nil {
 		return nil, status.Error(codes.Unimplemented, "not implemented")
 	}
-	ctx = WithEndpoint(ctx, EndpointPublishStream)
-	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
 	parsedReq := FromProto().PublishStreamRequest(protoReq)
+	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
 	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
 	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext)
@@ -69,10 +69,9 @@ func (a *streamSDKAdapter) RunStream(protoReq *pluginv2.RunStreamRequest, protoS
 		return status.Error(codes.Unimplemented, "not implemented")
 	}
 	ctx := protoSrv.Context()
-	ctx = WithEndpoint(ctx, EndpointRunStream)
-	ctx = propagateTenantIDIfPresent(ctx)
-	ctx = WithGrafanaConfig(ctx, NewGrafanaCfg(protoReq.PluginContext.GrafanaConfig))
+	ctx = setupContext(ctx, EndpointRunStream)
 	parsedReq := FromProto().RunStreamRequest(protoReq)
+	ctx = WithGrafanaConfig(ctx, parsedReq.PluginContext.GrafanaConfig)
 	ctx = WithPluginContext(ctx, parsedReq.PluginContext)
 	ctx = WithUser(ctx, parsedReq.PluginContext.User)
 	ctx = withContextualLogAttributes(ctx, parsedReq.PluginContext)

--- a/backend/tracing/tracing.go
+++ b/backend/tracing/tracing.go
@@ -2,10 +2,12 @@ package tracing
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -49,4 +51,17 @@ func TraceIDFromContext(ctx context.Context, requireSampled bool) string {
 	}
 
 	return spanCtx.TraceID().String()
+}
+
+// Error sets the status to error and record the error as an exception in the provided span.
+func Error(span trace.Span, err error) error {
+	span.SetStatus(codes.Error, err.Error())
+	span.RecordError(err)
+	return err
+}
+
+// Errorf wraps fmt.Errorf and also sets the status to error and record the error as an exception in the provided span.
+func Errorf(span trace.Span, format string, args ...any) error {
+	err := fmt.Errorf(format, args...)
+	return Error(span, err)
 }

--- a/experimental/errorsource/error_source.go
+++ b/experimental/errorsource/error_source.go
@@ -33,6 +33,10 @@ func (r Error) Source() backend.ErrorSource {
 	return r.source
 }
 
+func (r Error) ErrorSource() backend.ErrorSource {
+	return r.source
+}
+
 // PluginError will apply the source as plugin
 func PluginError(err error, override bool) error {
 	return SourceError(backend.ErrorSourcePlugin, err, override)

--- a/experimental/errorsource/error_source_test.go
+++ b/experimental/errorsource/error_source_test.go
@@ -84,3 +84,12 @@ func TestResponseWithOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestError(t *testing.T) {
+	err := errors.New("boom")
+	require.False(t, backend.IsDownstreamError(err))
+	pErr := PluginError(err, true)
+	require.False(t, backend.IsDownstreamError(pErr))
+	dErr := DownstreamError(err, true)
+	require.True(t, backend.IsDownstreamError(dErr))
+}


### PR DESCRIPTION
Makes the adapters share some common functionality (middlewares).
- Adds request/handler logs, traces and metrics.
- Adds basic support for capturing error source (status source in grafana) given QueryDataResponse to make it in pair with how Grafana works. In theory `backend.DownstreamError(...)` or `backend.WithDownstreamErrorSource(...) could be returned/used from `CheckHealth` and `CallResource`, but should be considered experimental.
- Copies `RequestStatus` from grafana into backend package for convenience (could be used by Grafana later)

Note 1) There's https://github.com/grafana/grafana-plugin-sdk-go/pull/1019 which I had in mind for this. However, I think we can pick that up later and rather focusing on getting this logic in place.

Reminder: https://grafana.com/developers/plugin-tools/how-to-guides/data-source-plugins/add-logs-metrics-traces-for-backend-plugins should be updated later in regards to automatic instrumentation by the SDK.