### PR TITLE
Update datasource metrics middleware

### DIFF
--- a/backend/httpclient/datasource_metrics_middleware.go
+++ b/backend/httpclient/datasource_metrics_middleware.go
@@ -117,9 +117,13 @@ func DataSourceMetricsMiddleware() Middleware {
 	})
 }
 
-func executeMiddleware(next http.RoundTripper, labels prometheus.Labels) http.RoundTripper {
+func executeMiddleware(next http.RoundTripper, labelsIn prometheus.Labels) http.RoundTripper {
 	return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		ctx := r.Context()
+		labels := prometheus.Labels{}
+		for k, v := range labelsIn {
+			labels[k] = v
+		}
 		labels["endpoint"] = ""
 		if ep := ctx.Value(endpointctx.EndpointCtxKey); ep != nil {
 			labels["endpoint"] = fmt.Sprintf("%v", ep)

--- a/backend/httpclient/datasource_metrics_middleware_test.go
+++ b/backend/httpclient/datasource_metrics_middleware_test.go
@@ -14,7 +14,7 @@ func TestDataSourceMetricsMiddleware(t *testing.T) {
 		origExecuteMiddlewareFunc := executeMiddlewareFunc
 		executeMiddlewareCalled := false
 		middlewareCalled := false
-		executeMiddlewareFunc = func(next http.RoundTripper, _ prometheus.Labels) http.RoundTripper {
+		executeMiddlewareFunc = func(next http.RoundTripper, _ string, _ string) http.RoundTripper {
 			executeMiddlewareCalled = true
 			return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 				middlewareCalled = true
@@ -52,7 +52,7 @@ func TestDataSourceMetricsMiddleware(t *testing.T) {
 		origExecuteMiddlewareFunc := executeMiddlewareFunc
 		executeMiddlewareCalled := false
 		middlewareCalled := false
-		executeMiddlewareFunc = func(next http.RoundTripper, _ prometheus.Labels) http.RoundTripper {
+		executeMiddlewareFunc = func(next http.RoundTripper, _ string, _ string) http.RoundTripper {
 			executeMiddlewareCalled = true
 			return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 				middlewareCalled = true
@@ -91,9 +91,9 @@ func TestDataSourceMetricsMiddleware(t *testing.T) {
 		executeMiddlewareCalled := false
 		labels := prometheus.Labels{}
 		middlewareCalled := false
-		executeMiddlewareFunc = func(next http.RoundTripper, datasourceLabel prometheus.Labels) http.RoundTripper {
+		executeMiddlewareFunc = func(next http.RoundTripper, datasourceLabel string, secureSocksProxyEnabled string) http.RoundTripper {
 			executeMiddlewareCalled = true
-			labels = datasourceLabel
+			labels = prometheus.Labels{"datasource_type": datasourceLabel, "secure_socks_ds_proxy_enabled": secureSocksProxyEnabled}
 			return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 				middlewareCalled = true
 				return next.RoundTrip(r)

--- a/backend/httpclient/datasource_metrics_middleware_test.go
+++ b/backend/httpclient/datasource_metrics_middleware_test.go
@@ -48,7 +48,7 @@ func TestDataSourceMetricsMiddleware(t *testing.T) {
 		require.False(t, middlewareCalled)
 	})
 
-	t.Run("Without data source name label options set should return next http.RoundTripper", func(t *testing.T) {
+	t.Run("Without data source type label options set should return next http.RoundTripper", func(t *testing.T) {
 		origExecuteMiddlewareFunc := executeMiddlewareFunc
 		executeMiddlewareCalled := false
 		middlewareCalled := false
@@ -86,7 +86,7 @@ func TestDataSourceMetricsMiddleware(t *testing.T) {
 		require.False(t, middlewareCalled)
 	})
 
-	t.Run("With datasource name label options set should execute middleware", func(t *testing.T) {
+	t.Run("With datasource type label options set should execute middleware", func(t *testing.T) {
 		origExecuteMiddlewareFunc := executeMiddlewareFunc
 		executeMiddlewareCalled := false
 		labels := prometheus.Labels{}
@@ -111,14 +111,14 @@ func TestDataSourceMetricsMiddleware(t *testing.T) {
 			{
 				description: "secure socks ds proxy is disabled",
 				httpClientOptions: Options{
-					Labels: map[string]string{"datasource_name": "My Data Source 123", "datasource_type": "prometheus"},
+					Labels: map[string]string{"datasource_type": "prometheus"},
 				},
 				expectedSecureSocksDSProxyEnabled: "false",
 			},
 			{
 				description: "secure socks ds proxy is enabled",
 				httpClientOptions: Options{
-					Labels:       map[string]string{"datasource_name": "My Data Source 123", "datasource_type": "prometheus"},
+					Labels:       map[string]string{"datasource_type": "prometheus"},
 					ProxyOptions: &proxy.Options{Enabled: true},
 				},
 				expectedSecureSocksDSProxyEnabled: "true",
@@ -147,8 +147,7 @@ func TestDataSourceMetricsMiddleware(t *testing.T) {
 				require.Len(t, ctx.callChain, 1)
 				require.ElementsMatch(t, []string{"finalrt"}, ctx.callChain)
 				require.True(t, executeMiddlewareCalled)
-				require.Len(t, labels, 3)
-				require.Equal(t, "My_Data_Source_123", labels["datasource"])
+				require.Len(t, labels, 2)
 				require.Equal(t, "prometheus", labels["datasource_type"])
 				require.Equal(t, tt.expectedSecureSocksDSProxyEnabled, labels["secure_socks_ds_proxy_enabled"])
 				require.True(t, middlewareCalled)


### PR DESCRIPTION
There's no need for us to record the data source name as a part of these metrics. Doing this could lead to a high cardinality metric and us creating many series' that contain information we do not need.

Additionally, there's a potential for a `nil` panic when setting `labels["endpoint"] = ""` and then updating the value for this key. Refactoring this to create the labels within the `executeMiddleware` function.