### PR TITLE
Remove datasource settings from QueryConversionHandler

### DIFF
--- a/backend/datasource/manage.go
+++ b/backend/datasource/manage.go
@@ -24,6 +24,9 @@ type ManageOpts struct {
 
 	// Stateless conversion handler
 	ConversionHandler backend.ConversionHandler
+
+	// Stateless query conversion handler
+	QueryConversionHandler backend.QueryConversionHandler
 }
 
 // Manage starts serving the data source over gPRC with automatic instance management.
@@ -49,7 +52,7 @@ func Manage(pluginID string, instanceFactory InstanceFactoryFunc, opts ManageOpt
 		CallResourceHandler:    handler,
 		QueryDataHandler:       handler,
 		StreamHandler:          handler,
-		QueryConversionHandler: handler,
+		QueryConversionHandler: opts.QueryConversionHandler,
 		AdmissionHandler:       opts.AdmissionHandler,
 		GRPCSettings:           opts.GRPCSettings,
 		ConversionHandler:      opts.ConversionHandler,

--- a/internal/automanagement/manager.go
+++ b/internal/automanagement/manager.go
@@ -105,14 +105,3 @@ func (m *Manager) RunStream(ctx context.Context, req *backend.RunStreamRequest, 
 	}
 	return status.Error(codes.Unimplemented, "unimplemented")
 }
-
-func (m *Manager) ConvertQueryDataRequest(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryConversionResponse, error) {
-	h, err := m.Get(ctx, req.PluginContext)
-	if err != nil {
-		return nil, err
-	}
-	if ds, ok := h.(backend.QueryConversionHandler); ok {
-		return ds.ConvertQueryDataRequest(ctx, req)
-	}
-	return nil, status.Error(codes.Unimplemented, "unimplemented")
-}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

Follow up from this [conversation](https://github.com/grafana/grafana/pull/92909#discussion_r1766371783). The HTTP call for doing a query conversion won't have datasource settings so the query conversion handler won't be a `Datasource` method (similar to the AdmissionHandler).

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
