### PR TITLE
backend: QueryDataResponse unmarshal: empty refId case signaled explicitly

### DIFF
--- a/backend/json.go
+++ b/backend/json.go
@@ -149,10 +149,27 @@ func readQueryDataResultsJSON(qdr *QueryDataResponse, iter *jsoniter.Iterator) {
 
 			qdr.Responses = make(Responses)
 
-			for l2Field := iter.ReadObject(); l2Field != ""; l2Field = iter.ReadObject() {
+			l2Field := iter.ReadObject()
+			for {
+				// the response may have an empty-string refId. this is not allowed,
+				// but it may happen, and we want to be able to handle the case.
+				// jsonIter uses empty-string to signalize both of these cases:
+				// - end of object
+				// - key found with the value empty-string
+				// to be able to differentiate between these two cases, we use the `WhatIsNext()`
+				// function, that tells us what is coming next, but does not consume content.
+				if l2Field == "" {
+					if iter.WhatIsNext() == jsoniter.ObjectValue {
+						iter.ReportError("read results", "empty refId found")
+					}
+					break
+				}
+
 				dr := DataResponse{}
 				readDataResponseJSON(&dr, iter)
 				qdr.Responses[l2Field] = dr
+
+				l2Field = iter.ReadObject()
 			}
 
 		default:

--- a/backend/json_test.go
+++ b/backend/json_test.go
@@ -143,3 +143,15 @@ func TestQueryDataResponseOrdering(t *testing.T) {
 
 	require.JSONEq(t, expected, string(b))
 }
+
+func TestQueryDataWithoutRefID(t *testing.T) {
+	qdr := backend.NewQueryDataResponse()
+	qdr.Responses[""] = testDataResponse()
+	b, err := json.Marshal(qdr)
+	require.NoError(t, err)
+
+	respCopy := &backend.QueryDataResponse{}
+	//Now unmarshall without a refId
+	err = json.Unmarshal(b, respCopy)
+	require.ErrorContains(t, err, "empty refId found")
+}


### PR DESCRIPTION
WIP