### PR TITLE
SQL utils: Fix error source when unmarhsaling invalid query object

### DIFF
--- a/data/sqlutil/query.go
+++ b/data/sqlutil/query.go
@@ -71,7 +71,7 @@ func GetQuery(query backend.DataQuery) (*Query, error) {
 	model := &Query{}
 
 	if err := json.Unmarshal(query.JSON, &model); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrorJSON, err)
+		return nil, backend.DownstreamError(fmt.Errorf("%w: %v", ErrorJSON, err))
 	}
 
 	// Copy directly from the well typed query


### PR DESCRIPTION
This utility is used in SQL data sources to process `backend.DataQuery.JSON` into a query object. If the provided JSON is incorrect, it results in a downstream error, as an invalid query was sent to the data source plugin.