### PR TITLE
Autoinstrumentation: Don't log errors in partial response that produce status=cancelled

### DIFF
--- a/backend/data_adapter.go
+++ b/backend/data_adapter.go
@@ -41,7 +41,7 @@ func (a *dataSDKAdapter) QueryData(ctx context.Context, req *pluginv2.QueryDataR
 		// and if there's no plugin error
 		var hasPluginError, hasDownstreamError bool
 		for refID, r := range resp.Responses {
-			if r.Error == nil {
+			if r.Error == nil || isCancelledError(r.Error) {
 				continue
 			}
 


### PR DESCRIPTION
The errors that produce status=cancelled don't need to be logged as partial data response, as they don't produce `status=error` state, but `status=cancelled`. 