### PR TITLE
Errorsource: mark protocol error as downstream

### DIFF
--- a/experimental/errorsource/error_source_middleware.go
+++ b/experimental/errorsource/error_source_middleware.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"strings"
 	"syscall"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -31,6 +32,9 @@ func RoundTripper(_ httpclient.Options, next http.RoundTripper) http.RoundTrippe
 		}
 		var dnsError *net.DNSError
 		if errors.As(err, &dnsError) && dnsError.IsNotFound {
+			return res, Error{source: backend.ErrorSourceDownstream, err: err}
+		}
+		if strings.Contains(err.Error(), "unsupported protocol scheme") {
 			return res, Error{source: backend.ErrorSourceDownstream, err: err}
 		}
 		return res, err


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
This error happens because the user sets a bad url, so it should be downstream. It's causing problems with the elasticsearch alerts.

Unfortunately because of the way it's declared, i don't have a better way to check for it than just checking for the string https://cs.opensource.google/go/go/+/master:src/net/http/transport.go;l=585?q=%22unsupported%20protocol%20scheme%22&ss=go%2Fgo

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
