### PR TITLE
PDC: add operation canceled error handler to socks proxy dialer

### DIFF
--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -312,12 +312,12 @@ func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr strin
 	c, err := dialer.DialContext(ctx, n, addr)
 
 	var code string
-	var oppErr *net.OpError
+	var opErr *net.OpError
 
 	switch {
 	case err == nil:
 		code = "0"
-	case errors.As(err, &oppErr):
+	case errors.As(err, &opErr):
 		unknownCode := socksUnknownError.FindStringSubmatch(err.Error())
 
 		// Socks errors defined here: https://cs.opensource.google/go/x/net/+/refs/tags/v0.15.0:internal/socks/socks.go;l=40-63
@@ -344,12 +344,14 @@ func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr strin
 			code = "io_timeout_error"
 		case strings.HasSuffix(err.Error(), "context canceled"):
 			code = "context_canceled_error"
+		case strings.HasSuffix(err.Error(), "operation was canceled"):
+			code = "context_canceled_error"
 		case len(unknownCode) > 1:
 			code = unknownCode[1]
 		default:
 			code = "socks_unknown_error"
 		}
-		log.DefaultLogger.Error("received oppErr from dialer", "network", n, "addr", addr, "oppErr", oppErr, "code", code)
+		log.DefaultLogger.Error("received opErr from dialer", "network", n, "addr", addr, "opErr", opErr, "code", code)
 	default:
 		log.DefaultLogger.Error("received err from dialer", "network", n, "addr", addr, "err", err)
 		code = "dial_error"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

We're getting socks_unknown_errors for errors ending in `operation was canceled`, even though we know these are closed due to sockets being closed or context canceled. Handle this as a context_canceled error.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/hosted-grafana/issues/5759

**Special notes for your reviewer**:
