### PR TITLE
codeowners: change ownership of /data/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@
 # these will be requested for review when someone opens a pull request.
 * @grafana/plugins-platform-backend
 /backend/gtime @grafana/observability-metrics @grafana/observability-logs @grafana/partner-datasources
-/data/ @grafana/data-plane-wg
+/data/ @grafana/grafana-datasources-core-services
 /data/sqlutil @grafana/oss-big-tent


### PR DESCRIPTION
i think a real squad is a better codeowner than a working group. wdyt?