### PR TITLE
Set HTTP timeouts as downstream errors

### DIFF
--- a/backend/error_source.go
+++ b/backend/error_source.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 )
 
@@ -63,9 +62,7 @@ func IsDownstreamError(err error) bool {
 		return true
 	}
 
-	// if error is HTTP network timeout error, we should treat it as downstream error
-	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
+	if isHTTPTimeoutError(err) {
 		return true
 	}
 

--- a/backend/error_source.go
+++ b/backend/error_source.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 )
 
 // ErrorSource type defines the source of the error
@@ -65,11 +64,8 @@ func IsDownstreamError(err error) bool {
 	}
 
 	// if error is HTTP network timeout error, we should treat it as downstream error
-	if err, ok := err.(net.Error); ok && err.Timeout() {
-		return true
-	}
-
-	if os.IsTimeout(err) {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
 		return true
 	}
 

--- a/backend/error_source.go
+++ b/backend/error_source.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"os"
 )
 
 // ErrorSource type defines the source of the error
@@ -59,6 +61,15 @@ func IsDownstreamError(err error) bool {
 
 	// nolint:errorlint
 	if errWithSource, ok := err.(errorWithSource); ok && errWithSource.ErrorSource() == ErrorSourceDownstream {
+		return true
+	}
+
+	// if error is HTTP network timeout error, we should treat it as downstream error
+	if err, ok := err.(net.Error); ok && err.Timeout() {
+		return true
+	}
+
+	if os.IsTimeout(err) {
 		return true
 	}
 

--- a/backend/error_source_test.go
+++ b/backend/error_source_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -31,6 +32,11 @@ func TestIsDownstreamError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "wrapped timeout network error",
+			err:      fmt.Errorf("oh no. err %w", newFakeNetworkError(true, false)),
+			expected: true,
+		},
+		{
 			name:     "temporary timeout network error",
 			err:      newFakeNetworkError(true, true),
 			expected: true,
@@ -43,6 +49,11 @@ func TestIsDownstreamError(t *testing.T) {
 		{
 			name:     "os.ErrDeadlineExceeded",
 			err:      os.ErrDeadlineExceeded,
+			expected: true,
+		},
+		{
+			name:     "wrapped os.ErrDeadlineExceeded",
+			err:      errors.Join(os.ErrDeadlineExceeded),
 			expected: true,
 		},
 		{

--- a/backend/error_source_test.go
+++ b/backend/error_source_test.go
@@ -52,8 +52,13 @@ func TestIsDownstreamError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "os.ErrDeadlineExceeded",
+			err:      fmt.Errorf("error: %w", os.ErrDeadlineExceeded),
+			expected: true,
+		},
+		{
 			name:     "wrapped os.ErrDeadlineExceeded",
-			err:      errors.Join(os.ErrDeadlineExceeded),
+			err:      errors.Join(fmt.Errorf("oh no"), os.ErrDeadlineExceeded),
 			expected: true,
 		},
 		{

--- a/backend/error_source_test.go
+++ b/backend/error_source_test.go
@@ -1,0 +1,85 @@
+package backend
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsDownstreamError(t *testing.T) {
+	tcs := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "downstream error",
+			err:      DownstreamError(nil),
+			expected: true,
+		},
+		{
+			name:     "timeout network error",
+			err:      newFakeNetworkError(true, false),
+			expected: true,
+		},
+		{
+			name:     "temporary timeout network error",
+			err:      newFakeNetworkError(true, true),
+			expected: true,
+		},
+		{
+			name:     "non-timeout network error",
+			err:      newFakeNetworkError(false, false),
+			expected: false,
+		},
+		{
+			name:     "os.ErrDeadlineExceeded",
+			err:      os.ErrDeadlineExceeded,
+			expected: true,
+		},
+		{
+			name:     "other error",
+			err:      fmt.Errorf("other error"),
+			expected: false,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equalf(t, tc.expected, IsDownstreamError(tc.err), "IsDownstreamError(%v)", tc.err)
+		})
+	}
+}
+
+var _ net.Error = &fakeNetworkError{}
+
+type fakeNetworkError struct {
+	timeout   bool
+	temporary bool
+}
+
+func newFakeNetworkError(timeout, temporary bool) *fakeNetworkError {
+	return &fakeNetworkError{
+		timeout:   timeout,
+		temporary: temporary,
+	}
+}
+
+func (d *fakeNetworkError) Error() string {
+	return "dummy timeout error"
+}
+
+func (d *fakeNetworkError) Timeout() bool {
+	return d.timeout
+}
+
+func (d *fakeNetworkError) Temporary() bool {
+	return d.temporary
+}

--- a/backend/request_status.go
+++ b/backend/request_status.go
@@ -114,5 +114,5 @@ func isHTTPTimeoutError(err error) bool {
 		return true
 	}
 
-	return errors.Is(err, os.ErrDeadlineExceeded) // relacement for os.IsTimeout(err)
+	return errors.Is(err, os.ErrDeadlineExceeded) // replacement for os.IsTimeout(err)
 }

--- a/backend/request_status.go
+++ b/backend/request_status.go
@@ -3,6 +3,8 @@ package backend
 import (
 	"context"
 	"errors"
+	"net"
+	"os"
 	"strings"
 
 	grpccodes "google.golang.org/grpc/codes"
@@ -104,4 +106,13 @@ func RequestStatusFromProtoQueryDataResponse(res *pluginv2.QueryDataResponse, er
 
 func isCancelledError(err error) bool {
 	return errors.Is(err, context.Canceled) || grpcstatus.Code(err) == grpccodes.Canceled
+}
+
+func isHTTPTimeoutError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	return errors.Is(err, os.ErrDeadlineExceeded) // relacement for os.IsTimeout(err)
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-plugin-sdk-go/issues/1064

