### PR TITLE
Export `ErrorInputFieldsWithoutRowsWideSeries` error

### DIFF
--- a/data/time_series.go
+++ b/data/time_series.go
@@ -218,7 +218,7 @@ func LongToWide(longFrame *Frame, fillMissing *FillMissing) (*Frame, error) {
 		return nil, err
 	}
 	if longLen == 0 {
-		return nil, fmt.Errorf("can not convert to wide series, input fields have no rows")
+		return nil, ErrorInputFieldsWithoutRowsWideSeries
 	}
 
 	wideFrame := NewFrame(longFrame.Name, NewField(longFrame.Fields[tsSchema.TimeIndex].Name, nil, []time.Time{}))
@@ -420,7 +420,7 @@ func WideToLong(wideFrame *Frame) (*Frame, error) {
 	if err != nil {
 		return nil, err
 	} else if wideLen == 0 {
-		return nil, ErrorInputFieldsWithoutRows
+		return nil, ErrorInputFieldsWithoutRowsLongSeries
 	}
 
 	var uniqueValueNames []string                        // unique names of Fields that are value types

--- a/data/time_series.go
+++ b/data/time_series.go
@@ -420,7 +420,7 @@ func WideToLong(wideFrame *Frame) (*Frame, error) {
 	if err != nil {
 		return nil, err
 	} else if wideLen == 0 {
-		return nil, ErrorInputFieldsWithoutRowsLongSeries
+		return nil, ErrorInputFieldsWithoutRows
 	}
 
 	var uniqueValueNames []string                        // unique names of Fields that are value types

--- a/data/time_series_errors.go
+++ b/data/time_series_errors.go
@@ -3,9 +3,8 @@ package data
 import "errors"
 
 var (
-	ErrorNullTimeValues        					 	= errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
-	ErrorSeriesUnsorted         					= errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time if possible")
+	ErrorNullTimeValues                   = errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
+	ErrorSeriesUnsorted                   = errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time if possible")
+	ErrorInputFieldsWithoutRows           = errors.New("can not convert to long series, input fields have no rows")
 	ErrorInputFieldsWithoutRowsWideSeries = errors.New("can not convert to wide series, input fields have no rows")
-	ErrorInputFieldsWithoutRows						= errors.New("can not convert to long series, input fields have no rows")
-
 )

--- a/data/time_series_errors.go
+++ b/data/time_series_errors.go
@@ -3,10 +3,9 @@ package data
 import "errors"
 
 var (
-	ErrorNullTimeValues         = errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
-	ErrorSeriesUnsorted         = errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time if possible")
+	ErrorNullTimeValues        					 	= errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
+	ErrorSeriesUnsorted         					= errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time if possible")
 	ErrorInputFieldsWithoutRowsWideSeries = errors.New("can not convert to wide series, input fields have no rows")
-	ErrorInputFieldsWithoutRowsLongSeries = errors.New("can not convert to long series, input fields have no rows")
-	// @deprecated use ErrorInputFieldsWithoutRowsWideSeries or ErrorInputFieldsWithoutRowsLongSeries instead
-	ErrorInputFieldsWithoutRows = ErrorInputFieldsWithoutRowsLongSeries
+	ErrorInputFieldsWithoutRows						= errors.New("can not convert to long series, input fields have no rows")
+
 )

--- a/data/time_series_errors.go
+++ b/data/time_series_errors.go
@@ -5,5 +5,8 @@ import "errors"
 var (
 	ErrorNullTimeValues         = errors.New("unable to process the data to wide series because input has null time values, make sure all time values are not null")
 	ErrorSeriesUnsorted         = errors.New("unable to process the data because it is not sorted in ascending order by time, please updated your query to sort the data by time if possible")
-	ErrorInputFieldsWithoutRows = errors.New("can not convert to long series, input fields have no rows")
+	ErrorInputFieldsWithoutRowsWideSeries = errors.New("can not convert to wide series, input fields have no rows")
+	ErrorInputFieldsWithoutRowsLongSeries = errors.New("can not convert to long series, input fields have no rows")
+	// @deprecated use ErrorInputFieldsWithoutRowsWideSeries or ErrorInputFieldsWithoutRowsLongSeries instead
+	ErrorInputFieldsWithoutRows = ErrorInputFieldsWithoutRowsLongSeries
 )


### PR DESCRIPTION
We're already exporting other processing errors, but ErrorInputFieldsWithoutRowsWideSeries is missing. We need to add it so some plugins can check for downstream processing errors that occur frequently and impact our success rate in some cases.