### PR TITLE
Support running nested plugins via standalone when debugging

### DIFF
--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -82,7 +82,7 @@ func RunDummyPluginLocator(address string) {
 }
 
 func serverSettings(pluginID string) (ServerSettings, error) {
-	cwd, err := os.Getwd()
+	cwd, err := currentWd()
 	if err != nil {
 		return ServerSettings{}, err
 	}
@@ -111,6 +111,10 @@ func serverSettings(pluginID string) (ServerSettings, error) {
 		Dir:     dir,
 	}, nil
 }
+
+// currentWd returns the current working directory.
+// This is a variable so that it can be mocked in tests.
+var currentWd = os.Getwd
 
 // clientSettings will attempt to find a standalone server's address and PID.
 func clientSettings(pluginID string) (ClientSettings, error) {

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -82,9 +82,19 @@ func RunDummyPluginLocator(address string) {
 }
 
 func serverSettings(pluginID string) (ServerSettings, error) {
-	cwd, _ := os.Getwd()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ServerSettings{}, err
+	}
+
+	// if we are in the pkg directory, go up one level
 	if filepath.Base(cwd) == "pkg" {
 		cwd = filepath.Dir(cwd)
+	}
+
+	// if dist directory exists, use that as the base directory
+	if _, err = os.Stat(filepath.Join(cwd, "dist")); err == nil {
+		cwd = filepath.Join(cwd, "dist")
 	}
 
 	dir, found := findPluginDir(cwd, pluginID)

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -89,7 +89,7 @@ func serverSettings(pluginID string) (ServerSettings, error) {
 
 	dir, found := findPluginDir(cwd, pluginID)
 	if !found {
-		return ServerSettings{}, fmt.Errorf("plugin root directory not found for plugin ID: %s", pluginID)
+		return ServerSettings{}, fmt.Errorf("plugin directory not found for plugin ID: %s", pluginID)
 	}
 
 	address, err := createStandaloneAddress(pluginID)

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"log"
 	"net"
 	"os"
@@ -81,14 +82,14 @@ func RunDummyPluginLocator(address string) {
 }
 
 func serverSettings(pluginID string) (ServerSettings, error) {
-	curProcPath, err := currentProcPath()
-	if err != nil {
-		return ServerSettings{}, err
+	cwd, _ := os.Getwd()
+	if filepath.Base(cwd) == "pkg" {
+		cwd = filepath.Dir(cwd)
 	}
 
-	dir := filepath.Dir(curProcPath) // Default to current directory
-	if pluginDir, found := findPluginRootDir(curProcPath); found {
-		dir = pluginDir
+	dir, found := findPluginDir(cwd, pluginID)
+	if !found {
+		return ServerSettings{}, fmt.Errorf("plugin root directory not found for plugin ID: %s", pluginID)
 	}
 
 	address, err := createStandaloneAddress(pluginID)
@@ -139,29 +140,39 @@ func currentProcPath() (string, error) {
 	return curProcPath, nil
 }
 
-// findPluginRootDir will attempt to find a plugin directory based on the executing process's file-system path.
-func findPluginRootDir(curProcPath string) (string, bool) {
-	cwd, _ := os.Getwd()
-	if filepath.Base(cwd) == "pkg" {
-		cwd = filepath.Join(cwd, "..")
-	}
-
-	check := []string{
-		filepath.Join(curProcPath, "plugin.json"),
-		filepath.Join(curProcPath, "dist", "plugin.json"),
-		filepath.Join(filepath.Dir(curProcPath), "plugin.json"),
-		filepath.Join(filepath.Dir(curProcPath), "dist", "plugin.json"),
-		filepath.Join(cwd, "dist", "plugin.json"),
-		filepath.Join(cwd, "plugin.json"),
-	}
-
-	for _, path := range check {
-		if _, err := os.Stat(path); err == nil {
-			return filepath.Dir(path), true
+// findPluginDir will attempt to find a plugin directory based on the provided plugin ID.
+// This function will traverse the filesystem from the provided directory until it finds a directory that contains
+// a plugin.json file containing an id matching the provided plugin ID.
+func findPluginDir(dir, pluginID string) (string, bool) {
+	var pluginDir string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
+
+		if d.Name() != "plugin.json" {
+			return nil
+		}
+
+		id, err := internal.GetStringValueFromJSON(path, "id")
+		if err != nil {
+			return nil
+		}
+
+		if pluginID == id {
+			pluginDir = filepath.Dir(path)
+			return fs.SkipAll
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		log.Printf("findPluginDir error: %s", err.Error())
+		return "", false
 	}
 
-	return "", false
+	return pluginDir, pluginDir != ""
 }
 
 func getStandaloneAddress(pluginID string, dir string) (string, error) {

--- a/internal/standalone/standalone.go
+++ b/internal/standalone/standalone.go
@@ -93,7 +93,7 @@ func serverSettings(pluginID string) (ServerSettings, error) {
 	}
 
 	// if dist directory exists, use that as the base directory
-	if _, err = os.Stat(filepath.Join(cwd, "dist")); err == nil {
+	if finfo, err := os.Stat(filepath.Join(cwd, "dist")); err == nil && finfo.IsDir() {
 		cwd = filepath.Join(cwd, "dist")
 	}
 
@@ -164,7 +164,7 @@ func findPluginDir(dir, pluginID string) (string, bool) {
 			return err
 		}
 
-		if d.Name() != "plugin.json" {
+		if d.Name() != "plugin.json" || d.IsDir() {
 			return nil
 		}
 

--- a/internal/standalone/standalone_test.go
+++ b/internal/standalone/standalone_test.go
@@ -160,6 +160,20 @@ func Test_findPluginDir(t *testing.T) {
 			exists:   true,
 		},
 		{
+			name:     "existing plugin found from nested plugin directory",
+			pluginID: "grafana-nested-datasource",
+			dir:      filepath.Join("testdata", "plugin"),
+			want:     filepath.Join("testdata", "plugin", "datasource"),
+			exists:   true,
+		},
+		{
+			name:     "existing plugin found from dist directory",
+			pluginID: "grafana-foobar-datasource",
+			dir:      filepath.Join("testdata", "dist"),
+			want:     filepath.Join("testdata", "dist"),
+			exists:   true,
+		},
+		{
 			name:     "non matching plugin id",
 			pluginID: pluginID,
 			dir:      filepath.Join("testdata", "GoLand"),

--- a/internal/standalone/standalone_test.go
+++ b/internal/standalone/standalone_test.go
@@ -197,12 +197,8 @@ func Test_findPluginDir(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, found := findPluginDir(tt.dir, tt.pluginID)
-			if found != tt.exists {
-				t.Errorf("findPluginDir() found = %v, want %v", found, tt.exists)
-			}
-			if got != tt.want {
-				t.Errorf("findPluginDir() got = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.exists, found)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -308,13 +304,14 @@ func TestServerSettings(t *testing.T) {
 	})
 
 	t.Run("Returns error when working directory cannot be determined", func(t *testing.T) {
+		wdErr := errors.New("mock working directory error")
 		currentWd = func() (string, error) {
-			return "", errors.New("mock working directory error")
+			return "", wdErr
 		}
 
 		settings, err := serverSettings(pluginID)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "mock working directory error")
+		require.ErrorIs(t, err, wdErr)
 		require.Empty(t, settings)
 	})
 }

--- a/internal/standalone/standalone_test.go
+++ b/internal/standalone/standalone_test.go
@@ -265,7 +265,7 @@ func TestServerSettings(t *testing.T) {
 		err = os.Mkdir(distDir, 0755)
 		require.NoError(t, err)
 
-		err = os.WriteFile(filepath.Join(distDir, "plugin.json"), []byte(`{"id": "`+pluginID+`"}`), 0644)
+		err = os.WriteFile(filepath.Join(distDir, "plugin.json"), []byte(`{"id": "`+pluginID+`"}`), 0600)
 		require.NoError(t, err)
 
 		currentWd = func() (string, error) {
@@ -290,7 +290,7 @@ func TestServerSettings(t *testing.T) {
 		err = os.Mkdir(distDir, 0755)
 		require.NoError(t, err)
 
-		err = os.WriteFile(filepath.Join(distDir, "plugin.json"), []byte(`{"id": "`+pluginID+`"}`), 0644)
+		err = os.WriteFile(filepath.Join(distDir, "plugin.json"), []byte(`{"id": "`+pluginID+`"}`), 0600)
 		require.NoError(t, err)
 
 		currentWd = func() (string, error) {

--- a/internal/standalone/standalone_test.go
+++ b/internal/standalone/standalone_test.go
@@ -166,3 +166,58 @@ func TestClientModeEnabled(t *testing.T) {
 		require.Zero(t, settings.TargetPID)
 	})
 }
+
+func Test_findPluginDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		dir      string
+		pluginID string
+		want     string
+		exists   bool
+	}{
+		{
+			name:     "existing plugin found from root directory",
+			pluginID: "grafana-foobar-datasource",
+			dir:      "testdata",
+			want:     filepath.Join("testdata", "plugin"),
+			exists:   true,
+		},
+		{
+			name:     "existing plugin found from plugin directory",
+			pluginID: "grafana-foobar-datasource",
+			dir:      filepath.Join("testdata", "plugin"),
+			want:     filepath.Join("testdata", "plugin"),
+			exists:   true,
+		},
+		{
+			name:     "non matching plugin id",
+			pluginID: "grafana-foobar-datasource",
+			dir:      filepath.Join("testdata", "GoLand"),
+			want:     "",
+		},
+		{
+			name:     "non-existing plugin",
+			pluginID: "non-existing-plugin",
+			dir:      "testdata",
+			want:     "",
+		},
+		{
+			name:     "empty plugin ID",
+			pluginID: "",
+			dir:      "testdata",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := findPluginDir(tt.dir, tt.pluginID)
+			if found != tt.exists {
+				t.Errorf("findPluginDir() found = %v, want %v", found, tt.exists)
+			}
+			if got != tt.want {
+				t.Errorf("findPluginDir() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/standalone/testdata/dist/plugin.json
+++ b/internal/standalone/testdata/dist/plugin.json
@@ -1,0 +1,3 @@
+{
+  "id": "grafana-foobar-datasource"
+}

--- a/internal/standalone/testdata/plugin/datasource/plugin.json
+++ b/internal/standalone/testdata/plugin/datasource/plugin.json
@@ -1,0 +1,3 @@
+{
+  "id": "grafana-nested-datasource"
+}

--- a/internal/standalone/testdata/plugin/plugin.json
+++ b/internal/standalone/testdata/plugin/plugin.json
@@ -1,3 +1,3 @@
 {
-  "id": "grafana-foobar-datasource"
+  "id": "grafana-test-datasource"
 }

--- a/internal/standalone/testdata/plugin/plugin.json
+++ b/internal/standalone/testdata/plugin/plugin.json
@@ -1,1 +1,3 @@
-{}
+{
+  "id": "grafana-foobar-datasource"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes it possible to run a nested backend datasource in standalone mode using the existing conventions (Zabbix for example) when debugging.
