### PR TITLE
Live: Add watch scope and allow dots in namespace

### DIFF
--- a/live/channel.go
+++ b/live/channel.go
@@ -69,7 +69,7 @@ func (c Channel) String() string {
 }
 
 var (
-	scopeNamespacePattern = regexp.MustCompile(`^[A-z0-9_\-]*$`)
+	scopeNamespacePattern = regexp.MustCompile(`^[A-z0-9_\-\.]*$`)
 	pathPattern           = regexp.MustCompile(`^[A-z0-9_\-/=.]*$`)
 )
 

--- a/live/channel_test.go
+++ b/live/channel_test.go
@@ -96,6 +96,16 @@ func TestParseChannel_IsValid(t *testing.T) {
 			id:      "grafana=/test=/path/dash-and-equal",
 			isValid: false,
 		},
+		{
+			name:    "scope_watch_dashboards",
+			id:      "watch/dashboard.grafana.app/dashboards",
+			isValid: true,
+		},
+		{
+			name:    "scope_watch_dashboards_with_name",
+			id:      "watch/dashboard.grafana.app/dashboards=name",
+			isValid: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/live/channel_test.go
+++ b/live/channel_test.go
@@ -102,8 +102,13 @@ func TestParseChannel_IsValid(t *testing.T) {
 			isValid: true,
 		},
 		{
-			name:    "scope_watch_dashboards_with_name",
-			id:      "watch/dashboard.grafana.app/dashboards=name",
+			name:    "scope_watch_dashboards_with_user_id",
+			id:      "watch/dashboard.grafana.app/dashboards/userid",
+			isValid: true,
+		},
+		{
+			name:    "scope_watch_dashboards_with_name_anduser_id",
+			id:      "watch/dashboard.grafana.app/dashboards=XYZ/userid",
 			isValid: true,
 		},
 	}

--- a/live/scope.go
+++ b/live/scope.go
@@ -9,4 +9,6 @@ const (
 	ScopeDatasource = "ds"
 	// ScopeStream is a managed data frame stream.
 	ScopeStream = "stream"
+	// ScopeWatch will watch a k8s style resource
+	ScopeWatch = "watch"
 )


### PR DESCRIPTION
Trying to support k8s watch from the frontend... but with http1 (not 2!) there can only be 6 concurrent connections so using long polling really breaks the frontend.
