### PR TITLE
CODEOWENERS: update ownership of /experimental/apis/data

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,5 @@
 * @grafana/plugins-platform-backend
 /backend/gtime @grafana/observability-metrics @grafana/observability-logs @grafana/partner-datasources
 /data/ @grafana/grafana-datasources-core-services
+/experimental/apis/data @grafana/grafana-datasources-core-services
 /data/sqlutil @grafana/oss-big-tent


### PR DESCRIPTION
the core-services squad already owns the `/data` folder, so it should probably also own `/experimental/apis/data`.