### PR TITLE
Skip empty headers key if they present in the `opts.Headers`

### DIFF
--- a/backend/httpclient/custom_headers_middleware.go
+++ b/backend/httpclient/custom_headers_middleware.go
@@ -18,6 +18,10 @@ func CustomHeadersMiddleware() Middleware {
 
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			for key, values := range opts.Header {
+				// Skip empty keys as they are not allowed
+				if key == "" {
+					continue
+				}
 				// According to https://pkg.go.dev/net/http#Request.Header, Host is a special case
 				if http.CanonicalHeaderKey(key) == "Host" {
 					req.Host = values[0]

--- a/backend/httpclient/custom_headers_middleware_test.go
+++ b/backend/httpclient/custom_headers_middleware_test.go
@@ -135,7 +135,6 @@ func TestCustomHeadersMiddleware(t *testing.T) {
 		}
 		require.Len(t, ctx.callChain, 1)
 		require.ElementsMatch(t, []string{"final"}, ctx.callChain)
-
-		require.Empty(t, req.Header.Values(""))
+		require.Equal(t, 0, len(req.Header))
 	})
 }

--- a/backend/httpclient/custom_headers_middleware_test.go
+++ b/backend/httpclient/custom_headers_middleware_test.go
@@ -112,4 +112,30 @@ func TestCustomHeadersMiddleware(t *testing.T) {
 
 		require.Equal(t, []string{"ValueOne"}, req.Header.Values("X-Headerone"))
 	})
+
+	t.Run("With empty key should skip adding the header", func(t *testing.T) {
+		ctx := &testContext{}
+		finalRoundTripper := ctx.createRoundTripper("final")
+		customHeaders := CustomHeadersMiddleware()
+		rt := customHeaders.CreateMiddleware(Options{Header: http.Header{
+			"": {"ValueOne"},
+		}}, finalRoundTripper)
+		require.NotNil(t, rt)
+		middlewareName, ok := customHeaders.(MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, CustomHeadersMiddlewareName, middlewareName.MiddlewareName())
+
+		req, err := http.NewRequest(http.MethodGet, "http://", nil)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		if res.Body != nil {
+			require.NoError(t, res.Body.Close())
+		}
+		require.Len(t, ctx.callChain, 1)
+		require.ElementsMatch(t, []string{"final"}, ctx.callChain)
+
+		require.Empty(t, req.Header.Values(""))
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updated the logic in the `CustomHeadersMiddleware`. The issue may happen when user created datasource with the empty headers value when setting `Custom HTTP Headers`.

**Which issue(s) this PR fixes**:
Related issue: https://github.com/grafana/grafana-plugin-sdk-go/issues/1202

Fixes #

**Special notes for your reviewer**:
