### PR TITLE
Capture log params from context metadata

### DIFF
--- a/backend/log.go
+++ b/backend/log.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"

--- a/backend/log.go
+++ b/backend/log.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -38,6 +37,11 @@ func withContextualLogAttributes(ctx context.Context, pCtx PluginContext) contex
 			args = append(args, "uname", pCtx.User.Name)
 		}
 	}
+
+	if ctxLogAttributes := log.ContextualAttributesFromIncomingContext(ctx); len(ctxLogAttributes) > 0 {
+		args = append(args, ctxLogAttributes...)
+	}
+
 	ctx = log.WithContextualAttributes(ctx, args)
 	return ctx
 }

--- a/backend/log.go
+++ b/backend/log.go
@@ -39,7 +39,7 @@ func withContextualLogAttributes(ctx context.Context, pCtx PluginContext) contex
 		}
 	}
 
-	if ctxLogAttributes := log.contextualAttributesFromIncomingContext(ctx); len(ctxLogAttributes) > 0 {
+	if ctxLogAttributes := log.ContextualAttributesFromIncomingContext(ctx); len(ctxLogAttributes) > 0 {
 		args = append(args, ctxLogAttributes...)
 	}
 

--- a/backend/log.go
+++ b/backend/log.go
@@ -39,7 +39,7 @@ func withContextualLogAttributes(ctx context.Context, pCtx PluginContext) contex
 		}
 	}
 
