### PR TITLE
backend: improve ParseIntervalStringToTimeDuration method performance in gtime package by ~93%

### DIFF
--- a/backend/gtime/gtime.go
+++ b/backend/gtime/gtime.go
@@ -171,9 +171,15 @@ func ParseIntervalStringToTimeDuration(interval string) (time.Duration, error) {
 			break
 		}
 	}
+
 	if isPureNum {
-		formattedInterval += "s"
+		num, err := strconv.ParseInt(formattedInterval, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(num) * time.Second, nil
 	}
+
 	parsedInterval, err := ParseDuration(formattedInterval)
 	if err != nil {
 		return time.Duration(0), err

--- a/backend/gtime/gtime.go
+++ b/backend/gtime/gtime.go
@@ -151,13 +151,19 @@ func GetIntervalFrom(dsInterval, queryInterval string, queryIntervalMS int64, de
 	return parsedInterval, nil
 }
 
-var isPureNumRegex = regexp.MustCompile(`^\d+$`)
-
 // ParseIntervalStringToTimeDuration converts a string representation of a expected (i.e. 1m30s) to time.Duration
 // this method copied from grafana/grafana/pkg/tsdb/intervalv2.go
 func ParseIntervalStringToTimeDuration(interval string) (time.Duration, error) {
 	formattedInterval := strings.Replace(strings.Replace(interval, "<", "", 1), ">", "", 1)
-	isPureNum := isPureNumRegex.MatchString(formattedInterval)
+
+	// Check if string contains only digits
+	isPureNum := true
+	for _, c := range formattedInterval {
+		if c < '0' || c > '9' {
+			isPureNum = false
+			break
+		}
+	}
 	if isPureNum {
 		formattedInterval += "s"
 	}

--- a/backend/gtime/gtime.go
+++ b/backend/gtime/gtime.go
@@ -153,34 +153,37 @@ func GetIntervalFrom(dsInterval, queryInterval string, queryIntervalMS int64, de
 // ParseIntervalStringToTimeDuration converts a string representation of a expected (i.e. 1m30s) to time.Duration
 // this method copied from grafana/grafana/pkg/tsdb/intervalv2.go
 func ParseIntervalStringToTimeDuration(interval string) (time.Duration, error) {
-	formattedInterval := interval
-	if len(formattedInterval) > 0 {
-		if formattedInterval[0] == '<' {
-			formattedInterval = formattedInterval[1:]
-		}
-		if len(formattedInterval) > 0 && formattedInterval[len(formattedInterval)-1] == '>' {
-			formattedInterval = formattedInterval[:len(formattedInterval)-1]
-		}
+	if len(interval) == 0 {
+		return 0, backend.DownstreamError(fmt.Errorf("invalid interval"))
+	}
+
+	// extract the interval if it is inside brackets i.e. <10m>
+	if interval[0] == '<' {
+		interval = interval[1:]
+	}
+	if len(interval) > 0 && interval[len(interval)-1] == '>' {
+		interval = interval[:len(interval)-1]
 	}
 
 	// Check if string contains only digits
 	isPureNum := true
-	for _, c := range formattedInterval {
+	for _, c := range interval {
 		if c < '0' || c > '9' {
 			isPureNum = false
 			break
 		}
 	}
 
+	// if it is number than return it immediately
 	if isPureNum {
-		num, err := strconv.ParseInt(formattedInterval, 10, 64)
+		num, err := strconv.ParseInt(interval, 10, 64)
 		if err != nil {
 			return 0, err
 		}
 		return time.Duration(num) * time.Second, nil
 	}
 
-	parsedInterval, err := ParseDuration(formattedInterval)
+	parsedInterval, err := ParseDuration(interval)
 	if err != nil {
 		return time.Duration(0), err
 	}

--- a/backend/gtime/gtime.go
+++ b/backend/gtime/gtime.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -154,7 +153,15 @@ func GetIntervalFrom(dsInterval, queryInterval string, queryIntervalMS int64, de
 // ParseIntervalStringToTimeDuration converts a string representation of a expected (i.e. 1m30s) to time.Duration
 // this method copied from grafana/grafana/pkg/tsdb/intervalv2.go
 func ParseIntervalStringToTimeDuration(interval string) (time.Duration, error) {
-	formattedInterval := strings.Replace(strings.Replace(interval, "<", "", 1), ">", "", 1)
+	formattedInterval := interval
+	if len(formattedInterval) > 0 {
+		if formattedInterval[0] == '<' {
+			formattedInterval = formattedInterval[1:]
+		}
+		if len(formattedInterval) > 0 && formattedInterval[len(formattedInterval)-1] == '>' {
+			formattedInterval = formattedInterval[:len(formattedInterval)-1]
+		}
+	}
 
 	// Check if string contains only digits
 	isPureNum := true

--- a/backend/gtime/gtime.go
+++ b/backend/gtime/gtime.go
@@ -151,14 +151,13 @@ func GetIntervalFrom(dsInterval, queryInterval string, queryIntervalMS int64, de
 	return parsedInterval, nil
 }
 
+var isPureNumRegex = regexp.MustCompile(`^\d+$`)
+
 // ParseIntervalStringToTimeDuration converts a string representation of a expected (i.e. 1m30s) to time.Duration
 // this method copied from grafana/grafana/pkg/tsdb/intervalv2.go
 func ParseIntervalStringToTimeDuration(interval string) (time.Duration, error) {
 	formattedInterval := strings.Replace(strings.Replace(interval, "<", "", 1), ">", "", 1)
-	isPureNum, err := regexp.MatchString(`^\d+$`, formattedInterval)
-	if err != nil {
-		return time.Duration(0), err
-	}
+	isPureNum := isPureNumRegex.MatchString(formattedInterval)
 	if isPureNum {
 		formattedInterval += "s"
 	}

--- a/backend/gtime/gtime_bench_test.go
+++ b/backend/gtime/gtime_bench_test.go
@@ -1,0 +1,36 @@
+package gtime
+
+import (
+	"testing"
+)
+
+// go test -benchmem -run=^$ -bench=BenchmarkParseIntervalStringToTimeDuration$ github.
+// com/grafana/grafana-plugin-sdk-go/backend/gtime/ -memprofile p_mem.out -count 6 | tee p_mem.txt
+func BenchmarkParseIntervalStringToTimeDuration(b *testing.B) {
+	testCases := []struct {
+		name     string
+		interval string
+	}{
+		{"PureNumber", "30"},
+		{"Seconds", "30s"},
+		{"Minutes", "5m"},
+		{"Hours", "2h"},
+		{"Days", "7d"},
+		{"Weeks", "2w"},
+		{"Months", "3M"},
+		{"Years", "1y"},
+		{"Complex", "1h30m"},
+		{"WithBrackets", "<30s>"},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := ParseIntervalStringToTimeDuration(tc.interval)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/backend/gtime/gtime_test.go
+++ b/backend/gtime/gtime_test.go
@@ -152,6 +152,7 @@ func TestParseIntervalStringToTimeDuration(t *testing.T) {
 		{inp: "<10s>", duration: 10 * time.Second},
 		{inp: "10s>", duration: 10 * time.Second},
 		{inp: "<10s", duration: 10 * time.Second},
+		{inp: "", err: regexp.MustCompile(`invalid interval`)},
 	}
 	for i, tc := range tcs {
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

`ParseIntervalStringToTimeDuration` method is used in `prometheus`, `loki` and `cloud-monitoring` data sources. `loki` and `prometheus` rely on it for all query request. Improving it's performance resulted a huge gain. See the comparison below. 

This method is using when we get the request and parse the request data into a model. Its overall impact to memory consumption is small comparing to the other parts. But considering that it's been used in many places total impact is still important. 

Also I improved it in all areas that means, less allocations, less gc overheat, faster calculations.

```
❯ benchstat pmem.0.txt pmem.4.txt                                                                                                                                                    
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana-plugin-sdk-go/backend/gtime
cpu: Apple M1 Pro
                                                  │  pmem.0.txt   │             pmem.4.txt             │
                                                  │    sec/op     │   sec/op     vs base               │
ParseIntervalStringToTimeDuration/PureNumber-10     1692.00n ± 1%   12.18n ± 0%  -99.28% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Seconds-10        1659.50n ± 1%   96.78n ± 0%  -94.17% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Minutes-10        1637.00n ± 2%   86.88n ± 0%  -94.69% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Hours-10          1634.00n ± 1%   89.68n ± 0%  -94.51% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Days-10            1721.5n ± 1%   152.2n ± 0%  -91.16% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Weeks-10           1727.0n ± 1%   156.8n ± 0%  -90.92% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Months-10          1718.5n ± 1%   154.9n ± 1%  -90.99% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Years-10           1727.0n ± 0%   155.1n ± 1%  -91.02% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Complex-10         1656.0n ± 1%   107.4n ± 1%  -93.51% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/WithBrackets-10   1726.50n ± 1%   96.58n ± 0%  -94.41% (p=0.002 n=6)
geomean                                               1.689µ        94.13n       -94.43%

                                                  │  pmem.0.txt   │                pmem.4.txt                │
                                                  │     B/op      │     B/op      vs base                    │
ParseIntervalStringToTimeDuration/PureNumber-10      2.321Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Seconds-10        2369.000 ± 0%     8.000 ± 0%   -99.66% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Minutes-10        2369.000 ± 0%     8.000 ± 0%   -99.66% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Hours-10          2369.000 ± 0%     8.000 ± 0%   -99.66% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Days-10             2513.0 ± 0%     152.0 ± 0%   -93.95% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Weeks-10            2513.0 ± 0%     152.0 ± 0%   -93.95% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Months-10           2513.0 ± 0%     152.0 ± 0%   -93.95% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Years-10            2513.0 ± 0%     152.0 ± 0%   -93.95% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Complex-10        2369.000 ± 0%     8.000 ± 0%   -99.66% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/WithBrackets-10   2385.000 ± 0%     8.000 ± 0%   -99.66% (p=0.002 n=6)
geomean                                              2.371Ki                      ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                                                  │ pmem.0.txt  │               pmem.4.txt               │
                                                  │  allocs/op  │ allocs/op   vs base                    │
ParseIntervalStringToTimeDuration/PureNumber-10      35.00 ± 0%    0.00 ± 0%  -100.00% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Seconds-10        34.000 ± 0%   1.000 ± 0%   -97.06% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Minutes-10        34.000 ± 0%   1.000 ± 0%   -97.06% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Hours-10          34.000 ± 0%   1.000 ± 0%   -97.06% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Days-10           36.000 ± 0%   3.000 ± 0%   -91.67% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Weeks-10          36.000 ± 0%   3.000 ± 0%   -91.67% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Months-10         36.000 ± 0%   3.000 ± 0%   -91.67% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Years-10          36.000 ± 0%   3.000 ± 0%   -91.67% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/Complex-10        34.000 ± 0%   1.000 ± 0%   -97.06% (p=0.002 n=6)
ParseIntervalStringToTimeDuration/WithBrackets-10   36.000 ± 0%   1.000 ± 0%   -97.22% (p=0.002 n=6)
geomean                                              35.09                    ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```


**Special notes for your reviewer**:
I'll improve other methods in `gtime` package in other PRs.