### PR TITLE
Return appropriate status type plugin request status handler func

### DIFF
--- a/backend/adapter_utils.go
+++ b/backend/adapter_utils.go
@@ -135,7 +135,7 @@ func logWrapper(next handlerWrapperFunc) handlerWrapperFunc {
 
 		ctxLogger := Logger.FromContext(ctx)
 		logFunc := ctxLogger.Debug
-		if status > RequestStatusOK {
+		if status > RequestStatusCancelled {
 			logFunc = ctxLogger.Error
 		}
 

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -59,7 +59,7 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 
 		if hasCancelledError {
 			if err := WithDownstreamErrorSource(ctx); err != nil {
-				return RequestStatusError, fmt.Errorf("failed to set cancelled status source: %w", errors.Join(innerErr, err))
+				return RequestStatusError, fmt.Errorf("failed to set downstream status source: %w", errors.Join(innerErr, err))
 			}
 			return RequestStatusCancelled, nil
 		}
@@ -75,7 +75,7 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 
 		if hasPluginError {
 			if err := WithErrorSource(ctx, ErrorSourcePlugin); err != nil {
-				return RequestStatusError, fmt.Errorf("failed to set default status source: %w", errors.Join(innerErr, err))
+				return RequestStatusError, fmt.Errorf("failed to set plugin status source: %w", errors.Join(innerErr, err))
 			}
 			return RequestStatusError, nil
 		}

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -37,6 +37,7 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 		// and if there's no plugin error
 		var hasPluginError bool
 		var hasDownstreamError bool
+		var dataRespErr error
 		for _, r := range resp.Responses {
 			if r.Error == nil {
 				continue
@@ -45,6 +46,9 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 				hasDownstreamError = true
 			} else {
 				hasPluginError = true
+			}
+			if dataRespErr == nil {
+				dataRespErr = r.Error
 			}
 		}
 
@@ -56,7 +60,15 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 			}
 		}
 
-		return RequestStatusFromError(innerErr), innerErr
+		if innerErr != nil {
+			return RequestStatusFromError(innerErr), innerErr
+		}
+
+		if dataRespErr != nil {
+			return RequestStatusFromError(dataRespErr), dataRespErr
+		}
+
+		return RequestStatusOK, nil
 	})
 	if err != nil {
 		return nil, err

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -33,7 +33,7 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 			return RequestStatusFromError(innerErr), innerErr
 		}
 
-		if errors.Is(innerErr, context.Canceled) {
+		if isCancelledError(innerErr) {
 			return RequestStatusCancelled, nil
 		}
 
@@ -47,7 +47,7 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 				continue
 			}
 
-			if errors.Is(r.Error, context.Canceled) {
+			if isCancelledError(r.Error) {
 				hasCancelledError = true
 			}
 			if r.ErrorSource == ErrorSourceDownstream {

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -47,7 +47,6 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 				hasPluginError = true
 			}
 		}
-		ctxLogger := Logger.FromContext(ctx)
 
 		// A plugin error has higher priority than a downstream error,
 		// so set to downstream only if there's no plugin error
@@ -55,14 +54,13 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 			if err := WithDownstreamErrorSource(ctx); err != nil {
 				return RequestStatusError, fmt.Errorf("failed to set downstream status source: %w", errors.Join(innerErr, err))
 			}
