### PR TITLE
Fix standalone mode for app plugins

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -39,7 +38,7 @@ func GetExecutableFromPluginJSON(dir string) (string, error) {
 			if strings.HasPrefix(exe, "../") {
 				return exe[3:], nil
 			}
-			return "", errors.New("datasource should reference executable in root folder")
+			return exe, nil
 		}
 	}
 	return exe, err

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -40,13 +40,13 @@ func TestGetExecutableFromPluginJSON(t *testing.T) {
 			expected:      "gpx_foo",
 		},
 		{
-			name: "Cannot retrieve executable field of nested 'datasource' plugin.json when executable path is not in the root directory",
+			name: "Can retrieve executable field of nested 'datasource' plugin.json when executable path is not in the root directory",
 			args: args{
 				pluginDir: "foobar-app",
 			},
 			pluginJSONDir: filepath.Join("foobar-app", "datasource"),
 			executable:    "gpx_foo",
-			err:           true,
+			expected:      "gpx_foo",
 		},
 		{
 			name: "Cannot retrieve executable when no plugin.json found in root or nested 'datasource' directory",


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/grafana-plugin-sdk-go/pull/1007 Added the possibility for app plugins not to include relative paths in the executable field but it is not working for standalone which I'd like to use for debug purposes. Launching standalone creates error `missing executable in plugin.json (standalone)` in zabbix.

