### PR TITLE
Fix user-agent parsing of security releases

### DIFF
--- a/backend/useragent/user_agent.go
+++ b/backend/useragent/user_agent.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	userAgentRegex   = regexp.MustCompile(`^Grafana/([0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9]+)?) \(([a-zA-Z0-9]+); ([a-zA-Z0-9]+)\)$`)
+	userAgentRegex   = regexp.MustCompile(`^Grafana/([0-9]+\.[0-9]+\.[0-9]+(?:[^\s]+)?) \(([a-zA-Z0-9]+); ([a-zA-Z0-9]+)\)$`)
 	errInvalidFormat = errors.New("invalid user agent format")
 )
 

--- a/backend/useragent/user_agent_test.go
+++ b/backend/useragent/user_agent_test.go
@@ -73,6 +73,14 @@ func TestParse(t *testing.T) {
 				os:             "darwin",
 				arch:           "amd64",
 			},
+		}, {
+			name:      "valid (with security suffix)",
+			userAgent: "Grafana/11.2.2+security-01 (darwin; amd64)",
+			expected: &UserAgent{
+				grafanaVersion: "11.2.2+security-01",
+				os:             "darwin",
+				arch:           "amd64",
+			},
 		},
 		{
 			name:      "invalid (missing os + arch)",


### PR DESCRIPTION
**What this PR does / why we need it**:

The user-agent parser fails on the recently released `11.2.2+security-01` grafana version string. My logs contains many entries like this:

```
logger=base.plugin.context t=2024-10-20T18:07:40.005997558 level=warn msg="Could not create user agent" error="invalid user agent format"
```

**Which issue(s) this PR fixes**:

https://github.com/grafana/grafana/issues/95006

**Special notes for your reviewer**:

The version `11.2.2+security-01` seems to be a valid semver string.
