### PR TITLE
experimental: query: sort keys in json-marshal

### DIFF
--- a/experimental/apis/data/v0alpha1/query.go
+++ b/experimental/apis/data/v0alpha1/query.go
@@ -3,6 +3,8 @@ package v0alpha1
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"strconv"
 	"unsafe"
 
@@ -309,7 +311,11 @@ func writeQuery(g *DataQuery, stream *j.Stream) {
 
 	// The additional properties
 	if g.additional != nil {
-		for k, v := range g.additional {
+		// we must sort the map-keys to always produce the same JSON
+		keys := slices.Sorted(maps.Keys(g.additional))
+
+		for _, k := range keys {
+			v := g.additional[k]
 			stream.WriteMore()
 			stream.WriteObjectField(k)
 			stream.WriteVal(v)

--- a/experimental/apis/data/v0alpha1/query_test.go
+++ b/experimental/apis/data/v0alpha1/query_test.go
@@ -7,6 +7,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSerializeAdditionalQueryFieldsOrdered(t *testing.T) {
+	q := DataQuery{
+		CommonQueryProperties: CommonQueryProperties{
+			RefID:         "A",
+			MaxDataPoints: 10,
+			IntervalMS:    500,
+		},
+		additional: map[string]any{
+			"utcOffsetSec": 3600,
+			"exemplar":     false,
+			"instant":      false,
+			"range":        true,
+			"editorMode":   "code",
+			"legendFormat": "__auto",
+		},
+	}
+	jsonBytes, err := json.Marshal(q)
+	require.NoError(t, err)
+	// NOTE: we cannot use require.JSONEq() here,
+	// because we want to make sure the object-keys
+	// are ordered
+	expectedBytes := []byte(`{"refId":"A","maxDataPoints":10,"intervalMs":500,"editorMode":"code","exemplar":false,"instant":false,"legendFormat":"__auto","range":true,"utcOffsetSec":3600}`)
+	require.Equal(t, expectedBytes, jsonBytes)
+}
+
 func TestParseQueriesIntoQueryDataRequest(t *testing.T) {
 	request := []byte(`{
 		"queries": [


### PR DESCRIPTION
currently, when a `DataQuery` is serialized to JSON, if you do it twice, you may get two different JSONs, because in go map-iteration-order is not fixed. to always generate the same JSON, we need to sort the keys before we serialize them.