### PR TITLE
data: Add NilAt method to Field and Frame

### DIFF
--- a/data/field.go
+++ b/data/field.go
@@ -173,6 +173,15 @@ func (f *Field) At(idx int) interface{} {
 	return f.vector.At(idx)
 }
 
+// NilAt returns true if the element at index idx of the Field is nil.
+// This is useful since the interface returned by At() will not be nil
+// even if the underlying element is nil (without an type assertion).
+// It will always return false if the Field is not nullable.
+// It can panic if idx is out of range.
+func (f *Field) NilAt(idx int) bool {
+	return f.vector.NilAt(idx)
+}
+
 // Len returns the number of elements in the Field.
 // It will return 0 if the field is nil.
 func (f *Field) Len() int {

--- a/data/field_test.go
+++ b/data/field_test.go
@@ -79,6 +79,19 @@ func TestFieldLen(t *testing.T) {
 	require.Equal(t, 0, f.Len())
 }
 
+func TestFieldNilAt(t *testing.T) {
+	f := data.NewField("value", nil, []*float64{nil, float64Ptr(1)})
+
+	require.True(t, f.NilAt(0))
+	require.False(t, f.At(0) == nil) // Why we have NilAt()
+	require.False(t, f.NilAt(1))
+
+	f = data.NewField("value", nil, []string{"", "foo"})
+	require.False(t, f.NilAt(1))
+	require.False(t, f.NilAt(2))
+	require.False(t, f.NilAt(77))
+}
+
 func TestField_String(t *testing.T) {
 	field := data.NewField("value", nil, make([]*string, 3))
 

--- a/data/field_type_enum.go
+++ b/data/field_type_enum.go
@@ -36,7 +36,7 @@ func (v *enumVector) At(i int) interface{} {
 	return (*v)[i]
 }
 
-func (v *enumVector) NilAt(i int) bool {
+func (v *enumVector) NilAt(_ int) bool {
 	return false
 }
 

--- a/data/field_type_enum.go
+++ b/data/field_type_enum.go
@@ -36,6 +36,10 @@ func (v *enumVector) At(i int) interface{} {
 	return (*v)[i]
 }
 
+func (v *enumVector) NilAt(i int) bool {
+	return false
+}
+
 func (v *enumVector) PointerAt(i int) interface{} {
 	return &(*v)[i]
 }
@@ -113,6 +117,10 @@ func (v *nullableEnumVector) Append(i interface{}) {
 
 func (v *nullableEnumVector) At(i int) interface{} {
 	return (*v)[i]
+}
+
+func (v *nullableEnumVector) NilAt(i int) bool {
+	return (*v)[i] == nil
 }
 
 func (v *nullableEnumVector) CopyAt(i int) interface{} {

--- a/data/frame.go
+++ b/data/frame.go
@@ -240,6 +240,12 @@ func (f *Frame) Rows() int {
 	return 0
 }
 
+// NilAt returns true if the element at fieldIdx and rowIdx is nil.
+// It will panic if either fieldIdx or rowIdx are out of range.
+func (f *Frame) NilAt(fieldIdx int, rowIdx int) bool {
+	return f.Fields[fieldIdx].vector.NilAt(rowIdx)
+}
+
 // At returns the value of the specified fieldIdx and rowIdx.
 // It will panic if either fieldIdx or rowIdx are out of range.
 func (f *Frame) At(fieldIdx int, rowIdx int) interface{} {

--- a/data/generic_nullable_vector.go
+++ b/data/generic_nullable_vector.go
@@ -34,6 +34,10 @@ func (v *nullablegenVector) Append(i interface{}) {
 	*v = append(*v, i.(*gen))
 }
 
+func (v *nullablegenVector) NilAt(i int) bool {
+	return (*v)[i] == nil
+}
+
 func (v *nullablegenVector) At(i int) interface{} {
 	return (*v)[i]
 }

--- a/data/generic_vector.go
+++ b/data/generic_vector.go
@@ -31,6 +31,10 @@ func (v *genVector) Append(i interface{}) {
 	*v = append(*v, i.(gen))
 }
 
+func (v *genVector) NilAt(i int) bool {
+	return false
+}
+
 func (v *genVector) At(i int) interface{} {
 	return (*v)[i]
 }

--- a/data/nullable_vector.gen.go
+++ b/data/nullable_vector.gen.go
@@ -43,6 +43,10 @@ func (v *nullableUint8Vector) Append(i interface{}) {
 	*v = append(*v, i.(*uint8))
 }
 
+func (v *nullableUint8Vector) NilAt(i int) bool {
+	return (*v)[i] == nil
+}
+
 func (v *nullableUint8Vector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -132,6 +136,10 @@ func (v *nullableUint16Vector) Append(i interface{}) {
 		return
 	}
 	*v = append(*v, i.(*uint16))
+}
+
+func (v *nullableUint16Vector) NilAt(i int) bool {
+	return (*v)[i] == nil
 }
 
 func (v *nullableUint16Vector) At(i int) interface{} {
@@ -225,6 +233,10 @@ func (v *nullableUint32Vector) Append(i interface{}) {
 	*v = append(*v, i.(*uint32))
 }
 
+func (v *nullableUint32Vector) NilAt(i int) bool {
+	return (*v)[i] == nil
+}
+
 func (v *nullableUint32Vector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -314,6 +326,10 @@ func (v *nullableUint64Vector) Append(i interface{}) {
 		return
 	}
 	*v = append(*v, i.(*uint64))
+}
+
+func (v *nullableUint64Vector) NilAt(i int) bool {
+	return (*v)[i] == nil
 }
 
 func (v *nullableUint64Vector) At(i int) interface{} {
@@ -407,6 +423,10 @@ func (v *nullableInt8Vector) Append(i interface{}) {
 	*v = append(*v, i.(*int8))
 }
 
+func (v *nullableInt8Vector) NilAt(i int) bool {
+	return (*v)[i] == nil
+}
+
 func (v *nullableInt8Vector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -496,6 +516,10 @@ func (v *nullableInt16Vector) Append(i interface{}) {
 		return
 	}
 	*v = append(*v, i.(*int16))
+}
+
+func (v *nullableInt16Vector) NilAt(i int) bool {
+	return (*v)[i] == nil
 }
 
 func (v *nullableInt16Vector) At(i int) interface{} {
@@ -589,6 +613,10 @@ func (v *nullableInt32Vector) Append(i interface{}) {
 	*v = append(*v, i.(*int32))
 }
 
+func (v *nullableInt32Vector) NilAt(i int) bool {
+	return (*v)[i] == nil
+}
+
 func (v *nullableInt32Vector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -678,6 +706,10 @@ func (v *nullableInt64Vector) Append(i interface{}) {
 		return
 	}
 	*v = append(*v, i.(*int64))
+}
+
+func (v *nullableInt64Vector) NilAt(i int) bool {
+	return (*v)[i] == nil
 }
 
 func (v *nullableInt64Vector) At(i int) interface{} {
@@ -771,6 +803,10 @@ func (v *nullableFloat32Vector) Append(i interface{}) {
 	*v = append(*v, i.(*float32))
 }
 
+func (v *nullableFloat32Vector) NilAt(i int) bool {
+	return (*v)[i] == nil
+}
+
 func (v *nullableFloat32Vector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -860,6 +896,10 @@ func (v *nullableFloat64Vector) Append(i interface{}) {
 		return
 	}
 	*v = append(*v, i.(*float64))
+}
+
+func (v *nullableFloat64Vector) NilAt(i int) bool {
+	return (*v)[i] == nil
 }
 
 func (v *nullableFloat64Vector) At(i int) interface{} {
@@ -953,6 +993,10 @@ func (v *nullableStringVector) Append(i interface{}) {
 	*v = append(*v, i.(*string))
 }
 
+func (v *nullableStringVector) NilAt(i int) bool {
+	return (*v)[i] == nil
+}
+
 func (v *nullableStringVector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -1042,6 +1086,10 @@ func (v *nullableBoolVector) Append(i interface{}) {
 		return
 	}
 	*v = append(*v, i.(*bool))
+}
+
+func (v *nullableBoolVector) NilAt(i int) bool {
+	return (*v)[i] == nil
 }
 
 func (v *nullableBoolVector) At(i int) interface{} {
@@ -1135,6 +1183,10 @@ func (v *nullableTimeTimeVector) Append(i interface{}) {
 	*v = append(*v, i.(*time.Time))
 }
 
+func (v *nullableTimeTimeVector) NilAt(i int) bool {
+	return (*v)[i] == nil
+}
+
 func (v *nullableTimeTimeVector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -1224,6 +1276,10 @@ func (v *nullableJsonRawMessageVector) Append(i interface{}) {
 		return
 	}
 	*v = append(*v, i.(*json.RawMessage))
+}
+
+func (v *nullableJsonRawMessageVector) NilAt(i int) bool {
+	return (*v)[i] == nil
 }
 
 func (v *nullableJsonRawMessageVector) At(i int) interface{} {

--- a/data/vector.gen.go
+++ b/data/vector.gen.go
@@ -34,6 +34,10 @@ func (v *uint8Vector) Append(i interface{}) {
 	*v = append(*v, i.(uint8))
 }
 
+func (v *uint8Vector) NilAt(i int) bool {
+	return false
+}
+
 func (v *uint8Vector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -104,6 +108,10 @@ func (v *uint16Vector) SetConcrete(idx int, i interface{}) {
 
 func (v *uint16Vector) Append(i interface{}) {
 	*v = append(*v, i.(uint16))
+}
+
+func (v *uint16Vector) NilAt(i int) bool {
+	return false
 }
 
 func (v *uint16Vector) At(i int) interface{} {
@@ -178,6 +186,10 @@ func (v *uint32Vector) Append(i interface{}) {
 	*v = append(*v, i.(uint32))
 }
 
+func (v *uint32Vector) NilAt(i int) bool {
+	return false
+}
+
 func (v *uint32Vector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -248,6 +260,10 @@ func (v *uint64Vector) SetConcrete(idx int, i interface{}) {
 
 func (v *uint64Vector) Append(i interface{}) {
 	*v = append(*v, i.(uint64))
+}
+
+func (v *uint64Vector) NilAt(i int) bool {
+	return false
 }
 
 func (v *uint64Vector) At(i int) interface{} {
@@ -322,6 +338,10 @@ func (v *int8Vector) Append(i interface{}) {
 	*v = append(*v, i.(int8))
 }
 
+func (v *int8Vector) NilAt(i int) bool {
+	return false
+}
+
 func (v *int8Vector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -392,6 +412,10 @@ func (v *int16Vector) SetConcrete(idx int, i interface{}) {
 
 func (v *int16Vector) Append(i interface{}) {
 	*v = append(*v, i.(int16))
+}
+
+func (v *int16Vector) NilAt(i int) bool {
+	return false
 }
 
 func (v *int16Vector) At(i int) interface{} {
@@ -466,6 +490,10 @@ func (v *int32Vector) Append(i interface{}) {
 	*v = append(*v, i.(int32))
 }
 
+func (v *int32Vector) NilAt(i int) bool {
+	return false
+}
+
 func (v *int32Vector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -536,6 +564,10 @@ func (v *int64Vector) SetConcrete(idx int, i interface{}) {
 
 func (v *int64Vector) Append(i interface{}) {
 	*v = append(*v, i.(int64))
+}
+
+func (v *int64Vector) NilAt(i int) bool {
+	return false
 }
 
 func (v *int64Vector) At(i int) interface{} {
@@ -610,6 +642,10 @@ func (v *float32Vector) Append(i interface{}) {
 	*v = append(*v, i.(float32))
 }
 
+func (v *float32Vector) NilAt(i int) bool {
+	return false
+}
+
 func (v *float32Vector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -680,6 +716,10 @@ func (v *float64Vector) SetConcrete(idx int, i interface{}) {
 
 func (v *float64Vector) Append(i interface{}) {
 	*v = append(*v, i.(float64))
+}
+
+func (v *float64Vector) NilAt(i int) bool {
+	return false
 }
 
 func (v *float64Vector) At(i int) interface{} {
@@ -754,6 +794,10 @@ func (v *stringVector) Append(i interface{}) {
 	*v = append(*v, i.(string))
 }
 
+func (v *stringVector) NilAt(i int) bool {
+	return false
+}
+
 func (v *stringVector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -824,6 +868,10 @@ func (v *boolVector) SetConcrete(idx int, i interface{}) {
 
 func (v *boolVector) Append(i interface{}) {
 	*v = append(*v, i.(bool))
+}
+
+func (v *boolVector) NilAt(i int) bool {
+	return false
 }
 
 func (v *boolVector) At(i int) interface{} {
@@ -898,6 +946,10 @@ func (v *timeTimeVector) Append(i interface{}) {
 	*v = append(*v, i.(time.Time))
 }
 
+func (v *timeTimeVector) NilAt(i int) bool {
+	return false
+}
+
 func (v *timeTimeVector) At(i int) interface{} {
 	return (*v)[i]
 }
@@ -968,6 +1020,10 @@ func (v *jsonRawMessageVector) SetConcrete(idx int, i interface{}) {
 
 func (v *jsonRawMessageVector) Append(i interface{}) {
 	*v = append(*v, i.(json.RawMessage))
+}
+
+func (v *jsonRawMessageVector) NilAt(i int) bool {
+	return false
 }
 
 func (v *jsonRawMessageVector) At(i int) interface{} {

--- a/data/vector.go
+++ b/data/vector.go
@@ -10,6 +10,7 @@ type vector interface {
 	Append(i interface{})
 	Extend(i int)
 	At(i int) interface{}
+	NilAt(i int) bool
 	Len() int
 	Type() FieldType
 	PointerAt(i int) interface{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the `NilAt(i int) bool` method to `Field`.

```
// NilAt returns true if the element at index idx of the Field is nil.
// This is useful since the interface returned by At() will not be nil
// even if the underlying element is nil (without an type assertion).
// It will always return false if the Field is not nullable.
// It can panic if idx is out of range.
func (f *Field) NilAt(idx int) bool {
	return f.vector.NilAt(idx)
}
```

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
