### PR TITLE
Fix missing info severity level in JSON for notices in frame meta

### DIFF
--- a/data/frame_meta.go
+++ b/data/frame_meta.go
@@ -126,7 +126,7 @@ type QueryStat struct {
 // Notice provides a structure for presenting notifications in Grafana's user interface.
 type Notice struct {
 	// Severity is the severity level of the notice: info, warning, or error.
-	Severity NoticeSeverity `json:"severity,omitempty"`
+	Severity NoticeSeverity `json:"severity"`
 
 	// Text is freeform descriptive text for the notice.
 	Text string `json:"text"`

--- a/data/frame_meta_test.go
+++ b/data/frame_meta_test.go
@@ -36,7 +36,7 @@ func TestJSONNotice(t *testing.T) {
 				Severity: NoticeSeverityInfo,
 				Text:     "Some text",
 			},
-			json: `{"text":"Some text"}`,
+			json: `{"severity":"info","text":"Some text"}`,
 		},
 	}
 	for i := range tests {

--- a/data/frame_meta_test.go
+++ b/data/frame_meta_test.go
@@ -15,12 +15,28 @@ func TestJSONNotice(t *testing.T) {
 		json   string
 	}{
 		{
-			name: "notice with severity and text",
+			name: "notice with error severity and text",
 			notice: Notice{
 				Severity: NoticeSeverityError,
 				Text:     "Some text",
 			},
 			json: `{"severity":"error","text":"Some text"}`,
+		},
+		{
+			name: "notice with warning severity and text",
+			notice: Notice{
+				Severity: NoticeSeverityWarning,
+				Text:     "Some text",
+			},
+			json: `{"severity":"warning","text":"Some text"}`,
+		},
+		{
+			name: "notice with info severity and text",
+			notice: Notice{
+				Severity: NoticeSeverityInfo,
+				Text:     "Some text",
+			},
+			json: `{"text":"Some text"}`,
 		},
 	}
 	for i := range tests {

--- a/experimental/testdata/frame-non-custom-meta.golden.jsonc
+++ b/experimental/testdata/frame-non-custom-meta.golden.jsonc
@@ -7,6 +7,7 @@
 //      ],
 //      "notices": [
 //          {
+//              "severity": "info",
 //              "text": "hello"
 //          }
 //      ],
@@ -56,6 +57,7 @@
           ],
           "notices": [
             {
+              "severity": "info",
               "text": "hello"
             }
           ],

--- a/experimental/testdata/frame-non-custom-meta.golden.txt
+++ b/experimental/testdata/frame-non-custom-meta.golden.txt
@@ -3,6 +3,7 @@
 Frame[0] {
     "notices": [
         {
+            "severity": "info",
             "text": "hello"
         }
     ],


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, if the severity level of a notice in frame meta is set to `NoticeSeverityInfo`, it will go missing in JSON due to `omitempty` as its value is 0 (iota). You can see this in the expanded unit test `TestJSONNotice` in the first commit. The second commit fixes that by removing `omitempty` and updates the test accordingly so we can preserve `"severity":"info"` in the JSON.

This only became relevant recently now that we are passing on info annotations from Prometheus and marking them separately from warnings in Grafana, see the PR below.

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/grafana/pull/97978

**Special notes for your reviewer**:
