### PR TITLE
errrorsource: Handle if errors are nil

### DIFF
--- a/experimental/errorsource/error_source.go
+++ b/experimental/errorsource/error_source.go
@@ -39,12 +39,18 @@ func (r Error) ErrorSource() backend.ErrorSource {
 
 // PluginError will apply the source as plugin
 func PluginError(err error, override bool) error {
-	return SourceError(backend.ErrorSourcePlugin, err, override)
+	if err != nil {
+		return SourceError(backend.ErrorSourcePlugin, err, override)
+	}
+	return nil
 }
 
 // DownstreamError will apply the source as downstream
 func DownstreamError(err error, override bool) error {
-	return SourceError(backend.ErrorSourceDownstream, err, override)
+	if err != nil {
+		return SourceError(backend.ErrorSourceDownstream, err, override)
+	}
+	return nil
 }
 
 // SourceError returns an error with the source

--- a/experimental/errorsource/error_source_test.go
+++ b/experimental/errorsource/error_source_test.go
@@ -93,3 +93,11 @@ func TestError(t *testing.T) {
 	dErr := DownstreamError(err, true)
 	require.True(t, backend.IsDownstreamError(dErr))
 }
+
+func TestNilError(t *testing.T) {
+	err := error(nil)
+	pErr := PluginError(err, true)
+	require.Nil(t, pErr)
+	dErr := DownstreamError(err, true)
+	require.Nil(t, dErr)
+}


### PR DESCRIPTION
The current implementation of the `errorsource` logic can lead to `nil` pointer dereferences. 

An example of this can be found [here](https://github.com/grafana/grafana/blob/6be787dd4781e1d5294ebfd346caba8e6bff860b/pkg/tsdb/cloud-monitoring/cloudmonitoring.go#L594). Any error value returned from the `gceDefaultProjectGetter` is a valid error. However, the function may also return `nil` if there is no error. 

The `DownstreamError` and `PluginError` functions should appropriately handle if the error is nil given that they technically return the `error` type.

Example issue [here](https://github.com/grafana/grafana/issues/95403).