### PR TITLE
Dataplane: Enable dataplane for results of LongToWide

### DIFF
--- a/data/time_series.go
+++ b/data/time_series.go
@@ -263,6 +263,11 @@ func LongToWide(longFrame *Frame, fillMissing *FillMissing) (*Frame, error) {
 		wideFrame.Meta = &FrameMeta{}
 	}
 	wideFrame.Meta.Type = FrameTypeTimeSeriesWide
+
+	// Setting the TypeVersion to greater than [0, 0] (along with Meta.Type being set) indicates that the produced
+	// frame follows the dataplane contract (see https://grafana.com/developers/dataplane/ and https://github.com/grafana/dataplane).
+	// https://grafana.com/developers/dataplane/timeseries#time-series-wide-format-timeserieswide defines TimeSeriesWide in dataplane.
+	wideFrame.Meta.TypeVersion = FrameTypeVersion{0, 1}
 	return wideFrame, nil
 }
 

--- a/data/time_series_test.go
+++ b/data/time_series_test.go
@@ -78,6 +78,8 @@ func TestTimeSeriesSchema(t *testing.T) {
 	}
 }
 
+var FTV01 = data.FrameTypeVersion{0, 1}
+
 func TestLongToWide(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -121,7 +123,8 @@ func TestLongToWide(t *testing.T) {
 					2.0,
 					4.0,
 				})).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -168,7 +171,8 @@ func TestLongToWide(t *testing.T) {
 						2.0,
 						4.0,
 					})).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -221,7 +225,8 @@ func TestLongToWide(t *testing.T) {
 					2,
 					4,
 				})).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -280,7 +285,8 @@ func TestLongToWide(t *testing.T) {
 					2,
 					4,
 				})).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -319,7 +325,8 @@ func TestLongToWide(t *testing.T) {
 					float64Ptr(2.0),
 					float64Ptr(4.0),
 				})).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -385,7 +392,8 @@ func TestLongToWide(t *testing.T) {
 					0.0,
 					6.0,
 				})).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 
 			Err: require.NoError,
@@ -452,7 +460,8 @@ func TestLongToWide(t *testing.T) {
 					nil,
 					float64Ptr(6.0),
 				})).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -548,7 +557,8 @@ func TestLongToWide(t *testing.T) {
 					6,
 				}),
 			).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -644,7 +654,8 @@ func TestLongToWide(t *testing.T) {
 					int64Ptr(6),
 				}),
 			).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -740,7 +751,8 @@ func TestLongToWide(t *testing.T) {
 					int64Ptr(6),
 				}),
 			).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -836,7 +848,8 @@ func TestLongToWide(t *testing.T) {
 					int64Ptr(6),
 				}),
 			).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -931,7 +944,8 @@ func TestLongToWide(t *testing.T) {
 					int64Ptr(6),
 				}),
 			).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -1026,7 +1040,8 @@ func TestLongToWide(t *testing.T) {
 					int64Ptr(6.0),
 				}),
 			).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},
@@ -1086,7 +1101,8 @@ func TestLongToWideBool(t *testing.T) {
 					1.0,
 					3.0,
 				})).SetMeta(&data.FrameMeta{
-				Type: data.FrameTypeTimeSeriesWide,
+				Type:        data.FrameTypeTimeSeriesWide,
+				TypeVersion: FTV01,
 			}),
 			Err: require.NoError,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting the TypeVersion to greater than [0, 0] (along with Meta.Type being set) indicates that the produced
frame follows the dataplane contract (see https://grafana.com/developers/dataplane/ and https://github.com/grafana/dataplane).

```
	wideFrame.Meta.TypeVersion = FrameTypeVersion{0, 1}
```

*Okay, so what will that do?*
From a user perspective, there are no expected changes.

Certain datasources call LongWide (In particular, SQL datasources) when the query type in the UI is set to "time series". This sets the output of that call to be "dataplane compliant".

Two consumers will follow a different code path in this case (Server Side Expressions and Recorded Queries). From a user perspective things should change unless there is a bug in those code paths.

In SSE, the fork in the code Path is at:

https://github.com/grafana/grafana/blob/2136fd9a929334f39a371c2127c57b6d83abdf28/pkg/expr/converter.go#L32-L38 

**Special notes for your reviewer**:
Since it is possible there could be an issue with a bug in the code that reads data plane data or something overlooked, I'm thinking through some role out possiblities (they have trade offs):
 - Just yolo it into the SDK
 - Change the signature of the function add argument (maybe `Options{}` so only done once, but breaking change, so this can be opted into)
 - Inverted approach - follow up with opt-out instructions (which would really just be overriding `FrameTypeVersion{0, 1}` back to `FrameTypeVersion{0, 0}` after calling `LongToWide`.