### PR TITLE
SQL: Set relevant errors to downstream

### DIFF
--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -23,7 +23,7 @@ import (
 func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*data.Frame, error) {
 	types, err := rows.ColumnTypes()
 	if err != nil {
-		return nil, backend.DownstreamError(err)
+		return nil, err
 	}
 
 	// If there is a dynamic converter, we need to use the dynamic framer
@@ -35,7 +35,7 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 
 	names, err := rows.Columns()
 	if err != nil {
-		return nil, backend.DownstreamError(err)
+		return nil, err
 	}
 
 	scanRow, err := MakeScanRow(types, names, converters...)

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
@@ -22,7 +23,7 @@ import (
 func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*data.Frame, error) {
 	types, err := rows.ColumnTypes()
 	if err != nil {
-		return nil, err
+		return nil, backend.DownstreamError(err)
 	}
 
 	// If there is a dynamic converter, we need to use the dynamic framer
@@ -34,7 +35,7 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 
 	names, err := rows.Columns()
 	if err != nil {
-		return nil, err
+		return nil, backend.DownstreamError(err)
 	}
 
 	scanRow, err := MakeScanRow(types, names, converters...)
@@ -73,7 +74,7 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 	}
 
 	if err := rows.Err(); err != nil {
-		return frame, err
+		return frame, backend.DownstreamError(err)
 	}
 
 	return frame, nil


### PR DESCRIPTION
Making some changes based on some errors being incorrectly marked in the MSSQL data source (that I believe can also be incorrectly marked in Postgres and MySQL also).

The errors that I've modified here are ones that I believe can only error due to downstream issues rather than the plugin. Please let me know if you disagree as I think determining which the ultimate source of an error is quite challenging.

With some follow up PR's to grafana/grafana this would fix some issues we're seeing atm.

If we don't want to mark all of these as downstream then I believe we should at least mark the `rows.Err()` error as downstream.