### PR TITLE
Build: Fix plugins not reloading correctly on dev mode

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -60,7 +60,7 @@ func getExecutableName(os string, arch string, pluginJSONPath string) (string, e
 		exname = exename
 	}
 
-	return asExecutableName(os, arch, pluginJSONPath), nil
+	return asExecutableName(os, arch, exname), nil
 }
 
 // execNameCache is a cache for the executable name, so we don't have to read the plugin.json file multiple times.

--- a/build/common_unix.go
+++ b/build/common_unix.go
@@ -18,7 +18,7 @@ import (
 
 // ReloadPlugin - kills any running instances and waits for grafana to reload the plugin
 func ReloadPlugin() error {
-	exeName, err := getExecutableName(runtime.GOOS, runtime.GOARCH, defaultPluginJSONPath)
+	exeName, err := getExecutableNameForPlugin(runtime.GOOS, runtime.GOARCH, defaultPluginJSONPath)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,10 @@ func Debugger() error {
 		time.Sleep(250 * time.Millisecond)
 	}
 	if pid == -1 {
-		return fmt.Errorf("could not find plugin process %q, perhaps Grafana is not running?", exeName)
+		return fmt.Errorf(
+			"could not find plugin process %q, perhaps Grafana is not running?",
+			exeName,
+		)
 	}
 
 	pidStr := strconv.Itoa(pid)


### PR DESCRIPTION
- **Build: Use exname to get executable name for plugin executable name**
- **Use getExecutableNameForPlugin instead of deprecated method**
