### PR TITLE
Add helper for batching DataQueries by time range

### DIFF
--- a/backend/data.go
+++ b/backend/data.go
@@ -110,6 +110,21 @@ type DataQuery struct {
 	JSON json.RawMessage
 }
 
+func BatchDataQueriesByTimeRange(queries []DataQuery) [][]DataQuery {
+	timeToBatch := make(map[TimeRange][]DataQuery)
+
+	for _, query := range queries {
+		key := TimeRange{From: query.TimeRange.From.UTC(), To: query.TimeRange.To.UTC()}
+		timeToBatch[key] = append(timeToBatch[key], query)
+	}
+
+	finalBatches := [][]DataQuery{}
+	for _, batch := range timeToBatch {
+		finalBatches = append(finalBatches, batch)
+	}
+	return finalBatches
+}
+
 // QueryDataResponse contains the results from a QueryDataRequest.
 // It is the return type of a QueryData call.
 type QueryDataResponse struct {

--- a/backend/data_test.go
+++ b/backend/data_test.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -102,4 +103,41 @@ func TestQueryDataRequest(t *testing.T) {
 			require.Empty(t, req.Headers)
 		})
 	})
+}
+
+func TestBatchDataQueriesByTimeRange(t *testing.T) {
+	start := time.Date(2024, time.November, 29, 0, 42, 34, 0, time.UTC)
+	FiveMin := time.Date(2024, time.November, 29, 0, 47, 34, 0, time.UTC)
+	TenMin := time.Date(2024, time.November, 29, 0, 52, 34, 0, time.UTC)
+	loc := time.FixedZone("UTC+1", 1*60*60)
+	FiveMinDifferentZone := time.Date(2024, time.November, 29, 1, 47, 34, 0, loc)
+	testQueries := []DataQuery{
+		{
+			RefID:     "A",
+			TimeRange: TimeRange{From: start, To: FiveMin},
+		},
+		{
+			RefID:     "B",
+			TimeRange: TimeRange{From: start, To: TenMin},
+		},
+		{
+			RefID:     "C",
+			TimeRange: TimeRange{From: start, To: FiveMinDifferentZone},
+		},
+	}
+	result := BatchDataQueriesByTimeRange(testQueries)
+	require.Equal(t, 2, len(result))
+	var FiveMinQueries = result[0]
+	var TenMinQueries = result[1]
+	if len(result[0]) == 1 {
+		TenMinQueries = result[0]
+		FiveMinQueries = result[1]
+	}
+
+	require.Equal(t, 2, len(FiveMinQueries))
+	require.Equal(t, "A", FiveMinQueries[0].RefID)
+	require.Equal(t, "C", FiveMinQueries[1].RefID)
+
+	require.Equal(t, 1, len(TenMinQueries))
+	require.Equal(t, "B", TenMinQueries[0].RefID)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
This is a helper function to separate a batch of queries into smaller batches by time range. This function can be used in datasource plugins that need to batch their queries before sending them to the datasources.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/grafana/issues/85495

**Special notes for your reviewer**:
We could also get the string values of the time range fields to use as the key, but that didn't seem necessary to me.
