### PR TITLE
fix: return response with errorsource instead of nil

### DIFF
--- a/internal/automanagement/manager.go
+++ b/internal/automanagement/manager.go
@@ -2,6 +2,7 @@ package automanagement
 
 import (
 	"context"
+	"errors"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
@@ -32,9 +33,14 @@ func (m *Manager) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 			// shouldn't be possible, but just in case
 			return nil, err
 		}
+		var esErr errorsource.Error
+		ok := errors.As(err, &esErr)
+		if !ok { // not an errorsource error, return opaquely
+			return nil, err
+		}
 		resp := backend.NewQueryDataResponse()
 		errorsource.AddErrorToResponse(req.Queries[0].RefID, resp, err)
-		return resp, err
+		return resp, nil
 	}
 	if ds, ok := h.(backend.QueryDataHandler); ok {
 		return ds.QueryData(ctx, req)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
Currently errors from `NewInstance` are returned from `Manager.QueryData` with a nil `QueryDataResponse`, which obscures the errorsource. This changes that method to return a `QueryDataResponse` with the error with errorsource set, which improves both user experience and alerting.

**Which issue(s) this PR fixes**:
Fixes #1068 

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
