### PR TITLE
Mark EOF errors coming from http request as downstream

### DIFF
--- a/experimental/status/status_source.go
+++ b/experimental/status/status_source.go
@@ -204,7 +204,7 @@ func isTLSCertificateVerificationError(err error) bool {
 	return false
 }
 
-// IsEOFError returns true if the error is an EOF error,indicating the connection was closed prematurely by server
+// isHTTPEOFError returns true if the error is an EOF error inside of url.Error or net.OpError, indicating the connection was closed prematurely by server
 func isHTTPEOFError(err error) bool {
 	var netErr *net.OpError
 	if errors.As(err, &netErr) {

--- a/experimental/status/status_source.go
+++ b/experimental/status/status_source.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -142,7 +143,8 @@ func IsDownstreamHTTPError(err error) bool {
 	return IsDownstreamError(err) ||
 		isConnectionResetOrRefusedError(err) ||
 		isDNSNotFoundError(err) ||
-		isTLSCertificateVerificationError(err)
+		isTLSCertificateVerificationError(err) ||
+		isEOFError(err)
 }
 
 // InCancelledError returns true if err is context.Canceled or is gRPC status Canceled.
@@ -200,6 +202,11 @@ func isTLSCertificateVerificationError(err error) bool {
 	}
 
 	return false
+}
+
+// IsEOFError returns true if the error is an EOF error,indicating the connection was closed before or during header reading.
+func isEOFError(err error) bool {
+	return errors.Is(err, io.EOF)
 }
 
 type sourceCtxKey struct{}

--- a/experimental/status/status_source.go
+++ b/experimental/status/status_source.go
@@ -204,7 +204,7 @@ func isTLSCertificateVerificationError(err error) bool {
 	return false
 }
 
-// IsEOFError returns true if the error is an EOF error,indicating the connection was closed before or during header reading.
+// IsEOFError returns true if the error is an EOF error,indicating the connection was closed prematurely by server
 func isEOFError(err error) bool {
 	return errors.Is(err, io.EOF)
 }

--- a/experimental/status/status_source_test.go
+++ b/experimental/status/status_source_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -246,6 +247,26 @@ func TestIsDownstreamHTTPError(t *testing.T) {
 		{
 			name:     "direct UnknownAuthorityError",
 			err:      x509.UnknownAuthorityError{},
+			expected: true,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "io.EOF error",
+			err:      io.EOF,
+			expected: true,
+		},
+		{
+			name:     "wrapped io.EOF error",
+			err:      fmt.Errorf("wrapped: %w", io.EOF),
+			expected: true,
+		},
+		{
+			name:     "joined error with io.EOF",
+			err:      errors.Join(io.EOF, fmt.Errorf("another error")),
 			expected: true,
 		},
 	}

--- a/experimental/status/status_source_test.go
+++ b/experimental/status/status_source_test.go
@@ -257,16 +257,26 @@ func TestIsDownstreamHTTPError(t *testing.T) {
 		{
 			name:     "io.EOF error",
 			err:      io.EOF,
+			expected: false,
+		},
+		{
+			name:     "url io.EOF error",
+			err:      &url.Error{Op: "Get", URL: "https://example.com", Err: io.EOF},
 			expected: true,
 		},
 		{
-			name:     "wrapped io.EOF error",
-			err:      fmt.Errorf("wrapped: %w", io.EOF),
+			name:     "net op io.EOF error",
+			err:      &net.OpError{Err: io.EOF},
+			expected: true,
+		},
+		{
+			name:     "wrapped url io.EOF error",
+			err:      fmt.Errorf("wrapped: %w", &url.Error{Op: "Get", URL: "https://example.com", Err: io.EOF}),
 			expected: true,
 		},
 		{
 			name:     "joined error with io.EOF",
-			err:      errors.Join(io.EOF, fmt.Errorf("another error")),
+			err:      errors.Join(io.EOF, &url.Error{Op: "Get", URL: "https://example.com", Err: io.EOF}),
 			expected: true,
 		},
 	}


### PR DESCRIPTION
EOF from http request is a common error happening for data source plugins. EOF happens  when connection is closed prematurely by server. This error should be downstream. 

Example: https://ops.grafana-ops.net/goto/zUkcXODHR?orgId=1
<img width="1904" alt="image" src="https://github.com/user-attachments/assets/c4824329-6c9b-487f-9801-8d34626932ec" />
