### PR TITLE
Mark no such host error as downstream

### DIFF
--- a/experimental/errorsource/error_source_middleware.go
+++ b/experimental/errorsource/error_source_middleware.go
@@ -2,6 +2,7 @@ package errorsource
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"syscall"
 
@@ -26,6 +27,10 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 			return res, Error{source: errorSource, err: err}
 		}
 		if errors.Is(err, syscall.ECONNREFUSED) {
+			return res, Error{source: backend.ErrorSourceDownstream, err: err}
+		}
+		var dnsError *net.DNSError
+		if errors.As(err, &dnsError) && dnsError.IsNotFound {
 			return res, Error{source: backend.ErrorSourceDownstream, err: err}
 		}
 		return res, err


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
Currently, "dial tcp: no such host" errors are getting marked as plugin errors, which is causing false alerts for the api server error rate alerts.

**Special notes for your reviewer**:
This will mark all "no such host" and "unknown port" errors as downstream, if there is ever a case when we want those to be plugin errors