### PR TITLE
SQLUtil: Mark errors regarding duplicate column names as downstream

### DIFF
--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"reflect"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 )
 
 // A ScanRow is a container for SQL metadata for a single row.
@@ -60,7 +62,7 @@ func MakeScanRow(colTypes []*sql.ColumnType, colNames []string, converters ...Co
 	seen := map[string]int{}
 	for i, name := range colNames {
 		if j, ok := seen[name]; ok {
-			return nil, fmt.Errorf(`duplicate column names are not allowed, found identical name "%v" at column indices %v and %v`, name, j, i)
+			return nil, errorsource.DownstreamError(fmt.Errorf(`duplicate column names are not allowed, found identical name "%v" at column indices %v and %v`, name, j, i), false)
 		}
 		seen[name] = i
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
While monitoring logs from api server for Athena plugin, we noticed this error: [duplicate column names are not allowed](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22hrk%22:%7B%22datasource%22:%22000000193%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bservice_name%3D%5C%22grafana%2Fathena-datasource-grafana-app-steady%5C%22%7D%20%7C%3D%20%60duplicate%20column%20names%20are%20not%20allowed%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22000000193%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)
I think these errors should be marked as downstream since as far as I can see they are a result of a user "error" (or at least a restriction on column processing in the sdk, so we shouldn't mark them as plugin errors). Open to suggestions though if that doesn't sound right!


**Special notes for your reviewer**:
