### PR TITLE
Add support for forwarding HTTP headers for streaming requests

### DIFF
--- a/backend/data.go
+++ b/backend/data.go
@@ -45,9 +45,7 @@ type QueryDataRequest struct {
 	PluginContext PluginContext
 
 	// Headers the environment/metadata information for the request.
-	//
-	// To access forwarded HTTP headers please use
-	// GetHTTPHeaders or GetHTTPHeader.
+	// To access forwarded HTTP headers please use GetHTTPHeaders or GetHTTPHeader.
 	Headers map[string]string
 
 	// Queries the data queries for the request.
@@ -56,7 +54,7 @@ type QueryDataRequest struct {
 
 // SetHTTPHeader sets the header entries associated with key to the
 // single element value. It replaces any existing values
-// associated with key. The key is case insensitive; it is
+// associated with key. The key is case-insensitive; it is
 // canonicalized by textproto.CanonicalMIMEHeaderKey.
 func (req *QueryDataRequest) SetHTTPHeader(key, value string) {
 	if req.Headers == nil {
@@ -67,7 +65,7 @@ func (req *QueryDataRequest) SetHTTPHeader(key, value string) {
 }
 
 // DeleteHTTPHeader deletes the values associated with key.
-// The key is case insensitive; it is canonicalized by
+// The key is case-insensitive; it is canonicalized by
 // CanonicalHeaderKey.
 func (req *QueryDataRequest) DeleteHTTPHeader(key string) {
 	deleteHTTPHeaderInStringMap(req.Headers, key)
@@ -75,7 +73,7 @@ func (req *QueryDataRequest) DeleteHTTPHeader(key string) {
 
 // GetHTTPHeader gets the first value associated with the given key. If
 // there are no values associated with the key, Get returns "".
-// It is case insensitive; textproto.CanonicalMIMEHeaderKey is
+// It is case-insensitive; textproto.CanonicalMIMEHeaderKey is
 // used to canonicalize the provided key. Get assumes that all
 // keys are stored in canonical form.
 func (req *QueryDataRequest) GetHTTPHeader(key string) string {

--- a/backend/diagnostics.go
+++ b/backend/diagnostics.go
@@ -66,15 +66,13 @@ type CheckHealthRequest struct {
 	PluginContext PluginContext
 
 	// Headers the environment/metadata information for the request.
-	//
-	// To access forwarded HTTP headers please use
-	// GetHTTPHeaders or GetHTTPHeader.
+	// To access forwarded HTTP headers please use GetHTTPHeaders or GetHTTPHeader.
 	Headers map[string]string
 }
 
 // SetHTTPHeader sets the header entries associated with key to the
 // single element value. It replaces any existing values
-// associated with key. The key is case insensitive; it is
+// associated with key. The key is case-insensitive; it is
 // canonicalized by textproto.CanonicalMIMEHeaderKey.
 func (req *CheckHealthRequest) SetHTTPHeader(key, value string) {
 	if req.Headers == nil {
@@ -85,7 +83,7 @@ func (req *CheckHealthRequest) SetHTTPHeader(key, value string) {
 }
 
 // DeleteHTTPHeader deletes the values associated with key.
-// The key is case insensitive; it is canonicalized by
+// The key is case-insensitive; it is canonicalized by
 // CanonicalHeaderKey.
 func (req *CheckHealthRequest) DeleteHTTPHeader(key string) {
 	deleteHTTPHeaderInStringMap(req.Headers, key)
@@ -93,7 +91,7 @@ func (req *CheckHealthRequest) DeleteHTTPHeader(key string) {
 
 // GetHTTPHeader gets the first value associated with the given key. If
 // there are no values associated with the key, Get returns "".
-// It is case insensitive; textproto.CanonicalMIMEHeaderKey is
+// It is case-insensitive; textproto.CanonicalMIMEHeaderKey is
 // used to canonicalize the provided key. Get assumes that all
 // keys are stored in canonical form.
 func (req *CheckHealthRequest) GetHTTPHeader(key string) string {

--- a/backend/http_headers.go
+++ b/backend/http_headers.go
@@ -35,18 +35,18 @@ const (
 type ForwardHTTPHeaders interface {
 	// SetHTTPHeader sets the header entries associated with key to the
 	// single element value. It replaces any existing values
-	// associated with key. The key is case insensitive; it is
+	// associated with key. The key is case-insensitive; it is
 	// canonicalized by textproto.CanonicalMIMEHeaderKey.
 	SetHTTPHeader(key, value string)
 
 	// DeleteHTTPHeader deletes the values associated with key.
-	// The key is case insensitive; it is canonicalized by
+	// The key is case-insensitive; it is canonicalized by
 	// CanonicalHeaderKey.
 	DeleteHTTPHeader(key string)
 
 	// GetHTTPHeader gets the first value associated with the given key. If
 	// there are no values associated with the key, Get returns "".
-	// It is case insensitive; textproto.CanonicalMIMEHeaderKey is
+	// It is case-insensitive; textproto.CanonicalMIMEHeaderKey is
 	// used to canonicalize the provided key. Get assumes that all
 	// keys are stored in canonical form.
 	GetHTTPHeader(key string) string

--- a/backend/resource.go
+++ b/backend/resource.go
@@ -36,7 +36,7 @@ type CallResourceRequest struct {
 
 // SetHTTPHeader sets the header entries associated with key to the
 // single element value. It replaces any existing values
-// associated with key. The key is case insensitive; it is
+// associated with key. The key is case-insensitive; it is
 // canonicalized by textproto.CanonicalMIMEHeaderKey.
 func (req *CallResourceRequest) SetHTTPHeader(key, value string) {
 	if req.Headers == nil {
@@ -47,7 +47,7 @@ func (req *CallResourceRequest) SetHTTPHeader(key, value string) {
 }
 
 // DeleteHTTPHeader deletes the values associated with key.
-// The key is case insensitive; it is canonicalized by
+// The key is case-insensitive; it is canonicalized by
 // CanonicalHeaderKey.
 func (req *CallResourceRequest) DeleteHTTPHeader(key string) {
 	if req.Headers == nil {
@@ -64,7 +64,7 @@ func (req *CallResourceRequest) DeleteHTTPHeader(key string) {
 
 // GetHTTPHeader gets the first value associated with the given key. If
 // there are no values associated with the key, Get returns "".
-// It is case insensitive; textproto.CanonicalMIMEHeaderKey is
+// It is case-insensitive; textproto.CanonicalMIMEHeaderKey is
 // used to canonicalize the provided key. Get assumes that all
 // keys are stored in canonical form.
 func (req *CallResourceRequest) GetHTTPHeader(key string) string {

--- a/backend/stream.go
+++ b/backend/stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
@@ -92,6 +93,43 @@ type SubscribeStreamRequest struct {
 	PluginContext PluginContext
 	Path          string
 	Data          json.RawMessage
+
+	// Headers the environment/metadata information for the request.
+	// To access forwarded HTTP headers please use GetHTTPHeaders or GetHTTPHeader.
+	Headers map[string]string
+}
+
+// SetHTTPHeader sets the header entries associated with key to the
+// single element value. It replaces any existing values
+// associated with key. The key is case-insensitive; it is
+// canonicalized by textproto.CanonicalMIMEHeaderKey.
+func (req *SubscribeStreamRequest) SetHTTPHeader(key, value string) {
+	if req.Headers == nil {
+		req.Headers = map[string]string{}
+	}
+
+	setHTTPHeaderInStringMap(req.Headers, key, value)
+}
+
+// DeleteHTTPHeader deletes the values associated with key.
+// The key is case-insensitive; it is canonicalized by
+// CanonicalHeaderKey.
+func (req *SubscribeStreamRequest) DeleteHTTPHeader(key string) {
+	deleteHTTPHeaderInStringMap(req.Headers, key)
+}
+
+// GetHTTPHeader gets the first value associated with the given key. If
+// there are no values associated with the key, Get returns "".
+// It is case-insensitive; textproto.CanonicalMIMEHeaderKey is
+// used to canonicalize the provided key. Get assumes that all
+// keys are stored in canonical form.
+func (req *SubscribeStreamRequest) GetHTTPHeader(key string) string {
+	return req.GetHTTPHeaders().Get(key)
+}
+
+// GetHTTPHeaders returns HTTP headers.
+func (req *SubscribeStreamRequest) GetHTTPHeaders() http.Header {
+	return getHTTPHeadersFromStringMap(req.Headers)
 }
 
 // SubscribeStreamStatus is a status of subscription response.
@@ -148,6 +186,43 @@ type PublishStreamRequest struct {
 	PluginContext PluginContext
 	Path          string
 	Data          json.RawMessage
+
+	// Headers the environment/metadata information for the request.
+	// To access forwarded HTTP headers please use GetHTTPHeaders or GetHTTPHeader.
+	Headers map[string]string
+}
+
+// SetHTTPHeader sets the header entries associated with key to the
+// single element value. It replaces any existing values
+// associated with key. The key is case-insensitive; it is
+// canonicalized by textproto.CanonicalMIMEHeaderKey.
+func (req *PublishStreamRequest) SetHTTPHeader(key, value string) {
+	if req.Headers == nil {
+		req.Headers = map[string]string{}
+	}
+
+	setHTTPHeaderInStringMap(req.Headers, key, value)
+}
+
+// DeleteHTTPHeader deletes the values associated with key.
+// The key is case-insensitive; it is canonicalized by
+// CanonicalHeaderKey.
+func (req *PublishStreamRequest) DeleteHTTPHeader(key string) {
+	deleteHTTPHeaderInStringMap(req.Headers, key)
+}
+
+// GetHTTPHeader gets the first value associated with the given key. If
+// there are no values associated with the key, Get returns "".
+// It is case-insensitive; textproto.CanonicalMIMEHeaderKey is
+// used to canonicalize the provided key. Get assumes that all
+// keys are stored in canonical form.
+func (req *PublishStreamRequest) GetHTTPHeader(key string) string {
+	return req.GetHTTPHeaders().Get(key)
+}
+
+// GetHTTPHeaders returns HTTP headers.
+func (req *PublishStreamRequest) GetHTTPHeaders() http.Header {
+	return getHTTPHeadersFromStringMap(req.Headers)
 }
 
 // PublishStreamStatus is a status of publication response.
@@ -173,6 +248,43 @@ type RunStreamRequest struct {
 	PluginContext PluginContext
 	Path          string
 	Data          json.RawMessage
+
+	// Headers the environment/metadata information for the request.
+	// To access forwarded HTTP headers please use GetHTTPHeaders or GetHTTPHeader.
+	Headers map[string]string
+}
+
+// SetHTTPHeader sets the header entries associated with key to the
+// single element value. It replaces any existing values
+// associated with key. The key is case-insensitive; it is
+// canonicalized by textproto.CanonicalMIMEHeaderKey.
+func (req *RunStreamRequest) SetHTTPHeader(key, value string) {
+	if req.Headers == nil {
+		req.Headers = map[string]string{}
+	}
+
+	setHTTPHeaderInStringMap(req.Headers, key, value)
+}
+
+// DeleteHTTPHeader deletes the values associated with key.
+// The key is case-insensitive; it is canonicalized by
+// CanonicalHeaderKey.
+func (req *RunStreamRequest) DeleteHTTPHeader(key string) {
+	deleteHTTPHeaderInStringMap(req.Headers, key)
+}
+
+// GetHTTPHeader gets the first value associated with the given key. If
+// there are no values associated with the key, Get returns "".
+// It is case-insensitive; textproto.CanonicalMIMEHeaderKey is
+// used to canonicalize the provided key. Get assumes that all
+// keys are stored in canonical form.
+func (req *RunStreamRequest) GetHTTPHeader(key string) string {
+	return req.GetHTTPHeaders().Get(key)
+}
+
+// GetHTTPHeaders returns HTTP headers.
+func (req *RunStreamRequest) GetHTTPHeaders() http.Header {
+	return getHTTPHeadersFromStringMap(req.Headers)
 }
 
 // StreamPacket represents a stream packet.
@@ -228,3 +340,7 @@ func (s *StreamSender) SendBytes(data []byte) error {
 	}
 	return s.packetSender.Send(FromProto().StreamPacket(packet))
 }
+
+var _ ForwardHTTPHeaders = (*SubscribeStreamRequest)(nil)
+var _ ForwardHTTPHeaders = (*PublishStreamRequest)(nil)
+var _ ForwardHTTPHeaders = (*RunStreamRequest)(nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to support reading HTTP header information like we do in `QueryData`, `CallResource` and `CheckHealth`, we need to ensure that the stream requests implement the `ForwardHTTPHeaders` interface.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-plugin-sdk-go/issues/1218

This still requires a change to `grafana/grafana`

