### PR TITLE
backend: improve parse function performance in gtime package

### DIFF
--- a/backend/gtime/gtime.go
+++ b/backend/gtime/gtime.go
@@ -75,18 +75,45 @@ func ParseDuration(inp string) (time.Duration, error) {
 }
 
 func parse(inp string) (time.Duration, string, error) {
-	result := dateUnitPattern.FindSubmatch([]byte(inp))
+	// Fast path for simple duration formats (no date units)
+	if len(inp) > 0 {
+		lastChar := inp[len(inp)-1]
+		if lastChar != 'd' && lastChar != 'w' && lastChar != 'M' && lastChar != 'y' {
+			dur, err := time.ParseDuration(inp)
+			return dur, "", err
+		}
+
+		// Check if the rest is a number for date units
+		numPart := inp[:len(inp)-1]
+		isNum := true
+		for _, c := range numPart {
+			if c < '0' || c > '9' {
+				isNum = false
+				break
+			}
+		}
+		if isNum {
+			num, err := strconv.Atoi(numPart)
+			if err != nil {
+				return 0, "", err
+			}
+			return time.Duration(num), string(lastChar), nil
+		}
+	}
+
+	// Fallback to regex for complex cases
+	result := dateUnitPattern.FindStringSubmatch(inp)
 	if len(result) != 3 {
 		dur, err := time.ParseDuration(inp)
 		return dur, "", err
 	}
 
-	num, err := strconv.Atoi(string(result[1]))
+	num, err := strconv.Atoi(result[1])
 	if err != nil {
 		return 0, "", err
 	}
 
-	return time.Duration(num), string(result[2]), nil
+	return time.Duration(num), result[2], nil
 }
 
 // FormatInterval converts a duration into the units that Grafana uses

--- a/backend/gtime/gtime_bench_test.go
+++ b/backend/gtime/gtime_bench_test.go
@@ -1,0 +1,29 @@
+package gtime
+
+import (
+	"testing"
+)
+
+// go test -benchmem -run=^$ -bench=BenchmarkParse$ github.com/grafana/grafana-plugin-sdk-go/backend/gtime/ -memprofile p_mem.out -count 6 | tee pmem.0.txt
+func BenchmarkParse(b *testing.B) {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{"PureNumber", "30"},
+		{"SimpleUnit", "5s"},
+		{"ComplexUnit", "1h30m"},
+		{"DateUnit", "7d"},
+		{"MonthUnit", "3M"},
+		{"YearUnit", "1y"},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _, _ = parse(tc.input)
+			}
+		})
+	}
+}

--- a/backend/gtime/gtime_test.go
+++ b/backend/gtime/gtime_test.go
@@ -211,3 +211,85 @@ func TestRoundInterval(t *testing.T) {
 		})
 	}
 }
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantDur      time.Duration
+		wantPeriod   string
+		wantErrRegex *regexp.Regexp
+	}{
+		{
+			name:       "simple duration seconds",
+			input:      "30s",
+			wantDur:    30 * time.Second,
+			wantPeriod: "",
+		},
+		{
+			name:       "simple duration minutes",
+			input:      "5m",
+			wantDur:    5 * time.Minute,
+			wantPeriod: "",
+		},
+		{
+			name:       "complex duration",
+			input:      "1h30m",
+			wantDur:    90 * time.Minute,
+			wantPeriod: "",
+		},
+		{
+			name:       "days unit",
+			input:      "7d",
+			wantDur:    7,
+			wantPeriod: "d",
+		},
+		{
+			name:       "weeks unit",
+			input:      "2w",
+			wantDur:    2,
+			wantPeriod: "w",
+		},
+		{
+			name:       "months unit",
+			input:      "3M",
+			wantDur:    3,
+			wantPeriod: "M",
+		},
+		{
+			name:       "years unit",
+			input:      "1y",
+			wantDur:    1,
+			wantPeriod: "y",
+		},
+		{
+			name:         "invalid duration",
+			input:        "invalid",
+			wantErrRegex: regexp.MustCompile(`time: invalid duration "?invalid"?`),
+		},
+		{
+			name:         "invalid number",
+			input:        "abc1d",
+			wantErrRegex: regexp.MustCompile(`time: invalid duration "?abc1d"?`),
+		},
+		{
+			name:         "empty string",
+			input:        "",
+			wantErrRegex: regexp.MustCompile(`time: invalid duration "?"`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDur, gotPeriod, err := parse(tt.input)
+			if tt.wantErrRegex != nil {
+				require.Error(t, err)
+				require.Regexp(t, tt.wantErrRegex, err.Error())
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantDur, gotDur)
+			require.Equal(t, tt.wantPeriod, gotPeriod)
+		})
+	}
+}

