### PR TITLE
Mark TLS certificate verification error as downstream

### DIFF
--- a/experimental/status/status_source.go
+++ b/experimental/status/status_source.go
@@ -2,10 +2,12 @@ package status
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"syscall"
 
@@ -132,7 +134,8 @@ func IsDownstreamError(err error) bool {
 func IsDownstreamHTTPError(err error) bool {
 	return IsDownstreamError(err) ||
 		isConnectionResetOrRefusedError(err) ||
-		isDNSNotFoundError(err)
+		isDNSNotFoundError(err) ||
+		isTLSCertificateVerificationError(err)
 }
 
 // InCancelledError returns true if err is context.Canceled or is gRPC status Canceled.
@@ -170,6 +173,27 @@ func isDNSNotFoundError(err error) bool {
 	return false
 }
 
+// isTLSCertificateVerificationError checks if the error is related to TLS certificate verification.
+func isTLSCertificateVerificationError(err error) bool {
+	var certErr *x509.CertificateInvalidError
+	var unknownAuthErr x509.UnknownAuthorityError
+
+	// Directly check for CertificateInvalidError or UnknownAuthorityError
+	if errors.As(err, &certErr) || errors.As(err, &unknownAuthErr) {
+		return true
+	}
+
+	// Check if the error is wrapped in a *url.Error
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		// Check the underlying error in urlErr
+		if errors.As(urlErr.Err, &certErr) || errors.As(urlErr.Err, &unknownAuthErr) {
+			return true
+		}
+	}
+
+	return false
+}
 type sourceCtxKey struct{}
 
 // SourceFromContext returns the source stored in the context.

--- a/experimental/status/status_source.go
+++ b/experimental/status/status_source.go
@@ -194,6 +194,7 @@ func isTLSCertificateVerificationError(err error) bool {
 
 	return false
 }
+
 type sourceCtxKey struct{}
 
 // SourceFromContext returns the source stored in the context.

--- a/experimental/status/status_source_test.go
+++ b/experimental/status/status_source_test.go
@@ -187,7 +187,7 @@ func TestIsDownstreamHTTPError(t *testing.T) {
 			err:      &net.DNSError{IsNotFound: true},
 			expected: true,
 		},
-				{
+		{
 			name:     "wrapped *url.Error with UnknownAuthorityError",
 			err:      &url.Error{Op: "Get", URL: "https://example.com", Err: x509.UnknownAuthorityError{}},
 			expected: true,

--- a/experimental/status/status_source_test.go
+++ b/experimental/status/status_source_test.go
@@ -2,9 +2,11 @@ package status_test
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"syscall"
 	"testing"
@@ -183,6 +185,26 @@ func TestIsDownstreamHTTPError(t *testing.T) {
 		{
 			name:     "DNS not found error",
 			err:      &net.DNSError{IsNotFound: true},
+			expected: true,
+		},
+				{
+			name:     "wrapped *url.Error with UnknownAuthorityError",
+			err:      &url.Error{Op: "Get", URL: "https://example.com", Err: x509.UnknownAuthorityError{}},
+			expected: true,
+		},
+		{
+			name:     "wrapped *url.Error with unrelated error",
+			err:      &url.Error{Op: "Get", URL: "https://example.com", Err: fmt.Errorf("some unrelated error")},
+			expected: false,
+		},
+		{
+			name:     "direct CertificateInvalidError",
+			err:      &x509.CertificateInvalidError{Reason: x509.Expired, Cert: nil},
+			expected: true,
+		},
+		{
+			name:     "direct UnknownAuthorityError",
+			err:      x509.UnknownAuthorityError{},
 			expected: true,
 		},
 	}


### PR DESCRIPTION
Mark TLS certificate verification error as downstream. Part of https://github.com/grafana/data-sources/issues/260.

More info in https://raintank-corp.slack.com/archives/C084W7DM7QS/p1734028243668549