### PR TITLE
Chore: Update max bytes reader middleware error message

### DIFF
--- a/backend/httpclient/max_bytes_reader.go
+++ b/backend/httpclient/max_bytes_reader.go
@@ -24,12 +24,13 @@ var ErrResponseBodyTooLarge = errors.New("http: response body too large")
 // MaxBytesReader prevents clients from accidentally or maliciously
 // sending a large request and wasting server resources.
 func MaxBytesReader(r io.ReadCloser, n int64) io.ReadCloser {
-	return &maxBytesReader{r: r, n: n}
+	return &maxBytesReader{r: r, n: n, a: n}
 }
 
 type maxBytesReader struct {
 	r   io.ReadCloser // underlying reader
 	n   int64         // max bytes remaining
+	a   int64         // the actual limit
 	err error         // sticky error
 }
 
@@ -57,7 +58,7 @@ func (l *maxBytesReader) Read(p []byte) (n int, err error) {
 	n = int(l.n)
 	l.n = 0
 
-	l.err = fmt.Errorf("error: %w, response limit is set to: %d", ErrResponseBodyTooLarge, n)
+	l.err = fmt.Errorf("error: %w, response limit is set to: %d", ErrResponseBodyTooLarge, l.a)
 	return n, l.err
 }
 

--- a/backend/httpclient/max_bytes_reader.go
+++ b/backend/httpclient/max_bytes_reader.go
@@ -24,13 +24,13 @@ var ErrResponseBodyTooLarge = errors.New("http: response body too large")
 // MaxBytesReader prevents clients from accidentally or maliciously
 // sending a large request and wasting server resources.
 func MaxBytesReader(r io.ReadCloser, n int64) io.ReadCloser {
-	return &maxBytesReader{r: r, remainingBytes: n, actualLimit: n}
+	return &maxBytesReader{r: r, remainingBytes: n, limit: n}
 }
 
 type maxBytesReader struct {
 	r              io.ReadCloser // underlying reader
 	remainingBytes int64         // max bytes remaining
-	actualLimit    int64         // the actual limit
+	limit          int64         // the actual limit
 	err            error         // sticky error
 }
 
@@ -58,7 +58,7 @@ func (l *maxBytesReader) Read(p []byte) (n int, err error) {
 	n = int(l.remainingBytes)
 	l.remainingBytes = 0
 
-	l.err = fmt.Errorf("error: %w, response limit is set to: %d", ErrResponseBodyTooLarge, l.actualLimit)
+	l.err = fmt.Errorf("error: %w, response limit is set to: %d", ErrResponseBodyTooLarge, l.limit)
 	return n, l.err
 }
 

