### PR TITLE
Add QueryConversionHandler

### DIFF
--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/featuretoggles"
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 	"github.com/grafana/grafana-plugin-sdk-go/internal/tenant"
 )
@@ -246,8 +247,13 @@ func TestQueryData(t *testing.T) {
 			return &QueryConversionResponse{Queries: req.Queries}, nil
 		}))
 		_, err := a.QueryData(context.Background(), &pluginv2.QueryDataRequest{
-			PluginContext: &pluginv2.PluginContext{},
-			Queries:       []*pluginv2.DataQuery{oldQuery},
+			PluginContext: &pluginv2.PluginContext{
+				// Enable feature flag
+				GrafanaConfig: map[string]string{
+					featuretoggles.EnabledFeatures: "dsQueryConvert",
+				},
+			},
+			Queries: []*pluginv2.DataQuery{oldQuery},
 		})
 		require.NoError(t, err)
 	})

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -69,7 +69,7 @@ func TestQueryData(t *testing.T) {
 	t.Run("When forward HTTP headers enabled should forward headers", func(t *testing.T) {
 		ctx := context.Background()
 		handler := newFakeDataHandlerWithOAuth()
-		adapter := newDataSDKAdapter(handler)
+		adapter := newDataSDKAdapter(handler, nil)
 		_, err := adapter.QueryData(ctx, &pluginv2.QueryDataRequest{
 			Headers: map[string]string{
 				"Authorization": "Bearer 123",
@@ -95,7 +95,7 @@ func TestQueryData(t *testing.T) {
 	t.Run("When forward HTTP headers disable should not forward headers", func(t *testing.T) {
 		ctx := context.Background()
 		handler := newFakeDataHandlerWithOAuth()
-		adapter := newDataSDKAdapter(handler)
+		adapter := newDataSDKAdapter(handler, nil)
 		_, err := adapter.QueryData(ctx, &pluginv2.QueryDataRequest{
 			Headers: map[string]string{
 				"Authorization": "Bearer 123",
@@ -122,7 +122,7 @@ func TestQueryData(t *testing.T) {
 		a := newDataSDKAdapter(QueryDataHandlerFunc(func(ctx context.Context, _ *QueryDataRequest) (*QueryDataResponse, error) {
 			require.Equal(t, tid, tenant.IDFromContext(ctx))
 			return NewQueryDataResponse(), nil
-		}))
+		}), nil)
 
 		ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
 			tenant.CtxKey: tid,
@@ -213,7 +213,7 @@ func TestQueryData(t *testing.T) {
 				a := newDataSDKAdapter(QueryDataHandlerFunc(func(ctx context.Context, _ *QueryDataRequest) (*QueryDataResponse, error) {
 					actualCtx = ctx
 					return tc.queryDataResponse, nil
-				}))
+				}), nil)
 				_, err := a.QueryData(context.Background(), &pluginv2.QueryDataRequest{
 					PluginContext: &pluginv2.PluginContext{},
 				})
@@ -228,6 +228,28 @@ func TestQueryData(t *testing.T) {
 				require.Equal(t, tc.expErrorSource, ss)
 			})
 		}
+	})
+
+	t.Run("When conversionHandler is defined", func(t *testing.T) {
+		oldQuery := &pluginv2.DataQuery{
+			TimeRange: &pluginv2.TimeRange{},
+			Json:      []byte(`{"old":"value"}`),
+		}
+		a := newDataSDKAdapter(QueryDataHandlerFunc(func(_ context.Context, q *QueryDataRequest) (*QueryDataResponse, error) {
+			require.Len(t, q.Queries, 1)
+			// Assert that the query has been converted
+			require.Equal(t, string(`{"new":"value"}`), string(q.Queries[0].JSON))
+			return &QueryDataResponse{}, nil
+		}), ConvertQueryFunc(func(_ context.Context, req *QueryConversionRequest) (*QueryConversionResponse, error) {
+			require.Len(t, req.Queries, 1)
+			req.Queries[0].JSON = []byte(`{"new":"value"}`)
+			return &QueryConversionResponse{Queries: req.Queries}, nil
+		}))
+		_, err := a.QueryData(context.Background(), &pluginv2.QueryDataRequest{
+			PluginContext: &pluginv2.PluginContext{},
+			Queries:       []*pluginv2.DataQuery{oldQuery},
+		})
+		require.NoError(t, err)
 	})
 }
 

--- a/backend/datasource/manage.go
+++ b/backend/datasource/manage.go
@@ -24,9 +24,6 @@ type ManageOpts struct {
 
 	// Stateless conversion handler
 	ConversionHandler backend.ConversionHandler
-
-	// Stateless query conversion handler
-	QueryConversionHandler backend.QueryConversionHandler
 }
 
 // Manage starts serving the data source over gPRC with automatic instance management.
@@ -52,9 +49,9 @@ func Manage(pluginID string, instanceFactory InstanceFactoryFunc, opts ManageOpt
 		CallResourceHandler:    handler,
 		QueryDataHandler:       handler,
 		StreamHandler:          handler,
+		QueryConversionHandler: handler,
 		AdmissionHandler:       opts.AdmissionHandler,
 		GRPCSettings:           opts.GRPCSettings,
 		ConversionHandler:      opts.ConversionHandler,
-		QueryConversionHandler: opts.QueryConversionHandler,
 	})
 }

--- a/backend/datasource/manage.go
+++ b/backend/datasource/manage.go
@@ -24,6 +24,9 @@ type ManageOpts struct {
 
 	// Stateless conversion handler
 	ConversionHandler backend.ConversionHandler
+
+	// Stateless query conversion handler
+	QueryConversionHandler backend.QueryConversionHandler
 }
 
 // Manage starts serving the data source over gPRC with automatic instance management.
@@ -45,11 +48,13 @@ func Manage(pluginID string, instanceFactory InstanceFactoryFunc, opts ManageOpt
 	}
 	handler := automanagement.NewManager(NewInstanceManager(instanceFactory))
 	return backend.Manage(pluginID, backend.ServeOpts{
-		CheckHealthHandler:  handler,
-		CallResourceHandler: handler,
-		QueryDataHandler:    handler,
-		StreamHandler:       handler,
-		AdmissionHandler:    opts.AdmissionHandler,
-		GRPCSettings:        opts.GRPCSettings,
+		CheckHealthHandler:     handler,
+		CallResourceHandler:    handler,
+		QueryDataHandler:       handler,
+		StreamHandler:          handler,
+		AdmissionHandler:       opts.AdmissionHandler,
+		GRPCSettings:           opts.GRPCSettings,
+		ConversionHandler:      opts.ConversionHandler,
+		QueryConversionHandler: opts.QueryConversionHandler,
 	})
 }

