### PR TITLE
 Autoinstrumentation improvements

### DIFF
--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -33,7 +33,7 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 		if innerErr != nil {
 			return status, innerErr
 		} else if resp == nil {
-			return RequestStatusError, fmt.Errorf("both response and error are nil, but one must be provided")
+			return RequestStatusError, errors.New("both response and error are nil, but one must be provided")
 		}
 		ctxLogger := Logger.FromContext(ctx)
 

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -33,7 +33,7 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 		if innerErr != nil {
 			return status, innerErr
 		} else if resp == nil {
-			return RequestStatusError, fmt.Errorf("response cannot be nil")
+			return RequestStatusError, fmt.Errorf("both response and error are nil, but one must be provided")
 		}
 		ctxLogger := Logger.FromContext(ctx)
 

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -30,6 +30,11 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 		resp, innerErr = a.queryDataHandler.QueryData(ctx, parsedReq)
 
 		status := RequestStatusFromQueryDataResponse(resp, innerErr)
+		if innerErr != nil {
+			return status, innerErr
+		} else if resp == nil {
+			return RequestStatusError, fmt.Errorf("response cannot be nil")
+		}
 		ctxLogger := Logger.FromContext(ctx)
 
 		// Set downstream status source in the context if there's at least one response with downstream status source,

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -29,34 +29,24 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 		var innerErr error
 		resp, innerErr = a.queryDataHandler.QueryData(ctx, parsedReq)
 
-		if resp == nil || len(resp.Responses) == 0 {
-			return RequestStatusFromError(innerErr), innerErr
-		}
-
-		if isCancelledError(innerErr) {
-			return RequestStatusCancelled, nil
-		}
-
-		if isHTTPTimeoutError(innerErr) {
-			return RequestStatusError, nil
-		}
+		status := RequestStatusFromQueryDataResponse(resp, innerErr)
+		ctxLogger := Logger.FromContext(ctx)
 
 		// Set downstream status source in the context if there's at least one response with downstream status source,
 		// and if there's no plugin error