-	if ctxLogAttributes := log.ContextualAttributesFromIncomingContext(ctx); len(ctxLogAttributes) > 0 {
+	if ctxLogAttributes := log.contextualAttributesFromIncomingContext(ctx); len(ctxLogAttributes) > 0 {
 		args = append(args, ctxLogAttributes...)
 	}
 

--- a/backend/log/context_grpc.go
+++ b/backend/log/context_grpc.go
@@ -22,6 +22,10 @@ func WithContextualAttributesForOutgoingContext(ctx context.Context, logParams [
 	for i := 0; i < len(logParams); i += 2 {
 		k := logParams[i].(string)
 		v := logParams[i+1].(string)
+		if k == "" || v == "" {
+			continue
+		}
+
 		ctx = metadata.AppendToOutgoingContext(ctx, logParamsCtxMetadataKey, fmt.Sprintf("%s%s%s", k, logParamSeparator, v))
 	}
 
@@ -38,6 +42,9 @@ func ContextualAttributesFromIncomingContext(ctx context.Context) []any {
 	var attrs []any
 	for _, param := range logParams {
 		kv := strings.Split(param, logParamSeparator)
+		if len(kv) != 2 {
+			continue
+		}
 		attrs = append(attrs, kv[0], kv[1])
 	}
 	return attrs

--- a/backend/log/context_grpc.go
+++ b/backend/log/context_grpc.go
@@ -1,0 +1,49 @@
+package log
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+)
+
+var loggerParamsCtxMetadataKey = "loggerParamsCtxMetadata"
+
+// WithContextualAttributesForOutgoingContext returns a new context with the given key/value log parameters appended to the existing ones.
+// It's possible to get a logger with those contextual parameters by using [FromContext].
+func WithContextualAttributesForOutgoingContext(ctx context.Context, logParams []any) context.Context {
+	if len(logParams) == 0 || len(logParams)%2 != 0 {
+		return ctx
+	}
+
+	// join the key/value pairs with a colon, and separate the pairs with a comma
+	var res strings.Builder
+	for i := 0; i < len(logParams); i += 2 {
+		if i > 0 {
+			res.WriteString(",")
+		}
+		res.WriteString(logParams[i].(string))
+		res.WriteString(":")
+		res.WriteString(logParams[i+1].(string))
+	}
+
+	return metadata.AppendToOutgoingContext(ctx, loggerParamsCtxMetadataKey, res.String())
+}
+
+// ContextualAttributesFromIncomingContext returns the contextual key/value log parameters from the given context.
+// If no contextual log parameters are set, it returns nil.
+func ContextualAttributesFromIncomingContext(ctx context.Context) []any {
+	logParams := metadata.ValueFromIncomingContext(ctx, loggerParamsCtxMetadataKey)
+	if len(logParams) == 0 {
+		return nil
+	}
+
+	kvs := strings.Split(logParams[0], ",")
+
+	var res []any
+	for i := 0; i < len(kvs); i++ {
+		kv := strings.Split(kvs[i], ":")
+		res = append(res, kv[0], kv[1])
+	}
+	return res
+}

--- a/backend/log/context_grpc.go
+++ b/backend/log/context_grpc.go
@@ -42,7 +42,7 @@ func ContextualAttributesFromIncomingContext(ctx context.Context) []any {
 	var attrs []any
 	for _, param := range logParams {
 		kv := strings.Split(param, logParamSeparator)
-		if len(kv) != 2 {
+		if len(kv) != 2 || kv[0] == "" || kv[1] == "" {
 			continue
 		}
 		attrs = append(attrs, kv[0], kv[1])

--- a/backend/log/context_grpc.go
+++ b/backend/log/context_grpc.go
@@ -26,7 +26,7 @@ func WithContextualAttributesForOutgoingContext(ctx context.Context, logParams [
 			continue
 		}
 
-		ctx = metadata.AppendToOutgoingContext(ctx, logParamsCtxMetadataKey, fmt.Sprintf("%s%s%s", k, logParamSeparator, v))
+		ctx = metadata.AppendToOutgoingContext(ctx, logParamsCtxMetadataKey, logParam(k, v))
 	}
 
 	return ctx
@@ -48,4 +48,8 @@ func ContextualAttributesFromIncomingContext(ctx context.Context) []any {
 		attrs = append(attrs, kv[0], kv[1])
 	}
 	return attrs
+}
+
+func logParam(k, v string) string {
+	return fmt.Sprintf("%s%s%s", k, logParamSeparator, v)
 }

--- a/backend/log/context_grpc.go
+++ b/backend/log/context_grpc.go
@@ -8,10 +8,12 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-var loggerParamsCtxMetadataKey = "loggerParamsCtxMetadata"
+const (
+	loggerParamsCtxMetadataKey = "loggerParamsCtxMetadata"
+	logParamSeparator          = ":"
+)
 
-// WithContextualAttributesForOutgoingContext returns a new context with the given key/value log parameters appended to the existing ones.
-// It's possible to get a logger with those contextual parameters by using [FromContext].
+// WithContextualAttributesForOutgoingContext will append the given key/value log parameters to the outgoing context.
 func WithContextualAttributesForOutgoingContext(ctx context.Context, logParams []any) context.Context {
 	if len(logParams) == 0 || len(logParams)%2 != 0 {
 		return ctx
@@ -20,24 +22,23 @@ func WithContextualAttributesForOutgoingContext(ctx context.Context, logParams [
 	for i := 0; i < len(logParams); i += 2 {
 		k := logParams[i].(string)
 		v := logParams[i+1].(string)
-		ctx = metadata.AppendToOutgoingContext(ctx, loggerParamsCtxMetadataKey, fmt.Sprintf("%s:%s", k, v))
+		ctx = metadata.AppendToOutgoingContext(ctx, loggerParamsCtxMetadataKey, fmt.Sprintf("%s%s%s", k, logParamSeparator, v))
 	}
 
 	return ctx
 }
 
-// ContextualAttributesFromIncomingContext returns the contextual key/value log parameters from the given context.
-// If no contextual log parameters are set, it returns nil.
+// ContextualAttributesFromIncomingContext returns the contextual key/value log parameters from the given incoming context.
 func ContextualAttributesFromIncomingContext(ctx context.Context) []any {
 	logParams := metadata.ValueFromIncomingContext(ctx, loggerParamsCtxMetadataKey)
 	if len(logParams) == 0 {
 		return nil
 	}
 
-	var res []any
+	var attrs []any
 	for _, param := range logParams {
-		kv := strings.Split(param, ":")
-		res = append(res, kv[0], kv[1])
+		kv := strings.Split(param, logParamSeparator)
+		attrs = append(attrs, kv[0], kv[1])
 	}
-	return res
+	return attrs
 }

--- a/backend/log/context_grpc.go
+++ b/backend/log/context_grpc.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	loggerParamsCtxMetadataKey = "loggerParamsCtxMetadata"
-	logParamSeparator          = ":"
+	logParamsCtxMetadataKey = "loggerParamsCtxMetadata"
+	logParamSeparator       = ":"
 )
 
 // WithContextualAttributesForOutgoingContext will append the given key/value log parameters to the outgoing context.
@@ -22,7 +22,7 @@ func WithContextualAttributesForOutgoingContext(ctx context.Context, logParams [
 	for i := 0; i < len(logParams); i += 2 {
 		k := logParams[i].(string)
 		v := logParams[i+1].(string)
-		ctx = metadata.AppendToOutgoingContext(ctx, loggerParamsCtxMetadataKey, fmt.Sprintf("%s%s%s", k, logParamSeparator, v))
+		ctx = metadata.AppendToOutgoingContext(ctx, logParamsCtxMetadataKey, fmt.Sprintf("%s%s%s", k, logParamSeparator, v))
 	}
 
 	return ctx
@@ -30,7 +30,7 @@ func WithContextualAttributesForOutgoingContext(ctx context.Context, logParams [
 
 // ContextualAttributesFromIncomingContext returns the contextual key/value log parameters from the given incoming context.
 func ContextualAttributesFromIncomingContext(ctx context.Context) []any {
-	logParams := metadata.ValueFromIncomingContext(ctx, loggerParamsCtxMetadataKey)
+	logParams := metadata.ValueFromIncomingContext(ctx, logParamsCtxMetadataKey)
 	if len(logParams) == 0 {
 		return nil
 	}

--- a/backend/log/context_grpc.go
+++ b/backend/log/context_grpc.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	logParamsCtxMetadataKey = "loggerParamsCtxMetadata"
-	logParamSeparator       = ":"
+	logParamSeparator       = ":::"
 )
 
 // WithContextualAttributesForOutgoingContext will append the given key/value log parameters to the outgoing context.
@@ -20,8 +20,8 @@ func WithContextualAttributesForOutgoingContext(ctx context.Context, logParams [
 	}
 
 	for i := 0; i < len(logParams); i += 2 {
-		k := logParams[i].(string)
-		v := logParams[i+1].(string)
+		k := fmt.Sprintf("%v", logParams[i])
+		v := fmt.Sprintf("%v", logParams[i+1])
 		if k == "" || v == "" {
 			continue
 		}

--- a/backend/log/context_grpc_test.go
+++ b/backend/log/context_grpc_test.go
@@ -1,0 +1,107 @@
+package log
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestWithContextualAttributesForOutgoingContext(t *testing.T) {
+	tcs := []struct {
+		name      string
+		logParams []any
+		expected  []string
+	}{
+		{
+			name:      "empty log params",
+			logParams: []any{},
+			expected:  []string{},
+		},
+		{
+			name:      "log params with odd number of elements",
+			logParams: []any{"key1", "value1", "key2"},
+			expected:  []string{},
+		},
+		{
+			name:      "log params with empty key",
+			logParams: []any{"", "value1"},
+			expected:  []string{},
+		},
+		{
+			name:      "log params with empty value",
+			logParams: []any{"key1", ""},
+			expected:  []string{},
+		},
+		{
+			name:      "log params with valid key and value",
+			logParams: []any{"key1", "value1"},
+			expected:  []string{"key1:value1"},
+		},
+		{
+			name:      "log params with multiple key value pairs",
+			logParams: []any{"key1", "value1", "key2", "value2"},
+			expected:  []string{"key1:value1", "key2:value2"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := WithContextualAttributesForOutgoingContext(context.Background(), tc.logParams)
+			md, ok := metadata.FromOutgoingContext(ctx)
+			if len(tc.expected) == 0 {
+				require.False(t, ok)
+				return
+			}
+
+			require.True(t, ok)
+			got := md.Get(logParamsCtxMetadataKey)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("expected %v, got %v", tc.expected, got)
+			}
+			for i := range got {
+				if got[i] != tc.expected[i] {
+					t.Fatalf("expected %v, got %v", tc.expected, got)
+				}
+			}
+		})
+	}
+}
+
+func TestContextualAttributesFromIncomingContext(t *testing.T) {
+	tcs := []struct {
+		name     string
+		md       metadata.MD
+		expected []any
+	}{
+		{
+			name:     "empty metadata",
+			md:       metadata.MD{},
+			expected: nil,
+		},
+		{
+			name:     "metadata without log params",
+			md:       metadata.MD{"key1": []string{"value1"}},
+			expected: nil,
+		},
+		{
+			name:     "metadata with valid log params",
+			md:       metadata.MD{logParamsCtxMetadataKey: []string{"key1:value1", "key2:value2"}},
+			expected: []any{"key1", "value1", "key2", "value2"},
+		},
+		{
+			name:     "metadata with invalid log params",
+			md:       metadata.MD{logParamsCtxMetadataKey: []string{"key1", "key2:value2"}},
+			expected: []any{"key2", "value2"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := metadata.NewIncomingContext(context.Background(), tc.md)
+			got := ContextualAttributesFromIncomingContext(ctx)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/backend/log/context_grpc_test.go
+++ b/backend/log/context_grpc_test.go
@@ -91,8 +91,18 @@ func TestContextualAttributesFromIncomingContext(t *testing.T) {
 			expected: []any{"key1", "value1", "key2", "value2"},
 		},
 		{
-			name:     "metadata with invalid log params",
-			md:       metadata.MD{logParamsCtxMetadataKey: []string{"key1", "key2:value2"}},
+			name:     "metadata with missing key",
+			md:       metadata.MD{logParamsCtxMetadataKey: []string{":value1", "key2:value2"}},
+			expected: []any{"key2", "value2"},
+		},
+		{
+			name:     "metadata with missing value",
+			md:       metadata.MD{logParamsCtxMetadataKey: []string{"key1:", "key2:value2"}},
+			expected: []any{"key2", "value2"},
+		},
+		{
+			name:     "metadata with invalid key + value",
+			md:       metadata.MD{logParamsCtxMetadataKey: []string{":", "key2:value2"}},
 			expected: []any{"key2", "value2"},
 		},
 	}

--- a/backend/log/context_grpc_test.go
+++ b/backend/log/context_grpc_test.go
@@ -37,12 +37,12 @@ func TestWithContextualAttributesForOutgoingContext(t *testing.T) {
 		{
 			name:      "log params with valid key and value",
 			logParams: []any{"key1", "value1"},
-			expected:  []string{"key1:value1"},
+			expected:  []string{logParam("key1", "value1")},
 		},
 		{
 			name:      "log params with multiple key value pairs",
 			logParams: []any{"key1", "value1", "key2", "value2"},
-			expected:  []string{"key1:value1", "key2:value2"},
+			expected:  []string{logParam("key1", "value1"), logParam("key2", "value2")},
 		},
 	}
 
@@ -87,22 +87,22 @@ func TestContextualAttributesFromIncomingContext(t *testing.T) {
 		},
 		{
 			name:     "metadata with valid log params",
-			md:       metadata.MD{logParamsCtxMetadataKey: []string{"key1:value1", "key2:value2"}},
+			md:       metadata.MD{logParamsCtxMetadataKey: []string{logParam("key1", "value1"), logParam("key2", "value2")}},
 			expected: []any{"key1", "value1", "key2", "value2"},
 		},
 		{
 			name:     "metadata with missing key",
-			md:       metadata.MD{logParamsCtxMetadataKey: []string{":value1", "key2:value2"}},
+			md:       metadata.MD{logParamsCtxMetadataKey: []string{logParam("", "value1"), logParam("key2", "value2")}},
 			expected: []any{"key2", "value2"},
 		},
 		{
 			name:     "metadata with missing value",
-			md:       metadata.MD{logParamsCtxMetadataKey: []string{"key1:", "key2:value2"}},
+			md:       metadata.MD{logParamsCtxMetadataKey: []string{logParam("key1", ""), logParam("key2", "value2")}},
 			expected: []any{"key2", "value2"},
 		},
 		{
 			name:     "metadata with invalid key + value",
-			md:       metadata.MD{logParamsCtxMetadataKey: []string{":", "key2:value2"}},
+			md:       metadata.MD{logParamsCtxMetadataKey: []string{logParam("", ""), logParam("key2", "value2")}},
 			expected: []any{"key2", "value2"},
 		},
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:
Similar to existing functionality in `backend/log/context.go`, we need a way to pass + retrieve contextual log information via _outgoing / incoming_ context. This gives us the ability for the client side to dictate useful log parameters.

For example:
```json
{"@level":"debug","@message":"Plugin Request Completed","@timestamp":"2024-08-15T14:30:53.382034+01:00","dsName":"GitHub","dsUID":"a5219f2a-6a14-48bd-b986-7a7822573bcc","duration":"3.306700834s","endpoint":"queryData","foo":"bar","pluginID":"grafana-github-datasource","stackId":"321","stackSlug":"wbrowne","status":"ok","statusSource":"plugin","uname":"admin"}
```
**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-plugin-sdk-go/issues/1040

**Special notes for your reviewer**:
