### PR TITLE
fix: avoid crash due to fallthrough in *ConfFloat64 nil comparisons

### DIFF
--- a/data/frame.go
+++ b/data/frame.go
@@ -347,10 +347,7 @@ func FrameTestCompareOptions() []cmp.Option {
 			if math.IsNaN(float64(*x)) {
 				return true
 			}
-			if math.IsInf(float64(*x), 1) {
-				return true
-			}
-			if math.IsInf(float64(*x), -1) {
+			if math.IsInf(float64(*x), 0) {
 				return true
 			}
 			return false
@@ -359,10 +356,7 @@ func FrameTestCompareOptions() []cmp.Option {
 			if math.IsNaN(float64(*y)) {
 				return true
 			}
-			if math.IsInf(float64(*y), 1) {
-				return true
-			}
-			if math.IsInf(float64(*y), -1) {
+			if math.IsInf(float64(*y), 0) {
 				return true
 			}
 			return false

--- a/data/frame.go
+++ b/data/frame.go
@@ -353,7 +353,7 @@ func FrameTestCompareOptions() []cmp.Option {
 			if math.IsInf(float64(*x), -1) {
 				return true
 			}
-			return false;
+			return false
 		}
 		if x == nil {
 			if math.IsNaN(float64(*y)) {
@@ -365,7 +365,7 @@ func FrameTestCompareOptions() []cmp.Option {
 			if math.IsInf(float64(*y), -1) {
 				return true
 			}
-			return false;
+			return false
 		}
 		return *x == *y
 	})

--- a/data/frame.go
+++ b/data/frame.go
@@ -353,6 +353,7 @@ func FrameTestCompareOptions() []cmp.Option {
 			if math.IsInf(float64(*x), -1) {
 				return true
 			}
+			return false;
 		}
 		if x == nil {
 			if math.IsNaN(float64(*y)) {
@@ -364,6 +365,7 @@ func FrameTestCompareOptions() []cmp.Option {
 			if math.IsInf(float64(*y), -1) {
 				return true
 			}
+			return false;
 		}
 		return *x == *y
 	})

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -564,10 +564,10 @@ func TestFrameTestCompareOptionsForConfFloat64(t *testing.T) {
 		}
 	})
 	t.Run("nil and non-nil *ConfFloat64 should compare without crashing", func(t *testing.T) {
-		if diff := cmp.Diff(pf1, pf2, data.FrameTestCompareOptions()...); diff == "" {
+		if diff := cmp.Diff(pf1, pnil, data.FrameTestCompareOptions()...); diff == "" {
 			t.Fatal("Expecting diff, got nothing")
 		}
-		if diff := cmp.Diff(pf2, pf1, data.FrameTestCompareOptions()...); diff == "" {
+		if diff := cmp.Diff(pnil, pf1, data.FrameTestCompareOptions()...); diff == "" {
 			t.Fatal("Expecting diff, got nothing")
 		}
 	})

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -539,9 +539,9 @@ func TestDataFrameFilterRowsByField(t *testing.T) {
 func TestFrameTestCompareOptionsForConfFloat64(t *testing.T) {
 	var f1 data.ConfFloat64 = 1.23456789
 	var f2 data.ConfFloat64 = 2.3456789
-	var pf1 *data.ConfFloat64 = &f1
-	var pf2 *data.ConfFloat64 = &f2
-	var pnil *data.ConfFloat64 = nil
+	var pf1 = &f1
+	var pf2 = &f2
+	var pnil *data.ConfFloat64
 	t.Run("ConfFloat64 should compare without crashing", func(t *testing.T) {
 		if diff := cmp.Diff(f1, f1, data.FrameTestCompareOptions()...); diff != "" {
 			t.Fatal(diff)

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -539,9 +539,9 @@ func TestDataFrameFilterRowsByField(t *testing.T) {
 func TestFrameTestCompareOptionsForConfFloat64(t *testing.T) {
 	var f1 data.ConfFloat64 = 1.23456789
 	var f2 data.ConfFloat64 = 2.3456789
-	var nan data.ConfFloat64 = data.ConfFloat64(math.NaN())
-	var posInf data.ConfFloat64 = data.ConfFloat64(math.Inf(1))
-	var negInf data.ConfFloat64 = data.ConfFloat64(math.Inf(-1))
+	var nan = data.ConfFloat64(math.NaN())
+	var posInf = data.ConfFloat64(math.Inf(1))
+	var negInf = data.ConfFloat64(math.Inf(-1))
 	var pnil *data.ConfFloat64
 	t.Run("ConfFloat64 should compare without crashing", func(t *testing.T) {
 		if diff := cmp.Diff(f1, f1, data.FrameTestCompareOptions()...); diff != "" {

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -536,6 +536,43 @@ func TestDataFrameFilterRowsByField(t *testing.T) {
 	}
 }
 
+func TestFrameTestCompareOptionsForConfFloat64(t *testing.T) {
+	var f1 data.ConfFloat64 = 1.23456789
+	var f2 data.ConfFloat64 = 2.3456789
+	var pf1 *data.ConfFloat64 = &f1
+	var pf2 *data.ConfFloat64 = &f2
+	var pnil *data.ConfFloat64 = nil
+	t.Run("ConfFloat64 should compare without crashing", func(t *testing.T) {
+		if diff := cmp.Diff(f1, f1, data.FrameTestCompareOptions()...); diff != "" {
+			t.Fatal(diff)
+		}
+		if diff := cmp.Diff(f1, f2, data.FrameTestCompareOptions()...); diff == "" {
+			t.Fatal("Expecting diff, got nothing")
+		}
+	})
+	t.Run("*ConfFloat64 should compare without crashing", func(t *testing.T) {
+		if diff := cmp.Diff(pf1, pf1, data.FrameTestCompareOptions()...); diff != "" {
+			t.Fatal(diff)
+		}
+		if diff := cmp.Diff(pf1, pf2, data.FrameTestCompareOptions()...); diff == "" {
+			t.Fatal("Expecting diff, got nothing")
+		}
+	})
+	t.Run("nil *ConfFloat64 should compare without crashing", func(t *testing.T) {
+		if diff := cmp.Diff(pnil, pnil, data.FrameTestCompareOptions()...); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+	t.Run("nil and non-nil *ConfFloat64 should compare without crashing", func(t *testing.T) {
+		if diff := cmp.Diff(pf1, pf2, data.FrameTestCompareOptions()...); diff == "" {
+			t.Fatal("Expecting diff, got nothing")
+		}
+		if diff := cmp.Diff(pf2, pf1, data.FrameTestCompareOptions()...); diff == "" {
+			t.Fatal("Expecting diff, got nothing")
+		}
+	})
+}
+
 func TestJSON(t *testing.T) {
 	frames := data.Frames{
 		data.NewFrame("http_requests_total",

--- a/data/frame_test.go
+++ b/data/frame_test.go
@@ -539,8 +539,9 @@ func TestDataFrameFilterRowsByField(t *testing.T) {
 func TestFrameTestCompareOptionsForConfFloat64(t *testing.T) {
 	var f1 data.ConfFloat64 = 1.23456789
 	var f2 data.ConfFloat64 = 2.3456789
-	var pf1 = &f1
-	var pf2 = &f2
+	var nan data.ConfFloat64 = data.ConfFloat64(math.NaN())
+	var posInf data.ConfFloat64 = data.ConfFloat64(math.Inf(1))
+	var negInf data.ConfFloat64 = data.ConfFloat64(math.Inf(-1))
 	var pnil *data.ConfFloat64
 	t.Run("ConfFloat64 should compare without crashing", func(t *testing.T) {
 		if diff := cmp.Diff(f1, f1, data.FrameTestCompareOptions()...); diff != "" {
@@ -551,10 +552,10 @@ func TestFrameTestCompareOptionsForConfFloat64(t *testing.T) {
 		}
 	})
 	t.Run("*ConfFloat64 should compare without crashing", func(t *testing.T) {
-		if diff := cmp.Diff(pf1, pf1, data.FrameTestCompareOptions()...); diff != "" {
+		if diff := cmp.Diff(&f1, &f1, data.FrameTestCompareOptions()...); diff != "" {
 			t.Fatal(diff)
 		}
-		if diff := cmp.Diff(pf1, pf2, data.FrameTestCompareOptions()...); diff == "" {
+		if diff := cmp.Diff(&f1, &f2, data.FrameTestCompareOptions()...); diff == "" {
 			t.Fatal("Expecting diff, got nothing")
 		}
 	})
@@ -564,11 +565,21 @@ func TestFrameTestCompareOptionsForConfFloat64(t *testing.T) {
 		}
 	})
 	t.Run("nil and non-nil *ConfFloat64 should compare without crashing", func(t *testing.T) {
-		if diff := cmp.Diff(pf1, pnil, data.FrameTestCompareOptions()...); diff == "" {
+		if diff := cmp.Diff(&f1, pnil, data.FrameTestCompareOptions()...); diff == "" {
 			t.Fatal("Expecting diff, got nothing")
 		}
-		if diff := cmp.Diff(pnil, pf1, data.FrameTestCompareOptions()...); diff == "" {
+		if diff := cmp.Diff(pnil, &f1, data.FrameTestCompareOptions()...); diff == "" {
 			t.Fatal("Expecting diff, got nothing")
+		}
+	})
+	t.Run("nil *ConfFloat64 is equivalent to NaN/+Inf/-Inf", func(t *testing.T) {
+		for _, p := range []*data.ConfFloat64{&nan, &posInf, &negInf} {
+			if diff := cmp.Diff(pnil, p, data.FrameTestCompareOptions()...); diff != "" {
+				t.Fatal(diff)
+			}
+			if diff := cmp.Diff(p, pnil, data.FrameTestCompareOptions()...); diff != "" {
+				t.Fatal(diff)
+			}
 		}
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes code that can cause crash in testing instead of a comparison test failure.

**Which issue(s) this PR fixes**:

There's a bug in `data.FrameTestCompareOptions` that causes `Frame` comparison tests to crash when (for example) the compared frames have different number of rows and one of the columns is a `ConfFloat64`.