### PR TITLE
Create IsDownstreamHTTPError method and add error source middleware

### DIFF
--- a/backend/error_source.go
+++ b/backend/error_source.go
@@ -4,7 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"os"
+	"syscall"
+
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 // ErrorSource type defines the source of the error
@@ -142,4 +148,75 @@ func WithErrorSource(ctx context.Context, s ErrorSource) error {
 // called before this function.
 func WithDownstreamErrorSource(ctx context.Context) error {
 	return WithErrorSource(ctx, ErrorSourceDownstream)
+}
+
+func IsDownstreamHttpError(err error) bool {
+	e := errorWithSourceImpl{
+		source: ErrorSourceDownstream,
+	}
+	if errors.Is(err, e) {
+		return true
+	}
+
+	type errorWithSource interface {
+		ErrorSource() ErrorSource
+	}
+
+	// nolint:errorlint
+	if errWithSource, ok := err.(errorWithSource); ok && errWithSource.ErrorSource() == ErrorSourceDownstream {
+		return true
+	}
+
+	// Check if the error is a HTTP timeout error or a context cancelled error
+	if isHTTPTimeoutError(err){
+		return true
+	}
+
+	if isCancelledError(err) {	
+		return true
+	}
+
+	if isConnectionResetOrRefusedError(err) {
+		return true
+	}
+
+	if isDnsNotFoundError(err) {
+		return true
+	}
+
+	return false
+}
+
+
+func isCancelledError(err error) bool {
+	return errors.Is(err, context.Canceled) || grpcstatus.Code(err) == grpccodes.Canceled
+}
+
+func isHTTPTimeoutError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	return errors.Is(err, os.ErrDeadlineExceeded) // replacement for os.IsTimeout(err)
+}
+
+func isConnectionResetOrRefusedError(err error) bool {
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		if sysErr, ok := netErr.Err.(*os.SyscallError); ok {
+			return sysErr.Err == syscall.ECONNRESET || sysErr.Err == syscall.ECONNREFUSED
+		}
+	}
+
+	return false
+}
+
+func isDnsNotFoundError(err error) bool {
+	var dnsError *net.DNSError
+	if errors.As(err, &dnsError) && dnsError.IsNotFound {
+		return true
+	}
+
+	return false
 }

--- a/backend/error_source.go
+++ b/backend/error_source.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 )
@@ -29,6 +31,13 @@ const (
 
 func (es ErrorSource) IsValid() bool {
 	return es == ErrorSourceDownstream || es == ErrorSourcePlugin
+}
+
+func ErrorSourceFromHttpError(err error) ErrorSource {
+	if httpclient.IsDownstreamHttpError(err) {
+		return ErrorSourceDownstream
+	}
+	return ErrorSourcePlugin
 }
 
 // ErrorSourceFromStatus returns an [ErrorSource] based on provided HTTP status code.

--- a/backend/error_source.go
+++ b/backend/error_source.go
@@ -4,14 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
-	"os"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
-
-	grpccodes "google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
 )
 
 // ErrorSource type defines the source of the error
@@ -156,17 +151,4 @@ func WithErrorSource(ctx context.Context, s ErrorSource) error {
 // called before this function.
 func WithDownstreamErrorSource(ctx context.Context) error {
 	return WithErrorSource(ctx, ErrorSourceDownstream)
-}
-
-func isCancelledError(err error) bool {
-	return errors.Is(err, context.Canceled) || grpcstatus.Code(err) == grpccodes.Canceled
-}
-
-func isHTTPTimeoutError(err error) bool {
-	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
-		return true
-	}
-
-	return errors.Is(err, os.ErrDeadlineExceeded) // replacement for os.IsTimeout(err)
 }

--- a/backend/httpclient/error_source_middleware.go
+++ b/backend/httpclient/error_source_middleware.go
@@ -1,11 +1,16 @@
 package httpclient
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
 	"net/http"
+	"os"
+	"syscall"
 
-	// this is throwing cicular dependency error - will need to refactor it
-	// if we want to use it
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 const ErrorSourceMiddlewareName = "ErrorSource"
@@ -14,11 +19,119 @@ func ErrorSourceMiddleware() Middleware {
 	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(_ Options, next http.RoundTripper) http.RoundTripper {
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			res, err := next.RoundTrip(req)
-			if err != nil && backend.IsDownstreamHttpError(err) {
-				return res, backend.DownstreamError(err) 
+			if err != nil && IsDownstreamHttpError(err) {
+				return res, DownstreamError(err) 
 			}
 
-			return res, nil
+			return res, err
 		})
 	})
