### PR TITLE
Fix: Check for missing client config in secure socks proxy check

### DIFF
--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -80,15 +80,14 @@ type cfgProxyWrapper struct {
 }
 
 // SecureSocksProxyEnabled checks if the Grafana instance allows the secure socks proxy to be used
-// and the datasource options specify to use the proxy
+// and the datasource options specify to use the proxy.
+// The secure proxy can only be used if it's enabled on both the datasource connection and the client (Grafana server)
 func (p *cfgProxyWrapper) SecureSocksProxyEnabled() bool {
-	// the secure proxy can only be used if it's enabled on both the datasource connection and the client (Grafana server)
 	if p.opts == nil || !p.opts.Enabled || p.opts.ClientCfg == nil {
 		return false
 	}
 
-	// if it's enabled on Grafana, check if the datasource is using it
-	return (p.opts != nil) && p.opts.Enabled
+	return true
 }
 
 // ConfigureSecureSocksHTTPProxy takes a http.DefaultTransport and wraps it in a socks5 proxy with TLS

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -85,7 +85,8 @@ func (p *cfgProxyWrapper) SecureSocksProxyEnabled() bool {
 	// it cannot be enabled if it's not enabled on Grafana
 	// p.opts is not always nil even if secure socks proxy is not enabled on Grafana
 	// check ClientCfg as well since it doesn't get set if it's not enabled
-	if p.opts == nil || p.opts.ClientCfg == nil {
+// the secure proxy can only be used if it's enabled on both the datasource connection and the client (Grafana server)
+	if p.opts == nil || !p.opts.Enabled || p.opts.ClientCfg == nil { 
 		return false
 	}
 

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -83,6 +83,8 @@ type cfgProxyWrapper struct {
 // and the datasource options specify to use the proxy
 func (p *cfgProxyWrapper) SecureSocksProxyEnabled() bool {
 	// it cannot be enabled if it's not enabled on Grafana
+	// p.opts is not always nil even if secure socks proxy is not enabled on Grafana
+	// check ClientCfg as well since it doesn't get set if it's not enabled
 	if p.opts == nil || p.opts.ClientCfg == nil {
 		return false
 	}

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -82,11 +82,8 @@ type cfgProxyWrapper struct {
 // SecureSocksProxyEnabled checks if the Grafana instance allows the secure socks proxy to be used
 // and the datasource options specify to use the proxy
 func (p *cfgProxyWrapper) SecureSocksProxyEnabled() bool {
-	// it cannot be enabled if it's not enabled on Grafana
-	// p.opts is not always nil even if secure socks proxy is not enabled on Grafana
-	// check ClientCfg as well since it doesn't get set if it's not enabled
-// the secure proxy can only be used if it's enabled on both the datasource connection and the client (Grafana server)
-	if p.opts == nil || !p.opts.Enabled || p.opts.ClientCfg == nil { 
+	// the secure proxy can only be used if it's enabled on both the datasource connection and the client (Grafana server)
+	if p.opts == nil || !p.opts.Enabled || p.opts.ClientCfg == nil {
 		return false
 	}
 

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -83,7 +83,7 @@ type cfgProxyWrapper struct {
 // and the datasource options specify to use the proxy
 func (p *cfgProxyWrapper) SecureSocksProxyEnabled() bool {
 	// it cannot be enabled if it's not enabled on Grafana
-	if p.opts == nil {
+	if p.opts == nil || p.opts.ClientCfg == nil {
 		return false
 	}
 

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -163,8 +163,12 @@ func TestSecureSocksProxyEnabled(t *testing.T) {
 		cli := New(nil)
 		assert.Equal(t, false, cli.SecureSocksProxyEnabled())
 	})
-	t.Run("enabled, if Enabled field is true", func(t *testing.T) {
+	t.Run("not enabled if opts.ClientCfg is nil", func(t *testing.T) {
 		cli := New(&Options{Enabled: true})
+		assert.Equal(t, false, cli.SecureSocksProxyEnabled())
+	})
+	t.Run("enabled, if Enabled field is true", func(t *testing.T) {
+		cli := New(&Options{Enabled: true, ClientCfg: &ClientCfg{}})
 		assert.Equal(t, true, cli.SecureSocksProxyEnabled())
 	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

When I was adding PDC support for some AWS data sources, it didn't look like `p.opts` was ever `nil` [when checking whether the secure socks proxy should be enabled](https://github.com/grafana/grafana-plugin-sdk-go/blob/01217aeec5ce34cc87085f0656ea31438d9ed359/backend/proxy/secure_socks_proxy.go#L86). It looks like it's [always set](https://github.com/grafana/grafana-plugin-sdk-go/blob/01217aeec5ce34cc87085f0656ea31438d9ed359/backend/common.go#L148), at least for the path that our data sources goes through.

This PR checks for the presence of a `clientCfg` in addition to checking if the proxy options are available as the `clientCfg` [doesn't get set if secure socks proxy is not enabled](https://github.com/grafana/grafana-plugin-sdk-go/blob/01217aeec5ce34cc87085f0656ea31438d9ed359/backend/config.go#L180) in Grafana.

I was running into an edge case where I enabled the secure socks proxy in my `custom.ini` as described [here](https://wiki.grafana-ops.net/w/index.php/Engineering/Grafana/Data_Sources/API_servers/Testing_datasources_with_PDC_Locally), then enabled the secure socks proxy for my data source, then disabled the secure socks proxy in my  `custom.ini` again. Since the data source still had the secure socks proxy setting enabled, I was hitting this [error](https://github.com/grafana/grafana-plugin-sdk-go/blob/01217aeec5ce34cc87085f0656ea31438d9ed359/backend/proxy/secure_socks_proxy.go#L124) because `p.opts` was never nil and the data source's settings still had the secure socks proxy setting [enabled](https://github.com/grafana/grafana-plugin-sdk-go/blob/01217aeec5ce34cc87085f0656ea31438d9ed359/backend/common.go#L319).

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
