### PR TITLE
JSON: Ensure all fields types work as expected when they are the first field in a frame

### DIFF
--- a/data/field_type.go
+++ b/data/field_type.go
@@ -81,7 +81,9 @@ const (
 
 	// FieldTypeJSON indicates the underlying primitive is a []json.RawMessage.
 	FieldTypeJSON
+
 	// FieldTypeNullableJSON indicates the underlying primitive is a []*json.RawMessage.
+	// Deprecated: Use FieldTypeJSON, an array can be null anyway
 	FieldTypeNullableJSON
 
 	// FieldTypeEnum indicates the underlying primitive is a []data.EnumItemIndex, with field mapping metadata

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -421,6 +421,7 @@ func int64FromJSON(v interface{}) (int64, error) {
 }
 
 // in this path, we do not yet know the length and must discover it from the array
+// nolint:gocyclo
 func jsonValuesToVector(iter *jsoniter.Iterator, ft FieldType) (vector, error) {
 	itere := sdkjsoniter.NewIterator(iter)
 	// we handle Uint64 differently because the regular method for unmarshalling to []any does not work for uint64 correctly
@@ -477,8 +478,8 @@ func jsonValuesToVector(iter *jsoniter.Iterator, ft FieldType) (vector, error) {
 
 		return vals, nil
 	}
-	// if it's not uint64 field, handle the array the old way
 
+	// if it's not uint64 field, handle the array the old way
 	convert := func(v interface{}) (interface{}, error) {
 		return v, nil
 	}

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -454,15 +454,14 @@ func jsonValuesToVector(iter *jsoniter.Iterator, ft FieldType) (vector, error) {
 	case FieldTypeJSON, FieldTypeNullableJSON:
 		vals := newJsonRawMessageVector(0)
 		for iter.ReadArray() {
+			var v json.RawMessage
 			t := iter.WhatIsNext()
 			if t == sdkjsoniter.NilValue {
 				iter.ReadNil()
-				vals.Append(nil)
 			} else {
-				var v json.RawMessage
 				iter.ReadVal(&v)
-				vals.Append(v)
 			}
+			vals.Append(v)
 		}
 
 		// Convert this to the pointer flavor

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -451,6 +451,14 @@ func jsonValuesToVector(iter *jsoniter.Iterator, ft FieldType) (vector, error) {
 		}
 		return newNullableUint64VectorWithValues(u), nil
 
+	case FieldTypeInt64:
+		vals := newInt64Vector(0)
+		for iter.ReadArray() {
+			v := iter.ReadInt64()
+			vals.Append(v)
+		}
+		return vals, nil
+
 	case FieldTypeJSON, FieldTypeNullableJSON:
 		vals := newJsonRawMessageVector(0)
 		for iter.ReadArray() {

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -437,6 +437,7 @@ func jsonValuesToVector(iter *jsoniter.Iterator, ft FieldType) (vector, error) {
 			return nil, err
 		}
 		return newUint64VectorWithValues(u), nil
+
 	case FieldTypeNullableUint64:
 		parseUint64 := func(s string) (*uint64, error) {
 			u, err := strconv.ParseUint(s, 0, 64)
@@ -456,6 +457,20 @@ func jsonValuesToVector(iter *jsoniter.Iterator, ft FieldType) (vector, error) {
 		for iter.ReadArray() {
 			v := iter.ReadInt64()
 			vals.Append(v)
+		}
+		return vals, nil
+
+	case FieldTypeNullableInt64:
+		vals := newNullableInt64Vector(0)
+		for iter.ReadArray() {
+			t := iter.WhatIsNext()
+			if t == sdkjsoniter.NilValue {
+				iter.ReadNil()
+				vals.Append(nil)
+			} else {
+				v := iter.ReadInt64()
+				vals.Append(v)
+			}
 		}
 		return vals, nil
 

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -469,7 +469,7 @@ func jsonValuesToVector(iter *jsoniter.Iterator, ft FieldType) (vector, error) {
 				vals.Append(nil)
 			} else {
 				v := iter.ReadInt64()
-				vals.Append(v)
+				vals.Append(&v)
 			}
 		}
 		return vals, nil
@@ -555,11 +555,6 @@ func jsonValuesToVector(iter *jsoniter.Iterator, ft FieldType) (vector, error) {
 		convert = func(v interface{}) (interface{}, error) {
 			iV, err := int64FromJSON(v)
 			return int32(iV), err
-		}
-
-	case FieldTypeInt64:
-		convert = func(v interface{}) (interface{}, error) {
-			return int64FromJSON(v)
 		}
 
 	case FieldTypeFloat32:

--- a/data/frame_json.go
+++ b/data/frame_json.go
@@ -1321,7 +1321,7 @@ func readTimeVectorJSON(iter *jsoniter.Iterator, nullable bool, size int) (vecto
 		} else {
 			ms := iter.ReadInt64()
 
-			tv := time.Unix(ms/int64(1e+3), (ms%int64(1e+3))*int64(1e+6))
+			tv := time.Unix(ms/int64(1e+3), (ms%int64(1e+3))*int64(1e+6)).UTC()
 			arr.SetConcrete(i, tv)
 		}
 	}

--- a/data/frame_json_test.go
+++ b/data/frame_json_test.go
@@ -67,6 +67,30 @@ func TestGoldenFrameJSON(t *testing.T) {
 	}
 }
 
+func TestMarshalFieldTypeJSON(t *testing.T) {
+	testJSON := func(ft data.FieldType) {
+		msg := json.RawMessage([]byte(`{"l1":"v1"}`))
+		f1 := data.NewFieldFromFieldType(ft, 1)
+		f1.SetConcrete(0, msg)
+
+		f := data.NewFrame("frame", f1)
+
+		fbytes, err := json.Marshal(f)
+		require.NoError(t, err)
+
+		// fmt.Println("frame in json:", string(fbytes))
+
+		f2 := &data.Frame{}
+		err = json.Unmarshal(fbytes, f2)
+		require.NoError(t, err)
+		val, ok := f2.Fields[0].ConcreteAt(0)
+		require.True(t, ok)
+		require.Equal(t, msg, val)
+	}
+	testJSON(data.FieldTypeJSON)
+	testJSON(data.FieldTypeNullableJSON) // this version is silly
+}
+
 type simpleTestObj struct {
 	Name   string          `json:"name,omitempty"`
 	FType  data.FieldType  `json:"type,omitempty"`


### PR DESCRIPTION
Currently the first field in values is read into a generic array and then converted to vector.  This fails for JSON fields.

This PR fixes parsing JSON from the first field.