### PR TITLE
httpclient: add count_bytes_reader

### DIFF
--- a/backend/httpclient/count_bytes_reader.go
+++ b/backend/httpclient/count_bytes_reader.go
@@ -1,0 +1,39 @@
+package httpclient
+
+import (
+	"io"
+)
+
+type CloseCallbackFunc func(bytesRead int64)
+
+// CountBytesReader counts the total amount of bytes read from the underlying reader.
+//
+// The provided callback func will be called before the underlying reader is closed.
+func CountBytesReader(reader io.ReadCloser, callback CloseCallbackFunc) io.ReadCloser {
+	if reader == nil {
+		panic("reader cannot be nil")
+	}
+
+	if callback == nil {
+		panic("callback cannot be nil")
+	}
+
+	return &countBytesReader{reader: reader, callback: callback}
+}
+
+type countBytesReader struct {
+	reader   io.ReadCloser
+	callback CloseCallbackFunc
+	counter  int64
+}
+
+func (r *countBytesReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.counter += int64(n)
+	return n, err
+}
+
+func (r *countBytesReader) Close() error {
+	r.callback(r.counter)
+	return r.reader.Close()
+}

--- a/backend/httpclient/count_bytes_reader_test.go
+++ b/backend/httpclient/count_bytes_reader_test.go
@@ -1,0 +1,38 @@
+package httpclient
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountBytesReader(t *testing.T) {
+	tcs := []struct {
+		body               string
+		expectedBytesCount int64
+	}{
+		{body: "d", expectedBytesCount: 1},
+		{body: "dummy", expectedBytesCount: 5},
+	}
+
+	for index, tc := range tcs {
+		t.Run(fmt.Sprintf("Test CountBytesReader %d", index), func(t *testing.T) {
+			body := io.NopCloser(strings.NewReader(tc.body))
+			var actualBytesRead int64
+
+			readCloser := CountBytesReader(body, func(bytesRead int64) {
+				actualBytesRead = bytesRead
+			})
+
+			bodyBytes, err := io.ReadAll(readCloser)
+			require.NoError(t, err)
+			err = readCloser.Close()
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedBytesCount, actualBytesRead)
+			require.Equal(t, string(bodyBytes), tc.body)
+		})
+	}
+}


### PR DESCRIPTION
this reader is moved here from `grafana/grafana` : https://github.com/grafana/grafana/blob/af976c9a0b7efe64f72d92cba6b85c33e1184da4/pkg/infra/httpclient/count_bytes_reader.go#L12

(license change approved)

(see related `grafana/grafana` PR at https://github.com/grafana/grafana/pull/92553 )

the reason is that we're planning to add logging of response-sizes to the `plugin-sdk-go`, and for that we need to use this reader. (see https://github.com/grafana/grafana-plugin-sdk-go/pull/1054#pullrequestreview-2256942909 for more info)