### PR TITLE
InternalDataLinks Update types for time range

### DIFF
--- a/data/field_config.go
+++ b/data/field_config.go
@@ -172,7 +172,7 @@ type InternalDataLink struct {
 	DatasourceName     string                      `json:"datasourceName,omitempty"`
 	ExplorePanelsState *ExplorePanelsState         `json:"panelsState,omitempty"`
 	Transformations    *[]LinkTransformationConfig `json:"transformations,omitempty"`
-	Range              *TimeRange                  `json:"timeRange,omitempty"`
+	Range              *TimeRange                  `json:"range,omitempty"`
 }
 
 // This is an object constructed with the keys as the values of the enum VisType and the value being a bag of properties
@@ -182,6 +182,18 @@ type ExplorePanelsState any
 type TimeRange struct {
 	From time.Time `json:"from,omitempty"`
 	To   time.Time `json:"to,omitempty"`
+	// Use RawTimeRangeTime or RawTimeRangeString when passing it to frontend
+	Raw interface{} `json:"raw,omitempty"`
+}
+
+type RawTimeRangeTime struct {
+	From time.Time `json:"from,omitempty"`
+	To   time.Time `json:"to,omitempty"`
+}
+
+type RawTimeRangeString struct {
+	From string `json:"from,omitempty"`
+	To   string `json:"to,omitempty"`
 }
 
 type LinkTransformationConfig struct {

--- a/data/field_config_test.go
+++ b/data/field_config_test.go
@@ -175,11 +175,11 @@ func TestCreateInternalDataLinks(t *testing.T) {
 						To:   linkTime,
 					},
 				},
-			},
+			}, `l`
 		},
 	}
 
-	expectedJson := `{
+	expectedJSON := `{
 		"links": [
 			{
 				"internal": {
@@ -223,5 +223,5 @@ func TestCreateInternalDataLinks(t *testing.T) {
 	require.NoError(t, err, "error marshalling json")
 
 	str := string(out)
-	assert.JSONEq(t, expectedJson, str)
+	assert.JSONEq(t, expectedJSON, str)
 }

--- a/data/field_config_test.go
+++ b/data/field_config_test.go
@@ -2,6 +2,7 @@ package data_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 

--- a/data/field_config_test.go
+++ b/data/field_config_test.go
@@ -175,7 +175,7 @@ func TestCreateInternalDataLinks(t *testing.T) {
 						To:   linkTime,
 					},
 				},
-			}, `l`
+			},
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/81306

* There was a JSON prop mismatch for marshaling the time range (this is used only when sending it frontend, probably never used send from the frontend to backend): `timeRange` --> `range`
* There was no way to pass "raw" time range which allows to pass relative time ranges and is being used by Explore. Without this prop, plugins cannot create data links with a time range in backend.