### PR TITLE
Add mage target for custom backend builds

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -221,11 +221,6 @@ func newBuildConfig(os string, arch string) Config {
 // Build is a namespace.
 type Build mg.Namespace
 
-// Custom allows customizable back-end plugin builds for the provided os and arch.
-func (Build) Custom(os, arch string) error {
-	return buildBackend(newBuildConfig(os, arch))
-}
-
 // Linux builds the back-end plugin for Linux.
 func (Build) Linux() error {
 	return buildBackend(newBuildConfig("linux", "amd64"))
@@ -254,6 +249,13 @@ func (Build) Darwin() error {
 // DarwinARM64 builds the back-end plugin for OSX on ARM (M1/M2).
 func (Build) DarwinARM64() error {
 	return buildBackend(newBuildConfig("darwin", "arm64"))
+}
+
+// Custom allows customizable back-end plugin builds for the provided os and arch.
+// Note: Cutomized builds are not officially supported by Grafana, so this option is intended for developers who need
+// to create their own custom build targets.
+func (Build) Custom(os, arch string) error {
+	return buildBackend(newBuildConfig(os, arch))
 }
 
 // GenerateManifestFile generates a manifest file for plugin submissions

--- a/build/common.go
+++ b/build/common.go
@@ -222,6 +222,11 @@ func newBuildConfig(os string, arch string) Config {
 type Build mg.Namespace
 
 // Linux builds the back-end plugin for Linux.
+func (Build) Custom(os, arch string) error {
+	return buildBackend(newBuildConfig(os, arch))
+}
+
+// Linux builds the back-end plugin for Linux.
 func (Build) Linux() error {
 	return buildBackend(newBuildConfig("linux", "amd64"))
 }

--- a/build/common.go
+++ b/build/common.go
@@ -221,7 +221,7 @@ func newBuildConfig(os string, arch string) Config {
 // Build is a namespace.
 type Build mg.Namespace
 
-// Linux builds the back-end plugin for Linux.
+// Custom allows customizable back-end plugin builds for the provided os and arch.
 func (Build) Custom(os, arch string) error {
 	return buildBackend(newBuildConfig(os, arch))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
To allow developers to customize their backend build for different OS + architectures.

Usage:

```
 mage build:custom linux s390x
```

For example:
- https://github.com/grafana/grafana-plugin-sdk-go/pull/541
- https://github.com/grafana/grafana-plugin-sdk-go/pull/1263