-		var hasPluginError bool
-		var hasDownstreamError bool
-		var hasCancelledError bool
-		var hasHTTPTimeoutError bool
-		for _, r := range resp.Responses {
+		var hasPluginError, hasDownstreamError bool
+		for refID, r := range resp.Responses {
 			if r.Error == nil {
 				continue
 			}
 
-			if isCancelledError(r.Error) {
-				hasCancelledError = true
+			// if error source not set and the error is a downstream error, set error source to downstream.
+			if !r.ErrorSource.IsValid() && IsDownstreamError(r.Error) {
+				r.ErrorSource = ErrorSourceDownstream
 			}
-			if isHTTPTimeoutError(r.Error) {
-				hasHTTPTimeoutError = true
+
+			if !r.Status.IsValid() {
+				r.Status = statusFromError(r.Error)
 			}
 
 			if r.ErrorSource == ErrorSourceDownstream {
@@ -64,43 +54,29 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 			} else {
 				hasPluginError = true
 			}
-		}
 
-		if hasCancelledError {
-			if err := WithDownstreamErrorSource(ctx); err != nil {
-				return RequestStatusError, fmt.Errorf("failed to set downstream status source: %w", errors.Join(innerErr, err))
+			logParams := []any{
+				"refID", refID,
+				"status", int(r.Status),
+				"error", r.Error,
+				"statusSource", string(r.ErrorSource),
 			}
-			return RequestStatusCancelled, nil
-		}
-
-		if hasHTTPTimeoutError {
-			if err := WithDownstreamErrorSource(ctx); err != nil {
-				return RequestStatusError, fmt.Errorf("failed to set downstream status source: %w", errors.Join(innerErr, err))
-			}
-			return RequestStatusError, nil
+			ctxLogger.Error("Partial data response error", logParams...)
 		}
 
 		// A plugin error has higher priority than a downstream error,
 		// so set to downstream only if there's no plugin error
-		if hasDownstreamError && !hasPluginError {
-			if err := WithDownstreamErrorSource(ctx); err != nil {
-				return RequestStatusError, fmt.Errorf("failed to set downstream status source: %w", errors.Join(innerErr, err))
-			}
-			return RequestStatusError, nil
-		}
-
 		if hasPluginError {
 			if err := WithErrorSource(ctx, ErrorSourcePlugin); err != nil {
 				return RequestStatusError, fmt.Errorf("failed to set plugin status source: %w", errors.Join(innerErr, err))
 			}
-			return RequestStatusError, nil
+		} else if hasDownstreamError {
+			if err := WithDownstreamErrorSource(ctx); err != nil {
+				return RequestStatusError, fmt.Errorf("failed to set downstream status source: %w", errors.Join(innerErr, err))
+			}
 		}
 
-		if innerErr != nil {
-			return RequestStatusFromError(innerErr), innerErr
-		}
-
-		return RequestStatusOK, nil
+		return status, nil
 	})
 	if err != nil {
 		return nil, err

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -180,6 +180,26 @@ func TestQueryData(t *testing.T) {
 				},
 				expErrorSource: ErrorSourcePlugin,
 			},
+			{
+				name: `single downstream error without error source should be "downstream" error source`,
+				queryDataResponse: &QueryDataResponse{
+					Responses: map[string]DataResponse{
+						"A": {Error: DownstreamErrorf("boom")},
+					},
+				},
+				expErrorSource: ErrorSourceDownstream,
+			},
+			{
+				name: `multiple downstream error without error source and single plugin error should be "plugin" error source`,
+				queryDataResponse: &QueryDataResponse{
+					Responses: map[string]DataResponse{
+						"A": {Error: DownstreamErrorf("boom")},
+						"B": {Error: someErr},
+						"C": {Error: DownstreamErrorf("boom")},
+					},
+				},
+				expErrorSource: ErrorSourcePlugin,
+			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				var actualCtx context.Context

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -140,6 +140,7 @@ func TestQueryData(t *testing.T) {
 			name              string
 			queryDataResponse *QueryDataResponse
 			expErrorSource    ErrorSource
+			expError          bool
 		}{
 			{
 				name: `single downstream error should be "downstream" error source`,
@@ -200,6 +201,12 @@ func TestQueryData(t *testing.T) {
 				},
 				expErrorSource: ErrorSourcePlugin,
 			},
+			{
+				name:              "nil queryDataResponse and nil error should throw error",
+				queryDataResponse: nil,
+				expErrorSource:    ErrorSourcePlugin,
+				expError:          true,
+			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				var actualCtx context.Context
@@ -210,7 +217,13 @@ func TestQueryData(t *testing.T) {
 				_, err := a.QueryData(context.Background(), &pluginv2.QueryDataRequest{
 					PluginContext: &pluginv2.PluginContext{},
 				})
-				require.NoError(t, err)
+
+				if tc.expError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+
 				ss := errorSourceFromContext(actualCtx)
 				require.Equal(t, tc.expErrorSource, ss)
 			})

--- a/backend/error_source.go
+++ b/backend/error_source.go
@@ -21,6 +21,10 @@ const (
 	DefaultErrorSource ErrorSource = ErrorSourcePlugin
 )
 
+func (es ErrorSource) IsValid() bool {
+	return es == ErrorSourceDownstream || es == ErrorSourcePlugin
+}
+
 // ErrorSourceFromStatus returns an [ErrorSource] based on provided HTTP status code.
 func ErrorSourceFromHTTPStatus(statusCode int) ErrorSource {
 	switch statusCode {
@@ -62,7 +66,7 @@ func IsDownstreamError(err error) bool {
 		return true
 	}
 
-	if isHTTPTimeoutError(err) {
+	if isHTTPTimeoutError(err) || isCancelledError(err) {
 		return true
 	}
 

--- a/experimental/apis/data/v0alpha1/openapi_test.go
+++ b/experimental/apis/data/v0alpha1/openapi_test.go
@@ -42,5 +42,5 @@ func TestOpenAPI(t *testing.T) {
 	// Ensure DataSourceRef exists and has three properties
 	def, ok = defs["github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1.DataSourceRef"]
 	require.True(t, ok)
-	require.Equal(t, []string{"type", "uid", "apiVersion"}, maps.Keys(def.Schema.Properties))
+	require.ElementsMatch(t, []string{"type", "uid", "apiVersion"}, maps.Keys(def.Schema.Properties))
 }


### PR DESCRIPTION
Follow up from #1063 and https://github.com/grafana/grafana-plugin-sdk-go/pull/1063#issuecomment-2315809736

Changes:
- Logs partial data response errors in a similar way as grafana does.
- Clean up code/logic for error source and request status in regards to query data.
- Fix a flaky test noted when running `mage testRace`