--- a/backend/log_test.go
+++ b/backend/log_test.go
@@ -40,7 +40,7 @@ func TestContextualLogger(t *testing.T) {
 			checkCtxLogger(ctx, t, map[string]any{"endpoint": "queryData", "pluginID": pluginID})
 			run <- struct{}{}
 			return NewQueryDataResponse(), nil
-		}))
+		}), nil)
 		_, err := a.QueryData(context.Background(), &pluginv2.QueryDataRequest{
 			PluginContext: pCtx,
 		})

--- a/backend/query_conversion.go
+++ b/backend/query_conversion.go
@@ -13,12 +13,12 @@ type QueryConversionHandler interface {
 
 type ConvertQueryFunc func(context.Context, *QueryConversionRequest) (*QueryConversionResponse, error)
 
-// ConvertObjects calls fn(ctx, req).
+// ConvertQuery calls fn(ctx, req).
 func (fn ConvertQueryFunc) ConvertQuery(ctx context.Context, req *QueryConversionRequest) (*QueryConversionResponse, error) {
 	return fn(ctx, req)
 }
 
-// ConversionRequest supports converting an object from on version to another
+// QueryConversionRequest supports converting a query from on version to another
 type QueryConversionRequest struct {
 	// NOTE: this may not include app or datasource instance settings depending on the request
 	PluginContext PluginContext `json:"pluginContext,omitempty"`

--- a/backend/query_conversion.go
+++ b/backend/query_conversion.go
@@ -1,0 +1,32 @@
+package backend
+
+import (
+	"context"
+)
+
+// QueryConversionHandler is an EXPERIMENTAL service that allows converting queries between versions
+
+type QueryConversionHandler interface {
+	// ConvertQuery is called to covert queries between different versions
+	ConvertQuery(context.Context, *QueryConversionRequest) (*QueryConversionResponse, error)
+}
+
+type ConvertQueryFunc func(context.Context, *QueryConversionRequest) (*QueryConversionResponse, error)
+
+// ConvertObjects calls fn(ctx, req).
+func (fn ConvertQueryFunc) ConvertQuery(ctx context.Context, req *QueryConversionRequest) (*QueryConversionResponse, error) {
+	return fn(ctx, req)
+}
+
+// ConversionRequest supports converting an object from on version to another
+type QueryConversionRequest struct {
+	// NOTE: this may not include app or datasource instance settings depending on the request
+	PluginContext PluginContext `json:"pluginContext,omitempty"`
+	// Queries to convert. This contains the full metadata envelope.
+	Queries []DataQuery `json:"objects,omitempty"`
+}
+
+type QueryConversionResponse struct {
+	// Converted queries.
+	Queries []DataQuery `json:"objects,omitempty"`
+}

--- a/backend/serve.go
+++ b/backend/serve.go
@@ -94,7 +94,7 @@ func GRPCServeOpts(opts ServeOpts) grpcplugin.ServeOpts {
 		pluginOpts.AdmissionServer = newAdmissionSDKAdapter(opts.AdmissionHandler)
 	}
 
-	if opts.ConversionHandler != nil || opts.QueryConversionHandler != nil {
+	if opts.ConversionHandler != nil {
 		pluginOpts.ConversionServer = newConversionSDKAdapter(opts.ConversionHandler)
 	}
 	return pluginOpts

--- a/backend/serve.go
+++ b/backend/serve.go
@@ -65,6 +65,10 @@ type ServeOpts struct {
 	// This is EXPERIMENTAL and is a subject to change till Grafana 12
 	ConversionHandler ConversionHandler
 
+	// QueryConversionHandler converts queries between versions
+	// This is EXPERIMENTAL and is a subject to change till Grafana 12
+	QueryConversionHandler QueryConversionHandler
+
 	// GRPCSettings settings for gPRC.
 	GRPCSettings GRPCSettings
 }
@@ -79,7 +83,7 @@ func GRPCServeOpts(opts ServeOpts) grpcplugin.ServeOpts {
 	}
 
 	if opts.QueryDataHandler != nil {
-		pluginOpts.DataServer = newDataSDKAdapter(opts.QueryDataHandler)
+		pluginOpts.DataServer = newDataSDKAdapter(opts.QueryDataHandler, opts.QueryConversionHandler)
 	}
 
 	if opts.StreamHandler != nil {
@@ -90,7 +94,7 @@ func GRPCServeOpts(opts ServeOpts) grpcplugin.ServeOpts {
 		pluginOpts.AdmissionServer = newAdmissionSDKAdapter(opts.AdmissionHandler)
 	}
 
-	if opts.ConversionHandler != nil {
+	if opts.ConversionHandler != nil || opts.QueryConversionHandler != nil {
 		pluginOpts.ConversionServer = newConversionSDKAdapter(opts.ConversionHandler)
 	}
 	return pluginOpts

--- a/internal/automanagement/manager.go
+++ b/internal/automanagement/manager.go
@@ -92,3 +92,14 @@ func (m *Manager) RunStream(ctx context.Context, req *backend.RunStreamRequest, 
 	}
 	return status.Error(codes.Unimplemented, "unimplemented")
 }
+
+func (m *Manager) ConvertQuery(ctx context.Context, req *backend.QueryConversionRequest) (*backend.QueryConversionResponse, error) {
+	h, err := m.Get(ctx, req.PluginContext)
+	if err != nil {
+		return nil, err
+	}
+	if ds, ok := h.(backend.QueryConversionHandler); ok {
+		return ds.ConvertQuery(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "unimplemented")
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Automatically executes a function `ConvertQuery` if a plugin implements it. This is executed before calling `QueryData` and is not yet exposed as a gRPC call (even though the goal is using `ConvertObjects` to call it).

See an example of how this may look like for a plugin [here](https://github.com/grafana/grafana-plugin-examples/pull/340/files#diff-e608edd147405086920bcb097aae449ffb1ca927fea2ab583e93e9bde6b6ee93)

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

First part of https://github.com/grafana/grafana/issues/92749

**Special notes for your reviewer**:
