### PR TITLE
OpenAPI: Include DataSourceRef as root type

### DIFF
--- a/experimental/apis/data/v0alpha1/openapi.go
+++ b/experimental/apis/data/v0alpha1/openapi.go
@@ -16,6 +16,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/grafana/grafana-plugin-sdk-go/data.Frame":                                              schemaDataFrame(ref),
 		"github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1.DataQuery":               schemaDataQuery(ref),
 		"github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1.QueryTypeDefinitionSpec": schemaQueryTypeDefinitionSpec(ref),
+		"github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1.DataSourceRef":           schemaDataSourceRef(ref),
 	}
 }
 
@@ -42,6 +43,25 @@ func schemaDataFrame(_ common.ReferenceCallback) common.OpenAPIDefinition {
 				AdditionalProperties: &spec.SchemaOrBool{Allows: true},
 			},
 		},
+	}
+}
+
+func schemaDataSourceRef(_ common.ReferenceCallback) common.OpenAPIDefinition {
+	s, _ := DataQuerySchema()
+	if s == nil {
+		s = &spec.Schema{}
+	}
+	p, ok := s.Properties["datasource"]
+	if !ok {
+		p = spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type:                 []string{"object"},
+				AdditionalProperties: &spec.SchemaOrBool{Allows: true},
+			},
+		}
+	}
+	return common.OpenAPIDefinition{
+		Schema: p,
 	}
 }
 

--- a/experimental/apis/data/v0alpha1/openapi_test.go
+++ b/experimental/apis/data/v0alpha1/openapi_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 	"k8s.io/kube-openapi/pkg/validation/strfmt"
 	"k8s.io/kube-openapi/pkg/validation/validate"
@@ -37,4 +38,9 @@ func TestOpenAPI(t *testing.T) {
 	for _, err := range result.Warnings {
 		assert.NoError(t, err, "validation warning")
 	}
+
+	// Ensure DataSourceRef exists and has three properties
+	def, ok = defs["github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1.DataSourceRef"]
+	require.True(t, ok)
+	require.Equal(t, []string{"type", "uid", "apiVersion"}, maps.Keys(def.Schema.Properties))
 }

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	golang.org/x/text v0.17.0
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
-	k8s.io/kube-openapi v0.0.0-20240220201932-37d671a357a5 // @grafana/grafana-app-platform-squad
+	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // @grafana/grafana-app-platform-squad
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -321,8 +321,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-k8s.io/kube-openapi v0.0.0-20240220201932-37d671a357a5 h1:QSpdNrZ9uRlV0VkqLvVO0Rqg8ioKi3oSw7O5P7pJV8M=
-k8s.io/kube-openapi v0.0.0-20240220201932-37d671a357a5/go.mod h1:Pa1PvrP7ACSkuX6I7KYomY6cmMA0Tx86waBhDUgoKPw=
+k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 h1:BZqlfIlq5YbRMFko6/PM7FjZpUb45WallggurYhKGag=
+k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340/go.mod h1:yD4MZYeKMBwQKVht279WycxKyM84kkAx2DPrTXaeb98=
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=


### PR DESCRIPTION
**What this PR does / why we need it**:

Includes DataSourceRef as a k8s compatible schema

**Which issue(s) this PR fixes**:

This helps with https://github.com/grafana/grafana/pull/92213/files#diff-b8a4e27c9b02ee518b1ffacc3cd19bb0361618cf0b80b19c1a48b921397e7dd9