--- a/backend/gtime/gtime_test.go
+++ b/backend/gtime/gtime_test.go
@@ -233,6 +233,12 @@ func TestParse(t *testing.T) {
 			wantPeriod: "",
 		},
 		{
+			name:       "simple duration minutes and seconds",
+			input:      "1m30s",
+			wantDur:    90 * time.Second,
+			wantPeriod: "",
+		},
+		{
 			name:       "complex duration",
 			input:      "1h30m",
 			wantDur:    90 * time.Minute,


### PR DESCRIPTION
**What this PR does / why we need it**:

`parse` function is used in `ParseDuration` and `ParseInterval`. Those methods is used in many places in `grafana/grafana`. `ParseDuration` is especially used in settings.go to parse the config. Improving their performance will result a better start time and less memory usage. 

This is also a complimentary PR for https://github.com/grafana/grafana-plugin-sdk-go/pull/1237

Here is the benchmark comparison:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana-plugin-sdk-go/backend/gtime
cpu: Apple M1 Pro
                     │  pmem.0.txt   │             pmem.2.txt             │
                     │    sec/op     │   sec/op     vs base               │
Parse/PureNumber-10    164.50n ± 11%   91.89n ± 1%  -44.14% (p=0.002 n=6)
Parse/SimpleUnit-10     79.85n ±  0%   15.21n ± 0%  -80.94% (p=0.002 n=6)
Parse/ComplexUnit-10   105.80n ±  0%   42.40n ± 1%  -59.93% (p=0.002 n=6)
Parse/DateUnit-10      148.55n ±  1%   13.27n ± 4%  -91.07% (p=0.002 n=6)
Parse/MonthUnit-10     151.40n ±  1%   13.66n ± 1%  -90.97% (p=0.002 n=6)
Parse/YearUnit-10      151.20n ±  1%   13.59n ± 0%  -91.01% (p=0.002 n=6)
geomean                 129.5n         22.95n       -82.28%

                     │  pmem.0.txt  │               pmem.2.txt               │
                     │     B/op     │    B/op     vs base                    │
Parse/PureNumber-10      80.00 ± 0%   72.00 ± 0%   -10.00% (p=0.002 n=6)
Parse/SimpleUnit-10      8.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
Parse/ComplexUnit-10     8.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
Parse/DateUnit-10      152.000 ± 0%   4.000 ± 0%   -97.37% (p=0.002 n=6)
Parse/MonthUnit-10     152.000 ± 0%   4.000 ± 0%   -97.37% (p=0.002 n=6)
Parse/YearUnit-10      152.000 ± 0%   4.000 ± 0%   -97.37% (p=0.002 n=6)
geomean                  51.18                    ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                     │ pmem.0.txt │               pmem.2.txt               │
                     │ allocs/op  │ allocs/op   vs base                    │
Parse/PureNumber-10    5.000 ± 0%   4.000 ± 0%   -20.00% (p=0.002 n=6)
Parse/SimpleUnit-10    1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
Parse/ComplexUnit-10   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
Parse/DateUnit-10      3.000 ± 0%   1.000 ± 0%   -66.67% (p=0.002 n=6)
Parse/MonthUnit-10     3.000 ± 0%   1.000 ± 0%   -66.67% (p=0.002 n=6)
Parse/YearUnit-10      3.000 ± 0%   1.000 ± 0%   -66.67% (p=0.002 n=6)
geomean                2.265                    ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```