--- a/backend/httpclient/max_bytes_reader.go
+++ b/backend/httpclient/max_bytes_reader.go
@@ -24,14 +24,14 @@ var ErrResponseBodyTooLarge = errors.New("http: response body too large")
 // MaxBytesReader prevents clients from accidentally or maliciously
 // sending a large request and wasting server resources.
 func MaxBytesReader(r io.ReadCloser, n int64) io.ReadCloser {
-	return &maxBytesReader{r: r, n: n, a: n}
+	return &maxBytesReader{r: r, remainingBytes: n, actualLimit: n}
 }
 
 type maxBytesReader struct {
-	r   io.ReadCloser // underlying reader
-	n   int64         // max bytes remaining
-	a   int64         // the actual limit
-	err error         // sticky error
+	r              io.ReadCloser // underlying reader
+	remainingBytes int64         // max bytes remaining
+	actualLimit    int64         // the actual limit
+	err            error         // sticky error
 }
 
 func (l *maxBytesReader) Read(p []byte) (n int, err error) {
@@ -44,21 +44,21 @@ func (l *maxBytesReader) Read(p []byte) (n int, err error) {
 	// If they asked for a 32KB byte read but only 5 bytes are
 	// remaining, no need to read 32KB. 6 bytes will answer the
 	// question of the whether we hit the limit or go past it.
-	if int64(len(p)) > l.n+1 {
-		p = p[:l.n+1]
+	if int64(len(p)) > l.remainingBytes+1 {
+		p = p[:l.remainingBytes+1]
 	}
 	n, err = l.r.Read(p)
 
-	if int64(n) <= l.n {
-		l.n -= int64(n)
+	if int64(n) <= l.remainingBytes {
+		l.remainingBytes -= int64(n)
 		l.err = err
 		return n, err
 	}
 
-	n = int(l.n)
-	l.n = 0
+	n = int(l.remainingBytes)
+	l.remainingBytes = 0
 
-	l.err = fmt.Errorf("error: %w, response limit is set to: %d", ErrResponseBodyTooLarge, l.a)
+	l.err = fmt.Errorf("error: %w, response limit is set to: %d", ErrResponseBodyTooLarge, l.actualLimit)
 	return n, l.err
 }
 

--- a/backend/httpclient/max_bytes_reader_test.go
+++ b/backend/httpclient/max_bytes_reader_test.go
@@ -12,14 +12,14 @@ import (
 
 func TestMaxBytesReader(t *testing.T) {
 	tcs := []struct {
-		limit      int64
-		bodyLength int
-		body       string
-		err        error
+		limit              int64
+		expectedBodyLength int
+		expectedBody       string
+		err                error
 	}{
-		{limit: 1, bodyLength: 1, body: "d", err: errors.New("error: http: response body too large, response limit is set to: 1")},
-		{limit: 1000000, bodyLength: 5, body: "dummy", err: nil},
-		{limit: 0, bodyLength: 0, body: "", err: errors.New("error: http: response body too large, response limit is set to: 0")},
+		{limit: 1, expectedBodyLength: 1, expectedBody: "d", err: errors.New("error: http: response body too large, response limit is set to: 1")},
+		{limit: 1000000, expectedBodyLength: 5, expectedBody: "dummy", err: nil},
+		{limit: 0, expectedBodyLength: 0, expectedBody: "", err: errors.New("error: http: response body too large, response limit is set to: 0")},
 	}
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("Test MaxBytesReader with limit: %d", tc.limit), func(t *testing.T) {
@@ -28,13 +28,13 @@ func TestMaxBytesReader(t *testing.T) {
 
 			bodyBytes, err := io.ReadAll(readCloser)
 			if err != nil {
-				require.EqualError(t, tc.err, err.Error())
+				require.EqualError(t, err, tc.err.Error())
 			} else {
 				require.NoError(t, tc.err)
 			}
 
-			require.Len(t, bodyBytes, tc.bodyLength)
-			require.Equal(t, string(bodyBytes), tc.body)
+			require.Len(t, bodyBytes, tc.expectedBodyLength)
+			require.Equal(t, tc.expectedBody, string(bodyBytes))
 		})
 	}
 }

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -14,14 +14,14 @@ import (
 
 func TestResponseLimitMiddleware(t *testing.T) {
 	tcs := []struct {
-		limit      int64
-		bodyLength int
-		body       string
-		err        error
+		limit              int64
+		expectedBodyLength int
+		expectedBody       string
+		err                error
 	}{
-		{limit: 1, bodyLength: 1, body: "d", err: errors.New("error: http: response body too large, response limit is set to: 1")},
-		{limit: 1000000, bodyLength: 5, body: "dummy", err: nil},
-		{limit: 0, bodyLength: 5, body: "dummy", err: nil},
+		{limit: 1, expectedBodyLength: 1, expectedBody: "d", err: errors.New("error: http: response body too large, response limit is set to: 1")},
+		{limit: 1000000, expectedBodyLength: 5, expectedBody: "dummy", err: nil},
+		{limit: 0, expectedBodyLength: 5, expectedBody: "dummy", err: nil},
 	}
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("Test ResponseLimitMiddleware with limit: %d", tc.limit), func(t *testing.T) {
@@ -51,8 +51,8 @@ func TestResponseLimitMiddleware(t *testing.T) {
 			}
 			require.NoError(t, res.Body.Close())
 
-			require.Len(t, bodyBytes, tc.bodyLength)
-			require.Equal(t, string(bodyBytes), tc.body)
+			require.Len(t, bodyBytes, tc.expectedBodyLength)
+			require.Equal(t, string(bodyBytes), tc.expectedBody)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We return the remaining bytes that need to be read when we hit the limit in the error message. That is confusing and misleading. Here I am making the change to return the actual response limit value when we hit the limit. 

Also, I did some small tweaks in test files to make it more understandable. 