### PR TITLE
Mark sorting error in longRowProcessor as downstream

### DIFF
--- a/data/time_series.go
+++ b/data/time_series.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/errorsource"
 )
 
 // TimeSeriesType represents the type of time series the schema can be treated as (if any).
@@ -308,7 +310,7 @@ func (p *longRowProcessor) process(longRowIdx int) error {
 	}
 
 	if currentTime.Before(p.lastTime) {
-		return fmt.Errorf("long series must be sorted ascending by time to be converted")
+		return errorsource.DownstreamError(fmt.Errorf("long series must be sorted ascending by time to be converted"), false)
 	}
 
 	sliceKey := make(tupleLabels, len(p.tsSchema.FactorIndices)) // factor columns idx:value tuples (used for lookup)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
We've been getting [plugin errors reported](https://ops.grafana-ops.net/d/ddwsj0wg3gr28c/0620e6c?orgId=1&var-datasource=athena&var-cluster=$__all&from=now-7d&to=now&timezone=browser&refresh=&var-Filters=error%7C%3D%7Clong%20series%20must%20be%20sorted%20ascending%20by%20time%20to%20be%20converted:%20Could%20not%20process%20SQL%20results) for Athena (and some other plugins): `long series must be sorted ascending by time to be converted: Could not process SQL results`. This seems like a downstream/user error, but lmk if that's not the case. 

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
