### PR TITLE
Fix proxy hash 

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -99,7 +99,7 @@ func (c *GrafanaCfg) Equal(c2 *GrafanaCfg) bool {
 }
 
 // ProxyHash returns the last four characters of the base64-encoded
-// // PDC client key contents, if present, for use in datasource instance
+// PDC client key contents, if present, for use in datasource instance
 // caching. The contents should be PEM-encoded, so we try to PEM-decode
 // them, and, if successful, return the base-64 encoding of the final three bytes,
 // giving a four character hash.

--- a/backend/config.go
+++ b/backend/config.go
@@ -108,6 +108,9 @@ func (c *GrafanaCfg) ProxyHash() string {
 		return ""
 	}
 	contents := c.config[proxy.PluginSecureSocksProxyClientKeyContents]
+	if contents == "" {
+		return ""
+	}
 	block, _ := pem.Decode([]byte(contents))
 	if block == nil {
 		Logger.Warn("ProxyHash(): key contents are not PEM-encoded")

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -382,7 +382,7 @@ func BenchmarkProxyHash(b *testing.B) {
 		proxy.PluginSecureSocksProxyClientKeyContents: string(kBytes),
 	}
 	for i := 0; i < b.N; i++ {
-		kBytes[88] = b64chars[mathrand.Intn(64)]
+		kBytes[88] = b64chars[mathrand.Intn(64)] //nolint:gosec
 		cm[proxy.PluginSecureSocksProxyClientKeyContents] = string(kBytes)
 		cfg := NewGrafanaCfg(cm)
 		hash := cfg.ProxyHash()

--- a/backend/datasource/instance_provider.go
+++ b/backend/datasource/instance_provider.go
@@ -63,8 +63,7 @@ func (ip *instanceProvider) GetKey(ctx context.Context, pluginContext backend.Pl
 	proxyHash := pluginContext.GrafanaConfig.ProxyHash()
 	tenantID := tenant.IDFromContext(ctx)
 
-	key := fmt.Sprintf("%d#%s#%s", dsID, tenantID, proxyHash)
-	return key, nil
+	return fmt.Sprintf("%d#%s#%s", dsID, tenantID, proxyHash), nil
 }
 
 func (ip *instanceProvider) NeedsUpdate(_ context.Context, pluginContext backend.PluginContext, cachedInstance instancemgmt.CachedInstance) bool {

--- a/backend/datasource/instance_provider.go
+++ b/backend/datasource/instance_provider.go
@@ -63,7 +63,8 @@ func (ip *instanceProvider) GetKey(ctx context.Context, pluginContext backend.Pl
 	proxyHash := pluginContext.GrafanaConfig.ProxyHash()
 	tenantID := tenant.IDFromContext(ctx)
 
-	return fmt.Sprintf("%d#%s#%s", dsID, tenantID, proxyHash), nil
+	key := fmt.Sprintf("%d#%s#%s", dsID, tenantID, proxyHash)
+	return key, nil
 }
 
 func (ip *instanceProvider) NeedsUpdate(_ context.Context, pluginContext backend.PluginContext, cachedInstance instancemgmt.CachedInstance) bool {

--- a/backend/datasource/instance_provider_test.go
+++ b/backend/datasource/instance_provider_test.go
@@ -2,6 +2,10 @@ package datasource
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,15 +39,22 @@ func TestInstanceProvider(t *testing.T) {
 	})
 
 	t.Run("When PDC is configured, datasource cache key should include its (so-called) hash", func(t *testing.T) {
+		contents := pem.EncodeToMemory(&pem.Block{
+			Type:  "PRIVATE KEY",
+			Bytes: []byte("this should work"),
+		})
+		want := base64.StdEncoding.EncodeToString([]byte("this should work"))
+		want = strings.TrimRight(want, "=")
+		want = want[len(want)-4:]
 		cfg := backend.NewGrafanaCfg(map[string]string{
-			proxy.PluginSecureSocksProxyClientKeyContents: "This should work",
+			proxy.PluginSecureSocksProxyClientKeyContents: string(contents),
 		})
 		key, err := ip.GetKey(context.Background(), backend.PluginContext{
 			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{ID: 5},
 			GrafanaConfig:              cfg,
 		})
 		require.NoError(t, err)
-		require.Equal(t, "5##work", key)
+		require.Equal(t, fmt.Sprintf("5##%s", want), key)
 	})
 
 	t.Run("When PDC is configured but the key is empty, no problem", func(t *testing.T) {
@@ -58,16 +69,16 @@ func TestInstanceProvider(t *testing.T) {
 		require.Equal(t, "6##", key)
 	})
 
-	t.Run("When PDC is configured, a too-short key doesn't cause an error", func(t *testing.T) {
+	t.Run("When PDC is configured but the key is not PEM-encoded, no problem", func(t *testing.T) {
 		cfg := backend.NewGrafanaCfg(map[string]string{
-			proxy.PluginSecureSocksProxyClientKeyContents: "doh",
+			proxy.PluginSecureSocksProxyClientKeyContents: "this is not\na valid string\n",
 		})
 		key, err := ip.GetKey(context.Background(), backend.PluginContext{
-			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{ID: 7},
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{ID: 6},
 			GrafanaConfig:              cfg,
 		})
 		require.NoError(t, err)
-		require.Equal(t, "7##doh", key)
+		require.Equal(t, "6##", key)
 	})
 
 	t.Run("When both the configuration and updated field of current data source instance settings are equal to the cache, should return false", func(t *testing.T) {

--- a/backend/datasource/instance_provider_test.go
+++ b/backend/datasource/instance_provider_test.go
@@ -39,11 +39,14 @@ func TestInstanceProvider(t *testing.T) {
 	})
 
 	t.Run("When PDC is configured, datasource cache key should include its (so-called) hash", func(t *testing.T) {
+		// the value of Bytes below must be a multiple of three in length for this test
+		// to pass, but that's an artifact of how the target value is created. The code
+		// itself isn't affected by the length of the key as long as it's at least 3 bytes.
 		contents := pem.EncodeToMemory(&pem.Block{
 			Type:  "PRIVATE KEY",
-			Bytes: []byte("this should work"),
+			Bytes: []byte("this will work."),
 		})
-		want := base64.StdEncoding.EncodeToString([]byte("this should work"))
+		want := base64.StdEncoding.EncodeToString([]byte("this will work."))
 		want = strings.TrimRight(want, "=")
 		want = want[len(want)-4:]
 		cfg := backend.NewGrafanaCfg(map[string]string{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
The proxy hash added to the datasource instance cache key in #1133 ends up always being `---\n`, because the contents of the proxy client key are PEM-encoded. This PR fixes that by PEM-decoding the contents, which gives a key in `[]bytes`, then base64-encoding the final three bytes, giving a four-character hash.

Since this is a bit more complex than the previous approach, I added a benchmark, which times this to about 250ns on my laptop, compared to the 1-2 microseconds for the original version discussed in #1133. Seems acceptable to me, but if need be we can do a hackier approach and just extract some characters directly from the key contents.

**Which issue(s) this PR fixes**:
https://github.com/grafana/app-platform-wg/issues/174, again.