### PR TITLE
Chore: Fix DeepCopyInto for DataQuery

### DIFF
--- a/experimental/apis/data/v0alpha1/query.go
+++ b/experimental/apis/data/v0alpha1/query.go
@@ -246,7 +246,7 @@ func (g *DataQuery) DeepCopyInto(out *DataQuery) {
 		out.additional = map[string]any{}
 		if len(g.additional) > 0 {
 			jj, err := json.Marshal(g.additional)
-			if err != nil {
+			if err == nil {
 				_ = json.Unmarshal(jj, &out.additional)
 			}
 		}

--- a/experimental/apis/data/v0alpha1/query_test.go
+++ b/experimental/apis/data/v0alpha1/query_test.go
@@ -20,7 +20,8 @@ func TestParseQueriesIntoQueryDataRequest(t *testing.T) {
 				"spreadsheet": "spreadsheetID",
 				"datasourceId": 4,
 				"intervalMs": 30000,
-				"maxDataPoints": 794
+				"maxDataPoints": 794,
+				"expr": "{filename=\"/var/log/docker/2e21a640173f1f3359e2a178905dad6b1b56e2da6e3d53dbdba0a1123cdcb4fe/json.log\"} | logfmt"
 			},
 			{
 				"refId": "Z",
@@ -73,6 +74,11 @@ func TestParseQueriesIntoQueryDataRequest(t *testing.T) {
 			  "to": "200"
 			}
 		  }`, string(out))
+	})
+
+	t.Run("verify deep copy", func(t *testing.T) {
+		cpy := req.DeepCopy()
+		require.Equal(t, req, cpy)
 	})
 
 	t.Run("same results from either parser", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

This [generated name retry function](https://github.com/kubernetes/kubernetes/blob/0aea469b96a1c0fed48dd2d4a0af96d36e24968c/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go#L450) was added in `0.30.0`. it adds a call to `DeepCopyObject`, which creates a copy of the object before passing it to storage. The copied object is missing properties due a bug in `DataQuery.DeepCopyInto`, but the bug was not obvious until the upstream changes triggered the bug.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
