### PR TITLE
go.mod: update go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/grafana-plugin-sdk-go
 
-go 1.22.7
-
-toolchain go1.23.3
+go 1.23.5
 
 require (
 	github.com/apache/arrow-go/v18 v18.0.1-0.20241212180703-82be143d7c30


### PR DESCRIPTION
updates go to the latest released version (well, go `1.23.0` was released half a year ago, but `1.23.5` is the latest patch-version).

`go mod tidy` deleted the `toolchain` directive.