### PR TITLE
fix: include Data field when converting PublishStreamRequest

### DIFF
--- a/backend/convert_from_protobuf.go
+++ b/backend/convert_from_protobuf.go
@@ -270,6 +270,7 @@ func (f ConvertFromProtobuf) PublishStreamRequest(protoReq *pluginv2.PublishStre
 	return &PublishStreamRequest{
 		PluginContext: f.PluginContext(protoReq.PluginContext),
 		Path:          protoReq.GetPath(),
+		Data:          protoReq.GetData(),
 	}
 }
 


### PR DESCRIPTION
This is missing right now so the 'data' field is always empty
for plugins handling publish requests.
