### PR TITLE
Implement `PluginErrorf`

### DIFF
--- a/backend/error_source.go
+++ b/backend/error_source.go
@@ -64,6 +64,12 @@ func DownstreamErrorf(format string, a ...any) error {
 	return DownstreamError(fmt.Errorf(format, a...))
 }
 
+// PluginErrorf creates a new error with status [ErrorSourcePlugin] and formats
+// according to a format specifier and returns the string as a value that satisfies error.
+func PluginErrorf(format string, a ...any) error {
+	return PluginError(fmt.Errorf(format, a...))
+}
+
 // ErrorSourceFromContext returns the error source stored in the context.
 // If no error source is stored in the context, [DefaultErrorSource] is returned.
 func ErrorSourceFromContext(ctx context.Context) ErrorSource {

--- a/experimental/status/status_source.go
+++ b/experimental/status/status_source.go
@@ -91,6 +91,12 @@ func DownstreamErrorf(format string, a ...any) error {
 	return DownstreamError(fmt.Errorf(format, a...))
 }
 
+// PluginErrorf creates a new error with status [ErrorSourcePlugin] and formats
+// according to a format specifier and returns the string as a value that satisfies error.
+func PluginErrorf(format string, a ...any) error {
+	return PluginError(fmt.Errorf(format, a...))
+}
+
 func (e ErrorWithSource) ErrorSource() Source {
 	return e.source
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements the `PluginErrorf` function, which works similarly to [`DownstreamErrorf`](https://github.com/grafana/grafana-plugin-sdk-go/blob/c6d2cafc9f34943ad3e107d8bfc641e1e6908a7c/experimental/status/status_source.go#L90-L92).