+}
+
+
+type ErrorSource string
+const (
+	ErrorSourcePlugin ErrorSource = "plugin"
+	ErrorSourceDownstream ErrorSource = "downstream"
+)
+
+type errorWithSourceImpl struct {
+	source ErrorSource
+	err    error
+}
+
+func IsDownstreamHttpError(err error) bool {
+	e := errorWithSourceImpl{
+		source: ErrorSourceDownstream,
+	}
+	if errors.Is(err, e) {
+		return true
+	}
+
+	// nolint:errorlint
+	if errWithSource, ok := err.(errorWithSourceImpl); ok && errWithSource.ErrorSource() == ErrorSourceDownstream {
+		return true
+	}
+
+	// Check if the error is a HTTP timeout error or a context cancelled error
+	if isHTTPTimeoutError(err){
+		return true
+	}
+
+	if isCancelledError(err) {	
+		return true
+	}
+
+	if isConnectionResetOrRefusedError(err) {
+		return true
+	}
+
+	if isDnsNotFoundError(err) {
+		return true
+	}
+
+	return false
+}
+
+
+func isCancelledError(err error) bool {
+	return errors.Is(err, context.Canceled) || grpcstatus.Code(err) == grpccodes.Canceled
+}
+
+func isHTTPTimeoutError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	return errors.Is(err, os.ErrDeadlineExceeded) // replacement for os.IsTimeout(err)
+}
+
+func isConnectionResetOrRefusedError(err error) bool {
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		if sysErr, ok := netErr.Err.(*os.SyscallError); ok {
+			return sysErr.Err == syscall.ECONNRESET || sysErr.Err == syscall.ECONNREFUSED
+		}
+	}
+
+	return false
+}
+
+func isDnsNotFoundError(err error) bool {
+	var dnsError *net.DNSError
+	if errors.As(err, &dnsError) && dnsError.IsNotFound {
+		return true
+	}
+
+	return false
+}
+
+
+func (e errorWithSourceImpl) ErrorSource() ErrorSource {
+	return e.source
+}
+
+func (e errorWithSourceImpl) Error() string {
+	return fmt.Errorf("%s error: %w", e.source, e.err).Error()
+}
+
+// Implements the interface used by [errors.Is].
+func (e errorWithSourceImpl) Is(err error) bool {
+	if errWithSource, ok := err.(errorWithSourceImpl); ok {
+		return errWithSource.ErrorSource() == e.source
+	}
+
+	return false
+}
+
+func (e errorWithSourceImpl) Unwrap() error {
+	return e.err
+}
+
+func DownstreamError(err error) error {
+	return errorWithSourceImpl{
+		source: ErrorSourceDownstream,
+		err:    err,
+	}
 }

--- a/backend/httpclient/error_source_middleware.go
+++ b/backend/httpclient/error_source_middleware.go
@@ -1,0 +1,24 @@
+package httpclient
+
+import (
+	"net/http"
+
+	// this is throwing cicular dependency error - will need to refactor it
+	// if we want to use it
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+const ErrorSourceMiddlewareName = "ErrorSource"
+
+func ErrorSourceMiddleware() Middleware {
+	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(_ Options, next http.RoundTripper) http.RoundTripper {
+		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			res, err := next.RoundTrip(req)
+			if err != nil && backend.IsDownstreamHttpError(err) {
+				return res, backend.DownstreamError(err) 
+			}
+
+			return res, nil
+		})
+	})
+}

