### PR TITLE
Export conversion error `ErrorUnexpectedTypeConversion`

### DIFF
--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -14,7 +14,6 @@ import (
 
 var ErrorUnexpectedTypeConversionError = errors.New("conversion error")
 
-
 // FrameConverter defines how to convert the scanned value into a value that can be put into a dataframe (OutputFieldType)
 type FrameConverter struct {
 	// FieldType is the type that is created for the dataframe field.

--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
-var ErrorUnexpectedTypeConversionError = errors.New("conversion error")
+var ErrorUnexpectedTypeConversion = errors.New("conversion error")
 
 // FrameConverter defines how to convert the scanned value into a value that can be put into a dataframe (OutputFieldType)
 type FrameConverter struct {
@@ -455,5 +455,5 @@ var TimeToNullableTime = data.FieldConverter{
 
 func toConversionError(expected string, v interface{}) error {
 	return fmt.Errorf(`%w, expected %s input but got type %T for value "%v"`,
-		ErrorUnexpectedTypeConversionError, expected, v, v)
+		ErrorUnexpectedTypeConversion, expected, v, v)
 }

--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -2,6 +2,7 @@ package sqlutil
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -10,6 +11,9 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
+
+var ErrorUnexpectedTypeConversionError = errors.New("conversion error")
+
 
 // FrameConverter defines how to convert the scanned value into a value that can be put into a dataframe (OutputFieldType)
 type FrameConverter struct {
@@ -451,5 +455,6 @@ var TimeToNullableTime = data.FieldConverter{
 }
 
 func toConversionError(expected string, v interface{}) error {
-	return fmt.Errorf(`expected %s input but got type %T for value "%v"`, expected, v, v)
+	return fmt.Errorf(`%w, expected %s input but got type %T for value "%v"`,
+		ErrorUnexpectedTypeConversionError, expected, v, v)
 }


### PR DESCRIPTION
Export `ErrorUnexpectedTypeConversion` error so we can use it in [isProcessingDownstreamError](https://github.com/grafana/sqlds/blob/main/query.go#L244) to check for this downstream error.