### PR TITLE
CODEOWENERS: update /backend/gtime ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone opens a pull request.
 * @grafana/plugins-platform-backend
-/backend/gtime @grafana/observability-metrics @grafana/observability-logs @grafana/partner-datasources
+/backend/gtime @grafana/oss-big-tent @grafana/observability-logs @grafana/partner-datasources
 /data/ @grafana/grafana-datasources-core-services
 /data/sqlutil @grafana/oss-big-tent


### PR DESCRIPTION
**What this PR does / why we need it**:

@grafana/oss-big-tent squad has ownership as prometheus backend moved to them. 