--- a/backend/httpclient/error_source_middleware.go
+++ b/backend/httpclient/error_source_middleware.go
@@ -16,7 +16,7 @@ import (
 const ErrorSourceMiddlewareName = "ErrorSource"
 
 func ErrorSourceMiddleware() Middleware {
-	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(_ Options, next http.RoundTripper) http.RoundTripper {
+	return NamedMiddlewareFunc(ErrorSourceMiddlewareName, func(_ Options, next http.RoundTripper) http.RoundTripper {
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			res, err := next.RoundTrip(req)
 			if err != nil && IsDownstreamHTTPError(err) {

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -210,6 +210,7 @@ func DefaultMiddlewares() []Middleware {
 		BasicAuthenticationMiddleware(),
 		CustomHeadersMiddleware(),
 		ContextualMiddleware(),
+		ErrorSourceMiddleware(),
 	}
 }
 

--- a/backend/httpclient/http_client_test.go
+++ b/backend/httpclient/http_client_test.go
@@ -55,11 +55,12 @@ func TestNewClient(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, client)
 
-		require.Len(t, usedMiddlewares, 4)
+		require.Len(t, usedMiddlewares, 5)
 		require.Equal(t, TracingMiddlewareName, usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 		require.Equal(t, BasicAuthenticationMiddlewareName, usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 		require.Equal(t, CustomHeadersMiddlewareName, usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 		require.Equal(t, ContextualMiddlewareName, usedMiddlewares[3].(MiddlewareName).MiddlewareName())
+		require.Equal(t, ErrorSourceMiddlewareName, usedMiddlewares[4].(MiddlewareName).MiddlewareName())
 	})
 
 	t.Run("New() with opts middleware should return expected http.Client", func(t *testing.T) {

--- a/backend/httpclient/provider_test.go
+++ b/backend/httpclient/provider_test.go
@@ -24,7 +24,7 @@ func TestProvider(t *testing.T) {
 			client, err := ctx.provider.New()
 			require.NoError(t, err)
 			require.NotNil(t, client)
-			require.Len(t, ctx.usedMiddlewares, 4)
+			require.Len(t, ctx.usedMiddlewares, 5)
 			require.Equal(t, TracingMiddlewareName, ctx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 			require.Equal(t, BasicAuthenticationMiddlewareName, ctx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 			require.Equal(t, CustomHeadersMiddlewareName, ctx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
@@ -36,7 +36,7 @@ func TestProvider(t *testing.T) {
 			transport, err := ctx.provider.GetTransport()
 			require.NoError(t, err)
 			require.NotNil(t, transport)
-			require.Len(t, ctx.usedMiddlewares, 4)
+			require.Len(t, ctx.usedMiddlewares, 5)
 			require.Equal(t, TracingMiddlewareName, ctx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 			require.Equal(t, BasicAuthenticationMiddlewareName, ctx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 			require.Equal(t, CustomHeadersMiddlewareName, ctx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
@@ -81,7 +81,7 @@ func TestProvider(t *testing.T) {
 			require.Equal(t, DefaultTimeoutOptions.Timeout, client.Timeout)
 
 			t.Run("Should use configured middlewares and implement MiddlewareName", func(t *testing.T) {
-				require.Len(t, pCtx.usedMiddlewares, 7)
+				require.Len(t, pCtx.usedMiddlewares, 8)
 				require.Equal(t, "mw1", pCtx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 				require.Equal(t, "mw2", pCtx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 				require.Equal(t, "mw3", pCtx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())

--- a/backend/request_status.go
+++ b/backend/request_status.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
-
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 )
 
 type RequestStatus int

--- a/backend/request_status.go
+++ b/backend/request_status.go
@@ -2,13 +2,7 @@ package backend
 
 import (
 	"context"
-	"errors"
-	"net"
-	"os"
 	"strings"
-
-	grpccodes "google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 )
@@ -102,17 +96,4 @@ func RequestStatusFromProtoQueryDataResponse(res *pluginv2.QueryDataResponse, er
 	}
 
 	return status
-}
-
-func isCancelledError(err error) bool {
-	return errors.Is(err, context.Canceled) || grpcstatus.Code(err) == grpccodes.Canceled
-}
-
-func isHTTPTimeoutError(err error) bool {
-	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
-		return true
-	}
-
-	return errors.Is(err, os.ErrDeadlineExceeded) // replacement for os.IsTimeout(err)
 }

--- a/experimental/errorsource/error_source_middleware.go
+++ b/experimental/errorsource/error_source_middleware.go
@@ -2,9 +2,7 @@ package errorsource
 
 import (
 	"errors"
-	"net"
 	"net/http"
-	"syscall"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
@@ -26,11 +24,7 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 			}
 			return res, Error{source: errorSource, err: err}
 		}
-		if errors.Is(err, syscall.ECONNREFUSED) {
-			return res, Error{source: backend.ErrorSourceDownstream, err: err}
-		}
-		var dnsError *net.DNSError
-		if errors.As(err, &dnsError) && dnsError.IsNotFound {
+		if httpclient.IsDownstreamHttpError(err) {
 			return res, Error{source: backend.ErrorSourceDownstream, err: err}
 		}
 		return res, err

--- a/experimental/errorsource/error_source_middleware.go
+++ b/experimental/errorsource/error_source_middleware.go
@@ -24,7 +24,7 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 			}
 			return res, Error{source: errorSource, err: err}
 		}
-		if httpclient.IsDownstreamHttpError(err) {
+		if httpclient.IsDownstreamHTTPError(err) {
 			return res, Error{source: backend.ErrorSourceDownstream, err: err}
 		}
 		return res, err


### PR DESCRIPTION
This PR:
- Creates `backend.IsDownstreamHTTPError` method that can be used by plugins to check if returned HTTP error is downstream
- Adds error source middleware to default middlewares that  checks if error is downstream and if so, adds source for it

There was an issue with circular dependencies. I initially tried to move some stuff to` backend/error_source.go` or `backend/experimental/errorsource`, but none of these can be imported in http client, because:
 - `backend` imports `httpclient` and therefore we can't import `backend` in `httpclient`  
 - `experimental/errorsource` imports both `backend` and `httpclient`

But then landed with the current solution. Let me know what do you think. 

