### PR TITLE
Export errors for time series processing

### DIFF
--- a/data/time_series.go
+++ b/data/time_series.go
@@ -308,7 +308,7 @@ func (p *longRowProcessor) process(longRowIdx int) error {
 	}
 
 	if currentTime.Before(p.lastTime) {
-		return fmt.Errorf("long series must be sorted ascending by time to be converted")
+		return ErrorSeriesUnsorted
 	}
 
 	sliceKey := make(tupleLabels, len(p.tsSchema.FactorIndices)) // factor columns idx:value tuples (used for lookup)
@@ -386,7 +386,7 @@ func (p *longRowProcessor) process(longRowIdx int) error {
 func timeAt(idx int, longFrame *Frame, tsSchema TimeSeriesSchema) (time.Time, error) { // get time.Time regardless if pointer
 	val, ok := longFrame.ConcreteAt(tsSchema.TimeIndex, idx)
 	if !ok {
-		return time.Time{}, fmt.Errorf("can not convert to wide series, input has null time values")
+		return time.Time{}, ErrorNullTimeValues
 	}
 	return val.(time.Time), nil
 }

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -420,7 +420,7 @@ func WideToLong(wideFrame *Frame) (*Frame, error) {
 	if err != nil {
 		return nil, err
 	} else if wideLen == 0 {
-		return nil, ErrInputFieldsWithoutRows
+		return nil, ErrorInputFieldsWithoutRows
 	}
 
 	var uniqueValueNames []string                        // unique names of Fields that are value types

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -420,7 +420,7 @@ func WideToLong(wideFrame *Frame) (*Frame, error) {
 	if err != nil {
 		return nil, err
 	} else if wideLen == 0 {
-		return nil, fmt.Errorf("can not convert to long series, input fields have no rows")
+		return nil, ErrInputFieldsWithoutRows
 	}
 
 	var uniqueValueNames []string                        // unique names of Fields that are value types

--- a/data/time_series_errors.go
+++ b/data/time_series_errors.go
@@ -1,0 +1,10 @@
+package data
+
+import "errors"
+
+var (
+	ErrorNullTimeValues = errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
+	ErrorSeriesUnsorted = errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time and try again")
+)
+
+	

--- a/data/time_series_errors.go
+++ b/data/time_series_errors.go
@@ -3,7 +3,7 @@ package data
 import "errors"
 
 var (
-	ErrorNullTimeValues       = errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
-	ErrorSeriesUnsorted       = errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time if possible")
+	ErrorNullTimeValues         = errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
+	ErrorSeriesUnsorted         = errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time if possible")
 	ErrorInputFieldsWithoutRows = errors.New("can not convert to long series, input fields have no rows")
 )

--- a/data/time_series_errors.go
+++ b/data/time_series_errors.go
@@ -3,9 +3,7 @@ package data
 import "errors"
 
 var (
-	ErrorNullTimeValues = errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
-	ErrorSeriesUnsorted = errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time and try again")
+	ErrorNullTimeValues       = errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
+	ErrorSeriesUnsorted       = errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time and try again")
 	ErrInputFieldsWithoutRows = errors.New("can not convert to long series, input fields have no rows")
 )
-
-	

--- a/data/time_series_errors.go
+++ b/data/time_series_errors.go
@@ -5,5 +5,5 @@ import "errors"
 var (
 	ErrorNullTimeValues       = errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
 	ErrorSeriesUnsorted       = errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time if possible")
-	ErrInputFieldsWithoutRows = errors.New("can not convert to long series, input fields have no rows")
+	ErrorInputFieldsWithoutRows = errors.New("can not convert to long series, input fields have no rows")
 )

--- a/data/time_series_errors.go
+++ b/data/time_series_errors.go
@@ -5,6 +5,7 @@ import "errors"
 var (
 	ErrorNullTimeValues = errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
 	ErrorSeriesUnsorted = errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time and try again")
+	ErrInputFieldsWithoutRows = errors.New("can not convert to long series, input fields have no rows")
 )
 
 	


### PR DESCRIPTION
Follow up/different strategy for https://github.com/grafana/grafana-plugin-sdk-go/pull/1099

This PR exports the errors that we can later check for downstream errors. It also updates errors to make them more understandable for user. 