-			ctxLogger.Debug("Set downstream error source")
+			return RequestStatusError, nil
 		}
 
 		if hasPluginError {
 			if err := WithErrorSource(ctx, ErrorSourcePlugin); err != nil {
 				return RequestStatusError, fmt.Errorf("failed to set default status source: %w", errors.Join(innerErr, err))
 			}
-			ctxLogger.Debug("Set default error source")
 			return RequestStatusError, nil
 		}
 

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -135,13 +135,11 @@ func TestQueryData(t *testing.T) {
 
 	t.Run("TestQueryDataResponse", func(t *testing.T) {
 		someErr := errors.New("oops")
-		someOtherErr := errors.New("oops")
 
 		for _, tc := range []struct {
 			name              string
 			queryDataResponse *QueryDataResponse
 			expErrorSource    ErrorSource
-			err               error
 		}{
 			{
 				name: `single downstream error should be "downstream" error source`,
@@ -151,7 +149,6 @@ func TestQueryData(t *testing.T) {
 					},
 				},
 				expErrorSource: ErrorSourceDownstream,
-				err:            someErr,
 			},
 			{
 				name: `single plugin error should be "plugin" error source`,
@@ -161,30 +158,27 @@ func TestQueryData(t *testing.T) {
 					},
 				},
 				expErrorSource: ErrorSourcePlugin,
-				err:            someErr,
 			},
 			{
 				name: `multiple downstream errors should be "downstream" error source`,
 				queryDataResponse: &QueryDataResponse{
 					Responses: map[string]DataResponse{
 						"A": {Error: someErr, ErrorSource: ErrorSourceDownstream},
-						"B": {Error: someOtherErr, ErrorSource: ErrorSourceDownstream},
+						"B": {Error: someErr, ErrorSource: ErrorSourceDownstream},
 					},
 				},
 				expErrorSource: ErrorSourceDownstream,
-				err:            someErr,
 			},
 			{
 				name: `single plugin error mixed with downstream errors should be "plugin" error source`,
 				queryDataResponse: &QueryDataResponse{
 					Responses: map[string]DataResponse{
-						"A": {Error: someOtherErr, ErrorSource: ErrorSourceDownstream},
+						"A": {Error: someErr, ErrorSource: ErrorSourceDownstream},
 						"B": {Error: someErr, ErrorSource: ErrorSourcePlugin},
 						"C": {Error: someErr, ErrorSource: ErrorSourceDownstream},
 					},
 				},
 				expErrorSource: ErrorSourcePlugin,
-				err:            someOtherErr,
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
@@ -196,12 +190,7 @@ func TestQueryData(t *testing.T) {
 				_, err := a.QueryData(context.Background(), &pluginv2.QueryDataRequest{
 					PluginContext: &pluginv2.PluginContext{},
 				})
-				if tc.err != nil {
-					require.Error(t, err)
-					require.Equal(t, tc.err, err)
-				} else {
-					require.NoError(t, err)
-				}
+				require.NoError(t, err)
 				ss := errorSourceFromContext(actualCtx)
 				require.Equal(t, tc.expErrorSource, ss)
 			})

--- a/backend/request_status.go
+++ b/backend/request_status.go
@@ -32,7 +32,7 @@ func RequestStatusFromError(err error) RequestStatus {
 	status := RequestStatusOK
 	if err != nil {
 		status = RequestStatusError
-		if errors.Is(err, context.Canceled) || grpcstatus.Code(err) == grpccodes.Canceled {
+		if isCancelledError(err) {
 			status = RequestStatusCancelled
 		}
 	}
@@ -100,4 +100,8 @@ func RequestStatusFromProtoQueryDataResponse(res *pluginv2.QueryDataResponse, er
 	}
 
 	return status
+}
+
+func isCancelledError(err error) bool {
+	return errors.Is(err, context.Canceled) || grpcstatus.Code(err) == grpccodes.Canceled
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In the cases where we have an error or cancellation set on the data response, we are not currently returning an error status from the request status handler, leading to incorrect instrumentation. This PR aims to fix this.

For a response handler such as:
```go
func (s *QueryHandler) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
	resp := backend.NewQueryDataResponse()
	for _, q := range req.Queries {
		respD := resp.Responses[q.RefID]
		respD.Frames = append(respD.Frames, data.NewFrame("response"))
		respD.Error = errors.New("this is a plugin error")
		respD.ErrorSource = backend.ErrorSourcePlugin
		resp.Responses[q.RefID] = respD
	}
	return resp, nil
}

```

Before:
```json
{
    "@level": "debug",
    "@message": "Plugin Request Completed",
    "@timestamp": "2024-07-15T16:48:05.129513+01:00",
    "dsName": "GitHub",
    "dsUID": "a5219f2a-6a14-48bd-b986-7a7822573bcc",
    "duration": "206.333µs",
    "endpoint": "queryData",
    "pluginID": "grafana-github-datasource",
    "status": "ok",
    "statusSource": "plugin",
    "uname": "admin"
}
```

After:
```json
{
    "@level": "error",
    "@message": "Plugin Request Completed",
    "@timestamp": "2024-07-15T16:37:34.284267+01:00",
    "dsName": "GitHub",
    "dsUID": "a5219f2a-6a14-48bd-b986-7a7822573bcc",
    "duration": "2.63065125s",
    "endpoint": "queryData",
    "error": "this is a plugin error",
    "pluginID": "grafana-github-datasource",
    "status": "error",
    "statusSource": "plugin",
    "uname": "admin"
}
```

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**: