### PR TITLE
backend: fix unmarshaling empty refids

### DIFF
--- a/backend/json_test.go
+++ b/backend/json_test.go
@@ -143,3 +143,39 @@ func TestQueryDataResponseOrdering(t *testing.T) {
 
 	require.JSONEq(t, expected, string(b))
 }
+
+func testQueryDataResponseRoundtrip(t *testing.T, qdr *backend.QueryDataResponse) {
+	t.Helper()
+	// to json
+	b, err := json.Marshal(qdr)
+	require.NoError(t, err)
+
+	// from json
+	qdr2 := &backend.QueryDataResponse{}
+	err = json.Unmarshal(b, qdr2)
+	require.NoError(t, err)
+
+	// to json again, to compare
+	b2, err := json.Marshal(qdr2)
+	require.NoError(t, err)
+	require.Equal(t, b2, b)
+}
+
+func TestQueryDataWithoutRefID(t *testing.T) {
+	qdr := backend.NewQueryDataResponse()
+	qdr.Responses[""] = testDataResponse()
+
+	testQueryDataResponseRoundtrip(t, qdr)
+}
+
+func TestQueryDataWithtRefID(t *testing.T) {
+	qdr := backend.NewQueryDataResponse()
+	qdr.Responses["A"] = testDataResponse()
+
+	testQueryDataResponseRoundtrip(t, qdr)
+}
+
+func TestQueryDataWithoutResponses(t *testing.T) {
+	qdr := backend.NewQueryDataResponse()
+	testQueryDataResponseRoundtrip(t, qdr)
+}


### PR DESCRIPTION
fixes https://github.com/grafana/grafana-plugin-sdk-go/issues/1177

sometimes a response in a `backend.QueryDataResponse` has no refId (the refId is `""`).
this is technically not allowed, but we need to be able to handle the situation, otherwise we just error out with a cryptic error message.
