### PR TITLE
Add no host found errors to downstream check

### DIFF
--- a/experimental/status/status_source.go
+++ b/experimental/status/status_source.go
@@ -141,7 +141,7 @@ func IsDownstreamError(err error) bool {
 // a HTTP timeout error or a cancelled error or a connection reset/refused error or dns not found error.
 func IsDownstreamHTTPError(err error) bool {
 	return IsDownstreamError(err) ||
-		isConnectionResetOrRefusedError(err) ||
+		isNetworkSyscallConnectionError(err) ||
 		isDNSNotFoundError(err) ||
 		isTLSCertificateVerificationError(err) ||
 		isHTTPEOFError(err)
@@ -161,12 +161,12 @@ func isHTTPTimeoutError(err error) bool {
 	return errors.Is(err, os.ErrDeadlineExceeded) // replacement for os.IsTimeout(err)
 }
 
-func isConnectionResetOrRefusedError(err error) bool {
+func isNetworkSyscallConnectionError(err error) bool {
 	var netErr *net.OpError
 	if errors.As(err, &netErr) {
 		var sysErr *os.SyscallError
 		if errors.As(netErr.Err, &sysErr) {
-			return errors.Is(sysErr.Err, syscall.ECONNRESET) || errors.Is(sysErr.Err, syscall.ECONNREFUSED)
+			return errors.Is(sysErr.Err, syscall.ECONNRESET) || errors.Is(sysErr.Err, syscall.ECONNREFUSED) || errors.Is(sysErr.Err, syscall.EHOSTUNREACH) || errors.Is(sysErr.Err, syscall.ENETUNREACH)
 		}
 	}
 

--- a/experimental/status/status_source_test.go
+++ b/experimental/status/status_source_test.go
@@ -230,6 +230,11 @@ func TestIsDownstreamHTTPError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "network unreachable error",
+			err:      &net.OpError{Err: &os.SyscallError{Err: syscall.ENETUNREACH}},
+			expected: true,
+		},
+		{
 			name:     "DNS not found error",
 			err:      &net.DNSError{IsNotFound: true},
 			expected: true,

--- a/experimental/status/status_source_test.go
+++ b/experimental/status/status_source_test.go
@@ -225,6 +225,11 @@ func TestIsDownstreamHTTPError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "host unreachable error",
+			err:      &net.OpError{Err: &os.SyscallError{Err: syscall.EHOSTUNREACH}},
+			expected: true,
+		},
+		{
 			name:     "DNS not found error",
 			err:      &net.DNSError{IsNotFound: true},
 			expected: true,


### PR DESCRIPTION
This PR adds http errors observed in Zabbix to downstream error check. 