### PR TITLE
Fix error source for certificare verification hostname error

### DIFF
--- a/experimental/status/status_source.go
+++ b/experimental/status/status_source.go
@@ -190,11 +190,16 @@ func isDNSNotFoundError(err error) bool {
 
 // isTLSCertificateVerificationError checks if the error is related to TLS certificate verification.
 func isTLSCertificateVerificationError(err error) bool {
-	var certErr *x509.CertificateInvalidError
-	var unknownAuthErr x509.UnknownAuthorityError
+	var (
+		certErr       *x509.CertificateInvalidError
+		unknownAuthErr x509.UnknownAuthorityError
+		hostnameErr   *x509.HostnameError
+	)
 
-	// Directly check for CertificateInvalidError or UnknownAuthorityError
-	if errors.As(err, &certErr) || errors.As(err, &unknownAuthErr) {
+	// Directly check for certificate-related errors
+	if errors.As(err, &certErr) || 
+	   errors.As(err, &unknownAuthErr) ||
+	   errors.As(err, &hostnameErr) {
 		return true
 	}
 
@@ -202,7 +207,9 @@ func isTLSCertificateVerificationError(err error) bool {
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
 		// Check the underlying error in urlErr
-		if errors.As(urlErr.Err, &certErr) || errors.As(urlErr.Err, &unknownAuthErr) {
+		if errors.As(urlErr.Err, &certErr) || 
+		   errors.As(urlErr.Err, &unknownAuthErr) ||
+		   errors.As(urlErr.Err, &hostnameErr) {
 			return true
 		}
 	}

--- a/experimental/status/status_source.go
+++ b/experimental/status/status_source.go
@@ -191,15 +191,15 @@ func isDNSNotFoundError(err error) bool {
 // isTLSCertificateVerificationError checks if the error is related to TLS certificate verification.
 func isTLSCertificateVerificationError(err error) bool {
 	var (
-		certErr       *x509.CertificateInvalidError
+		certErr        *x509.CertificateInvalidError
 		unknownAuthErr x509.UnknownAuthorityError
-		hostnameErr   *x509.HostnameError
+		hostnameErr    *x509.HostnameError
 	)
 
 	// Directly check for certificate-related errors
-	if errors.As(err, &certErr) || 
-	   errors.As(err, &unknownAuthErr) ||
-	   errors.As(err, &hostnameErr) {
+	if errors.As(err, &certErr) ||
+		errors.As(err, &unknownAuthErr) ||
+		errors.As(err, &hostnameErr) {
 		return true
 	}
 
@@ -207,9 +207,9 @@ func isTLSCertificateVerificationError(err error) bool {
 	var urlErr *url.Error
 	if errors.As(err, &urlErr) {
 		// Check the underlying error in urlErr
-		if errors.As(urlErr.Err, &certErr) || 
-		   errors.As(urlErr.Err, &unknownAuthErr) ||
-		   errors.As(urlErr.Err, &hostnameErr) {
+		if errors.As(urlErr.Err, &certErr) ||
+			errors.As(urlErr.Err, &unknownAuthErr) ||
+			errors.As(urlErr.Err, &hostnameErr) {
 			return true
 		}
 	}

--- a/experimental/status/status_source_test.go
+++ b/experimental/status/status_source_test.go
@@ -289,6 +289,18 @@ func TestIsDownstreamHTTPError(t *testing.T) {
 			err:      errors.Join(io.EOF, &url.Error{Op: "Get", URL: "https://example.com", Err: io.EOF}),
 			expected: true,
 		},
+		{
+			name: "TLS hostname verification error",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://example.com",
+				Err: &x509.HostnameError{
+					Host:        "example.com",
+					Certificate: &x509.Certificate{},
+				},
+			},
+			expected: true,
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Added `x509.HostnameError` handling in the `isTLSCertificateVerificationError` function, as observed in Zabbix.  

This error type is now checked both directly and when wrapped in `url.Error`. I have also added a corresponding test case for a hostname verification scenario.