### PR TITLE
Mark invalid duration as downstream error

### DIFF
--- a/backend/gtime/gtime.go
+++ b/backend/gtime/gtime.go
@@ -17,7 +17,7 @@ var dateUnitPattern = regexp.MustCompile(`^(\d+)([dwMy])$`)
 func ParseInterval(inp string) (time.Duration, error) {
 	dur, period, err := parse(inp)
 	if err != nil {
-		return 0, err
+		return 0, errorsource.DownstreamError(err, false)
 	}
 	if period == "" {
 		return dur, nil


### PR DESCRIPTION
Realized I missed one more place where the error should be marked as downstream when duration provided is invalid 😔