### PR TITLE
1147: Implement default timeFromValue and timeToValue

### DIFF
--- a/data/sqlutil/macros.go
+++ b/data/sqlutil/macros.go
@@ -74,6 +74,15 @@ func macroTimeFrom(query *Query, args []string) (string, error) {
 	return fmt.Sprintf("%s >= '%s'", args[0], query.TimeRange.From.UTC().Format(time.RFC3339)), nil
 }
 
+// Default macro to return the starting query time range.
+// It requires no arguments.
+// Example:
+//
+//	$__timeFromValue() => '2006-01-02T15:04:05Z07:00'
+func macroTimeFromValue(query *Query, _ []string) (string, error) {
+	return fmt.Sprintf("'%s'", query.TimeRange.To.UTC().Format(time.RFC3339)), nil
+}
+
 // Default time filter for SQL based on the ending query time range.
 // It requires one argument, the time column to filter.
 // Example:
@@ -85,6 +94,15 @@ func macroTimeTo(query *Query, args []string) (string, error) {
 	}
 
 	return fmt.Sprintf("%s <= '%s'", args[0], query.TimeRange.To.UTC().Format(time.RFC3339)), nil
+}
+
+// Default macro to return the ending query time range.
+// It requires no arguments.
+// Example:
+//
+//	$__timeToValue() => '2006-01-02T15:04:05Z07:00'
+func macroTimeToValue(query *Query, _ []string) (string, error) {
+	return fmt.Sprintf("'%s'", query.TimeRange.To.UTC().Format(time.RFC3339)), nil
 }
 
 // Default time group for SQL based the given period.
@@ -136,14 +154,16 @@ func macroColumn(query *Query, _ []string) (string, error) {
 }
 
 var DefaultMacros = Macros{
-	"interval":    macroInterval,
-	"interval_ms": macroIntervalMS,
-	"timeFilter":  macroTimeFilter,
-	"timeFrom":    macroTimeFrom,
-	"timeGroup":   macroTimeGroup,
-	"timeTo":      macroTimeTo,
-	"table":       macroTable,
-	"column":      macroColumn,
+	"interval":      macroInterval,
+	"interval_ms":   macroIntervalMS,
+	"timeFilter":    macroTimeFilter,
+	"timeFrom":      macroTimeFrom,
+	"timeFromValue": macroTimeFromValue,
+	"timeGroup":     macroTimeGroup,
+	"timeTo":        macroTimeTo,
+	"timeToValue":   macroTimeToValue,
+	"table":         macroTable,
+	"column":        macroColumn,
 }
 
 type macroMatch struct {

--- a/data/sqlutil/macros_test.go
+++ b/data/sqlutil/macros_test.go
@@ -142,8 +142,18 @@ func TestInterpolate(t *testing.T) {
 			output: "select * from foo where time <= '0001-01-01T00:00:00Z'",
 		},
 		{
+			name:   "default timeToValue macro",
+			input:  "select * from foo where time <= $__timeToValue()",
+			output: "select * from foo where time <= '0001-01-01T00:00:00Z'",
+		},
+		{
 			name:   "default timeFrom macro",
 			input:  "select * from foo where $__timeFrom(time)",
+			output: "select * from foo where time >= '0001-01-01T00:00:00Z'",
+		},
+		{
+			name:   "default timeFromValue macro",
+			input:  "select * from foo where time >= $__timeFromValue()",
 			output: "select * from foo where time >= '0001-01-01T00:00:00Z'",
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:  Implement default macros timeFromValue and timeToValue

**Which issue(s) this PR fixes**: https://github.com/grafana/grafana-plugin-sdk-go/issues/1147

Fixes #1147

**Special notes for your reviewer**:
