### PR TITLE
Fix error source in partial data response error for context.Canceled and other downstream errors

### DIFF
--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -45,8 +45,8 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 				continue
 			}
 
-			// if error source not set and the error is a downstream error, set error source to downstream.
-			if !r.ErrorSource.IsValid() && IsDownstreamError(r.Error) {
+			// we check if error is downstream error and set the error source to downstream.
+			if IsDownstreamError(r.Error) {
 				r.ErrorSource = ErrorSourceDownstream
 			}
 

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -48,6 +48,9 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 			// we check if error is downstream error and set the error source to downstream.
 			if IsDownstreamError(r.Error) {
 				r.ErrorSource = ErrorSourceDownstream
+			// otherwise we check if error source is valid and if not, we set it to plugin.
+			} else if !r.ErrorSource.IsValid() {
+				r.ErrorSource = ErrorSourcePlugin
 			}
 
 			if !r.Status.IsValid() {

--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -48,7 +48,7 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 			// we check if error is downstream error and set the error source to downstream.
 			if IsDownstreamError(r.Error) {
 				r.ErrorSource = ErrorSourceDownstream
-			// otherwise we check if error source is valid and if not, we set it to plugin.
+				// otherwise we check if error source is valid and if not, we set it to plugin.
 			} else if !r.ErrorSource.IsValid() {
 				r.ErrorSource = ErrorSourcePlugin
 			}

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -225,6 +225,15 @@ func TestQueryData(t *testing.T) {
 				},
 				expErrorSource: ErrorSourceDownstream,
 			},
+			{
+				name: `single error response that has no error source should have "plugin" error source`,
+				queryDataResponse: &QueryDataResponse{
+					Responses: map[string]DataResponse{
+						"A": {Error: someErr},
+					},
+				},
+				expErrorSource: ErrorSourcePlugin,
+			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				var actualCtx context.Context

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -207,6 +207,15 @@ func TestQueryData(t *testing.T) {
 				expErrorSource:    ErrorSourcePlugin,
 				expError:          true,
 			},
+			{
+				name: `single error that we override as "downstream" should be "downstream" error source even if "plugin" error source`,
+				queryDataResponse: &QueryDataResponse{
+					Responses: map[string]DataResponse{
+						"A": {Error: context.Canceled, ErrorSource: ErrorSourcePlugin},
+					},
+				},
+				expErrorSource: ErrorSourceDownstream,
+			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				var actualCtx context.Context

--- a/backend/data_adapter_test.go
+++ b/backend/data_adapter_test.go
@@ -216,6 +216,15 @@ func TestQueryData(t *testing.T) {
 				},
 				expErrorSource: ErrorSourceDownstream,
 			},
+			{
+				name: `single error that we override as "downstream" and has no error source should have "downstream" error source`,
+				queryDataResponse: &QueryDataResponse{
+					Responses: map[string]DataResponse{
+						"A": {Error: context.Canceled},
+					},
+				},
+				expErrorSource: ErrorSourceDownstream,
+			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
 				var actualCtx context.Context


### PR DESCRIPTION
When reporting errors in `Plugin Request Completed`, we override error source for some of the errors and set it to `downstream`. However, we weren't doing it in `Partial data response error`, which created discrepancy between error source in `Plugin Request Completed` and  `Partial data response error`. 


Logs with the fix (both logs have statusSource=downstream)
```
{"@level":"error","@message":"Partial data response error","@timestamp":"2024-09-26T15:57:17.753655+02:00","dsName":"cold-plunge-form","dsUID":"bc67b2e5-5ca8-4405-a1ba-6eccbc6b2756","endpoint":"queryData","error":"context canceled","pluginID":"grafana-googlesheets-datasource","refID":"A","status":500,"statusSource":"downstream","uname":"admin"}
{"@level":"debug","@message":"Plugin Request Completed","@timestamp":"2024-09-26T15:57:17.753744+02:00","dsName":"cold-plunge-form","dsUID":"bc67b2e5-5ca8-4405-a1ba-6eccbc6b2756","duration":"5.271724625s","endpoint":"queryData","pluginID":"grafana-googlesheets-datasource","status":"cancelled","statusSource":"downstream","uname":"admin"}
```

Logs before (1 log has statusSource=downstream and the other has plugin)
```
{"@level":"error","@message":"Partial data response error","@timestamp":"2024-09-26T15:58:14.100009+02:00","dsName":"cold-plunge-form","dsUID":"bc67b2e5-5ca8-4405-a1ba-6eccbc6b2756","endpoint":"queryData","error":"context canceled","pluginID":"grafana-googlesheets-datasource","refID":"A","status":500,"statusSource":"plugin","uname":"admin"}
{"@level":"debug","@message":"Plugin Request Completed","@timestamp":"2024-09-26T15:58:14.100073+02:00","dsName":"cold-plunge-form","dsUID":"bc67b2e5-5ca8-4405-a1ba-6eccbc6b2756","duration":"2.704154041s","endpoint":"queryData","pluginID":"grafana-googlesheets-datasource","status":"cancelled","statusSource":"plugin","uname":"admin"}
```