### PR TITLE
add response limits to default middleware for httpclient

### DIFF
--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -235,6 +235,7 @@ func DefaultMiddlewares() []Middleware {
 		CustomHeadersMiddleware(),
 		ContextualMiddleware(),
 		ErrorSourceMiddleware(),
+		ResponseLimitMiddleware(0),
 	}
 }
 

--- a/backend/httpclient/http_client_test.go
+++ b/backend/httpclient/http_client_test.go
@@ -70,13 +70,14 @@ func TestNewClient(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, client)
 
-		require.Len(t, usedMiddlewares, 6)
+		require.Len(t, usedMiddlewares, 7)
 		require.Equal(t, TracingMiddlewareName, usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 		require.Equal(t, DataSourceMetricsMiddlewareName, usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 		require.Equal(t, BasicAuthenticationMiddlewareName, usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 		require.Equal(t, CustomHeadersMiddlewareName, usedMiddlewares[3].(MiddlewareName).MiddlewareName())
 		require.Equal(t, ContextualMiddlewareName, usedMiddlewares[4].(MiddlewareName).MiddlewareName())
 		require.Equal(t, ErrorSourceMiddlewareName, usedMiddlewares[5].(MiddlewareName).MiddlewareName())
+		require.Equal(t, ResponseLimitMiddlewareName, usedMiddlewares[6].(MiddlewareName).MiddlewareName())
 	})
 
 	t.Run("New() with opts middleware should return expected http.Client", func(t *testing.T) {

--- a/backend/httpclient/provider_test.go
+++ b/backend/httpclient/provider_test.go
@@ -25,13 +25,14 @@ func TestProvider(t *testing.T) {
 			client, err := ctx.provider.New()
 			require.NoError(t, err)
 			require.NotNil(t, client)
-			require.Len(t, ctx.usedMiddlewares, 6)
+			require.Len(t, ctx.usedMiddlewares, 7)
 			require.Equal(t, TracingMiddlewareName, ctx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 			require.Equal(t, DataSourceMetricsMiddlewareName, ctx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 			require.Equal(t, BasicAuthenticationMiddlewareName, ctx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 			require.Equal(t, CustomHeadersMiddlewareName, ctx.usedMiddlewares[3].(MiddlewareName).MiddlewareName())
 			require.Equal(t, ContextualMiddlewareName, ctx.usedMiddlewares[4].(MiddlewareName).MiddlewareName())
 			require.Equal(t, ErrorSourceMiddlewareName, ctx.usedMiddlewares[5].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ResponseLimitMiddlewareName, ctx.usedMiddlewares[6].(MiddlewareName).MiddlewareName())
 		})
 
 		t.Run("Transport should use default middlewares", func(t *testing.T) {

--- a/backend/httpclient/provider_test.go
+++ b/backend/httpclient/provider_test.go
@@ -39,13 +39,14 @@ func TestProvider(t *testing.T) {
 			transport, err := ctx.provider.GetTransport()
 			require.NoError(t, err)
 			require.NotNil(t, transport)
-			require.Len(t, ctx.usedMiddlewares, 6)
+			require.Len(t, ctx.usedMiddlewares, 7)
 			require.Equal(t, TracingMiddlewareName, ctx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 			require.Equal(t, DataSourceMetricsMiddlewareName, ctx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 			require.Equal(t, BasicAuthenticationMiddlewareName, ctx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 			require.Equal(t, CustomHeadersMiddlewareName, ctx.usedMiddlewares[3].(MiddlewareName).MiddlewareName())
 			require.Equal(t, ContextualMiddlewareName, ctx.usedMiddlewares[4].(MiddlewareName).MiddlewareName())
 			require.Equal(t, ErrorSourceMiddlewareName, ctx.usedMiddlewares[5].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ResponseLimitMiddlewareName, ctx.usedMiddlewares[6].(MiddlewareName).MiddlewareName())
 		})
 
 		t.Run("New() with options and no middleware should return expected http client and transport", func(t *testing.T) {
@@ -86,7 +87,7 @@ func TestProvider(t *testing.T) {
 			require.Equal(t, DefaultTimeoutOptions.Timeout, client.Timeout)
 
 			t.Run("Should use configured middlewares and implement MiddlewareName", func(t *testing.T) {
-				require.Len(t, pCtx.usedMiddlewares, 9)
+				require.Len(t, pCtx.usedMiddlewares, 10)
 				require.Equal(t, "mw1", pCtx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 				require.Equal(t, "mw2", pCtx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 				require.Equal(t, "mw3", pCtx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
@@ -96,6 +97,7 @@ func TestProvider(t *testing.T) {
 				require.Equal(t, CustomHeadersMiddlewareName, pCtx.usedMiddlewares[6].(MiddlewareName).MiddlewareName())
 				require.Equal(t, ContextualMiddlewareName, pCtx.usedMiddlewares[7].(MiddlewareName).MiddlewareName())
 				require.Equal(t, ErrorSourceMiddlewareName, pCtx.usedMiddlewares[8].(MiddlewareName).MiddlewareName())
+				require.Equal(t, ResponseLimitMiddlewareName, pCtx.usedMiddlewares[9].(MiddlewareName).MiddlewareName())
 			})
 
 			t.Run("When roundtrip should call expected middlewares", func(t *testing.T) {

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -26,7 +26,6 @@ func ResponseLimitMiddleware(limit int64) Middleware {
 
 			log.DefaultLogger.Error("failed to parse GF_DATAPROXY_RESPONSE_LIMIT", "error", err)
 		}
-
 	}
 
 	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(_ Options, next http.RoundTripper) http.RoundTripper {

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -2,12 +2,33 @@ package httpclient
 
 import (
 	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+)
+
+const (
+	ResponseLimitEnvVar = "GF_DATAPROXY_RESPONSE_LIMIT"
 )
 
 // ResponseLimitMiddlewareName is the middleware name used by ResponseLimitMiddleware.
 const ResponseLimitMiddlewareName = "response-limit"
 
 func ResponseLimitMiddleware(limit int64) Middleware {
+	if limit <= 0 {
+		envLimit, ok := os.LookupEnv(ResponseLimitEnvVar)
+		if ok && envLimit != "" {
+			limitInt, err := strconv.ParseInt(envLimit, 10, 64)
+			if err == nil && limitInt > 0 {
+				limit = limitInt
+			}
+
+			log.DefaultLogger.Error("failed to parse GF_DATAPROXY_RESPONSE_LIMIT", "error", err)
+		}
+
+	}
+
 	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(_ Options, next http.RoundTripper) http.RoundTripper {
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			res, err := next.RoundTrip(req)

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/config"
 )
 
 // ResponseLimitMiddlewareName is the middleware name used by ResponseLimitMiddleware.
@@ -17,28 +18,6 @@ const (
 	ResponseLimitMiddlewareName = "response-limit"
 	responseLimitEnvVar         = "GF_DATAPROXY_RESPONSE_LIMIT"
 )
-
-type responseLimitContextKey struct{}
-
-// WithResponseLimitContext stores a response size limit in the context for
-// ResponseLimitMiddleware to apply per-request. Called by WithGrafanaConfig in the
-// backend package to propagate GrafanaCfg.ResponseLimit() — plugins do not need to call
-// this directly.
-//
-// Note: when set, the context value takes priority over GF_DATAPROXY_RESPONSE_LIMIT.
-// A context value of 0 disables limiting entirely — the env var and limit argument are
-// not consulted.
-func WithResponseLimitContext(ctx context.Context, limit int64) context.Context {
-	return context.WithValue(ctx, responseLimitContextKey{}, &limit)
-}
-
-func responseLimitFromContext(ctx context.Context) (int64, bool) {
-	v, ok := ctx.Value(responseLimitContextKey{}).(*int64)
-	if !ok || v == nil {
-		return 0, false
-	}
-	return *v, true
-}
 
 // ResponseLimitMiddleware limits the size of downstream response bodies.
 // When the limit is exceeded the response body returns ErrResponseBodyTooLarge and a
@@ -101,7 +80,7 @@ func parseEnvResponseLimit() int64 {
 // The per-request context value from GrafanaCfg wins if present, then the env var,
 // then the static limit argument. Returns 0 if none are set, which disables limiting.
 func resolveResponseLimit(envLimit, limit int64, ctx context.Context) int64 {
-	if ctxLimit, ok := responseLimitFromContext(ctx); ok {
+	if ctxLimit := config.GrafanaConfigFromContext(ctx).ResponseLimit(); ctxLimit > 0 {
 		return ctxLimit
 	}
 	if envLimit > 0 {

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -1,49 +1,134 @@
 package httpclient
 
 import (
+	"context"
+	"errors"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
+	"sync"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
+// ResponseLimitMiddlewareName is the middleware name used by ResponseLimitMiddleware.
 const (
-	ResponseLimitEnvVar = "GF_DATAPROXY_RESPONSE_LIMIT"
+	ResponseLimitMiddlewareName = "response-limit"
+	responseLimitEnvVar         = "GF_DATAPROXY_RESPONSE_LIMIT"
 )
 
-// ResponseLimitMiddlewareName is the middleware name used by ResponseLimitMiddleware.
-const ResponseLimitMiddlewareName = "response-limit"
+type responseLimitContextKey struct{}
 
-func ResponseLimitMiddleware(limit int64) Middleware {
-	if limit <= 0 {
-		envLimit, ok := os.LookupEnv(ResponseLimitEnvVar)
-		if ok && envLimit != "" {
-			limitInt, err := strconv.ParseInt(envLimit, 10, 64)
-			if err == nil && limitInt > 0 {
-				limit = limitInt
-			}
+// WithResponseLimitContext stores a response size limit in the context for
+// ResponseLimitMiddleware to apply per-request. Called by WithGrafanaConfig in the
+// backend package to propagate GrafanaCfg.ResponseLimit() — plugins do not need to call
+// this directly.
+//
+// Note: when set, the context value takes priority over GF_DATAPROXY_RESPONSE_LIMIT.
+// A context value of 0 disables limiting entirely — the env var and limit argument are
+// not consulted.
+func WithResponseLimitContext(ctx context.Context, limit int64) context.Context {
+	return context.WithValue(ctx, responseLimitContextKey{}, &limit)
+}
 
-			log.DefaultLogger.Error("failed to parse GF_DATAPROXY_RESPONSE_LIMIT", "error", err)
-		}
+func responseLimitFromContext(ctx context.Context) (int64, bool) {
+	v, ok := ctx.Value(responseLimitContextKey{}).(*int64)
+	if !ok || v == nil {
+		return 0, false
 	}
+	return *v, true
+}
 
-	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(_ Options, next http.RoundTripper) http.RoundTripper {
-		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			res, err := next.RoundTrip(req)
-			if err != nil {
-				return nil, err
-			}
+// ResponseLimitMiddleware limits the size of downstream response bodies.
+// When the limit is exceeded the response body returns ErrResponseBodyTooLarge and a
+// warning is logged with the datasource identifiers from opts.Labels.
+//
+// The limit is resolved per-request in the following priority order:
+//  1. GrafanaCfg.ResponseLimit() from the request context, set by WithGrafanaConfig
+//  2. GF_DATAPROXY_RESPONSE_LIMIT env var — read once at client construction
+//  3. The limit argument, if > 0
+//
+// If none are set, limiting is disabled.
+func ResponseLimitMiddleware(limit int64) Middleware {
+	return NamedMiddlewareFunc(
+		ResponseLimitMiddlewareName,
+		func(opts Options, next http.RoundTripper) http.RoundTripper {
+			envLimit := parseEnvResponseLimit()
+			dsUID := opts.Labels["datasource_uid"]
+			dsName := opts.Labels["datasource_name"]
 
-			if limit <= 0 {
+			return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				effectiveLimit := resolveResponseLimit(envLimit, limit, req.Context())
+
+				res, err := next.RoundTrip(req)
+				if err != nil {
+					return nil, err
+				}
+
+				if effectiveLimit <= 0 {
+					return res, nil
+				}
+
+				if res != nil && res.StatusCode != http.StatusSwitchingProtocols {
+					res.Body = &responseLimitBody{
+						ReadCloser: MaxBytesReader(res.Body, effectiveLimit),
+						ctx:        req.Context(),
+						limit:      effectiveLimit,
+						dsUID:      dsUID,
+						dsName:     dsName,
+					}
+				}
+
 				return res, nil
-			}
+			})
+		},
+	)
+}
 
-			if res != nil && res.StatusCode != http.StatusSwitchingProtocols {
-				res.Body = MaxBytesReader(res.Body, limit)
-			}
+// parseEnvResponseLimit reads GF_DATAPROXY_RESPONSE_LIMIT once at client construction time.
+// Changes to the env var after the client is built will not take effect until the client
+// is recreated.
+func parseEnvResponseLimit() int64 {
+	v, err := strconv.ParseInt(os.Getenv(responseLimitEnvVar), 10, 64)
+	if err == nil && v > 0 {
+		return v
+	}
+	return 0
+}
 
-			return res, nil
+// resolveResponseLimit determines the effective limit for a request.
+// The per-request context value from GrafanaCfg wins if present, then the env var,
+// then the static limit argument. Returns 0 if none are set, which disables limiting.
+func resolveResponseLimit(envLimit, limit int64, ctx context.Context) int64 {
+	if ctxLimit, ok := responseLimitFromContext(ctx); ok {
+		return ctxLimit
+	}
+	if envLimit > 0 {
+		return envLimit
+	}
+	return limit
+}
+
+type responseLimitBody struct {
+	io.ReadCloser
+	ctx    context.Context
+	limit  int64
+	dsUID  string
+	dsName string
+	once   sync.Once
+}
+
+func (b *responseLimitBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if err != nil && errors.Is(err, ErrResponseBodyTooLarge) {
+		b.once.Do(func() {
+			log.DefaultLogger.FromContext(b.ctx).Warn("downstream response body exceeded limit",
+				"datasource_uid", b.dsUID,
+				"datasource_name", b.dsName,
+				"limit_bytes", b.limit,
+			)
 		})
-	})
+	}
+	return n, err
 }

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -38,7 +38,7 @@ func ResponseLimitMiddleware(limit int64) Middleware {
 			dsName := opts.Labels["datasource_name"]
 
 			return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				effectiveLimit := resolveResponseLimit(envLimit, limit, req.Context())
+				effectiveLimit := resolveResponseLimit(req.Context(), envLimit, limit)
 
 				res, err := next.RoundTrip(req)
 				if err != nil {
@@ -79,7 +79,7 @@ func parseEnvResponseLimit() int64 {
 // resolveResponseLimit determines the effective limit for a request.
 // The per-request context value from GrafanaCfg wins if present, then the env var,
 // then the static limit argument. Returns 0 if none are set, which disables limiting.
-func resolveResponseLimit(envLimit, limit int64, ctx context.Context) int64 {
+func resolveResponseLimit(ctx context.Context, envLimit, limit int64) int64 {
 	if ctxLimit := config.GrafanaConfigFromContext(ctx).ResponseLimit(); ctxLimit > 0 {
 		return ctxLimit
 	}

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -3,6 +3,7 @@ package httpclient
 import (
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -11,15 +12,38 @@ import (
 )
 
 func TestResponseLimitMiddleware(t *testing.T) {
-	t.Run("should use static limit when no context limit is set", func(t *testing.T) {
-		next := &mockRoundTripper{
-			response: &http.Response{
-				Body: io.NopCloser(strings.NewReader("dummy")),
-			},
-		}
+	tcs := []struct {
+		limit              int64
+		expectedBodyLength int
+		expectedBody       string
+		err                error
+		envLimit           string
+	}{
+		// Test that the limit is set from arguments
+		{limit: 1, expectedBodyLength: 1, expectedBody: "d", err: errors.New("error: http: response body too large, response limit is set to: 1"), envLimit: ""},
+		{limit: 1000000, expectedBodyLength: 5, expectedBody: "dummy", err: nil, envLimit: ""},
+		{limit: 0, expectedBodyLength: 5, expectedBody: "dummy", err: nil, envLimit: ""},
+		// Test that the limit is set from the environment variable
+		{limit: 0, expectedBodyLength: 1, expectedBody: "d", err: errors.New("error: http: response body too large, response limit is set to: 1"), envLimit: "1"},
+		{limit: 0, expectedBodyLength: 5, expectedBody: "dummy", err: nil, envLimit: "1000000"},
+		{limit: 0, expectedBodyLength: 5, expectedBody: "dummy", err: nil, envLimit: "-1"},
+		{limit: 0, expectedBodyLength: 5, expectedBody: "dummy", err: nil, envLimit: "0"},
+	}
+	for _, tc := range tcs {
+		t.Run(fmt.Sprintf("Test ResponseLimitMiddleware with limit: %d and envLimit: %s", tc.limit, tc.envLimit), func(t *testing.T) {
+			finalRoundTripper := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
+			})
 
-		middleware := ResponseLimitMiddleware(1)
-		rt := middleware.CreateMiddleware(Options{}, next)
+			os.Setenv(ResponseLimitEnvVar, tc.envLimit)
+			defer os.Unsetenv(ResponseLimitEnvVar)
+
+			mw := ResponseLimitMiddleware(tc.limit)
+			rt := mw.CreateMiddleware(Options{}, finalRoundTripper)
+			require.NotNil(t, rt)
+			middlewareName, ok := mw.(MiddlewareName)
+			require.True(t, ok)
+			require.Equal(t, ResponseLimitMiddlewareName, middlewareName.MiddlewareName())
 
 		req, err := http.NewRequest(http.MethodGet, "http://", nil)
 		require.NoError(t, err)

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -3,7 +3,6 @@ package httpclient
 import (
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 
@@ -35,8 +34,9 @@ func TestResponseLimitMiddleware(t *testing.T) {
 				return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
 			})
 
-			os.Setenv(ResponseLimitEnvVar, tc.envLimit)
-			defer os.Unsetenv(ResponseLimitEnvVar)
+			if tc.envLimit != "" {
+				t.Setenv(responseLimitEnvVar, tc.envLimit)
+			}
 
 			mw := ResponseLimitMiddleware(tc.limit)
 			rt := mw.CreateMiddleware(Options{}, finalRoundTripper)
@@ -143,4 +143,81 @@ type mockRoundTripper struct {
 
 func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return m.response, m.err
+}
+
+func newRoundTripperWithBody(body string) http.RoundTripper {
+	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Request:    req,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	})
+}
+
+func newRequestWithCtx(t *testing.T, ctx context.Context) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.com/query", nil)
+	require.NoError(t, err)
+	return req
+}
+
+func TestResponseLimitMiddlewarePriority(t *testing.T) {
+	t.Run("grafana config limit is applied first", func(t *testing.T) {
+		// env var is loose, context (cfg) is tight — context wins
+		t.Setenv(responseLimitEnvVar, "1000000")
+		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripperWithBody("dummy"))
+
+		ctx := WithResponseLimitContext(context.Background(), 3)
+		res, err := rt.RoundTrip(newRequestWithCtx(t, ctx))
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(res.Body)
+		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	})
+
+	t.Run("env var is used when grafana config is not set", func(t *testing.T) {
+		t.Setenv(responseLimitEnvVar, "3")
+		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripperWithBody("dummy"))
+
+		res, err := rt.RoundTrip(newRequestWithCtx(t, context.Background()))
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(res.Body)
+		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	})
+
+	t.Run("limit arg is used when grafana config and env var are not set", func(t *testing.T) {
+		rt := ResponseLimitMiddleware(3).CreateMiddleware(Options{}, newRoundTripperWithBody("dummy"))
+
+		res, err := rt.RoundTrip(newRequestWithCtx(t, context.Background()))
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(res.Body)
+		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	})
+
+	t.Run("grafana config 0 disables limiting even when env var is set", func(t *testing.T) {
+		t.Setenv(responseLimitEnvVar, "3")
+		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripperWithBody("dummy"))
+
+		ctx := WithResponseLimitContext(context.Background(), 0)
+		res, err := rt.RoundTrip(newRequestWithCtx(t, ctx))
+		require.NoError(t, err)
+
+		bodyBytes, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "dummy", string(bodyBytes))
+	})
+
+	t.Run("no limit when nothing is set", func(t *testing.T) {
+		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripperWithBody("dummy"))
+
+		res, err := rt.RoundTrip(newRequestWithCtx(t, context.Background()))
+		require.NoError(t, err)
+
+		bodyBytes, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "dummy", string(bodyBytes))
+	})
 }

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -1,223 +1,76 @@
 package httpclient
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/grafana/grafana-plugin-sdk-go/config"
 	"github.com/stretchr/testify/require"
 )
 
+func ptr[T any](v T) *T { return &v }
+
 func TestResponseLimitMiddleware(t *testing.T) {
 	tcs := []struct {
+		name               string
 		limit              int64
+		ctxLimit           *int64
+		envLimit           string
 		expectedBodyLength int
 		expectedBody       string
-		err                error
-		envLimit           string
+		expectErr          bool
 	}{
-		// Test that the limit is set from arguments
-		{limit: 1, expectedBodyLength: 1, expectedBody: "d", err: errors.New("error: http: response body too large, response limit is set to: 1"), envLimit: ""},
-		{limit: 1000000, expectedBodyLength: 5, expectedBody: "dummy", err: nil, envLimit: ""},
-		{limit: 0, expectedBodyLength: 5, expectedBody: "dummy", err: nil, envLimit: ""},
-		// Test that the limit is set from the environment variable
-		{limit: 0, expectedBodyLength: 1, expectedBody: "d", err: errors.New("error: http: response body too large, response limit is set to: 1"), envLimit: "1"},
-		{limit: 0, expectedBodyLength: 5, expectedBody: "dummy", err: nil, envLimit: "1000000"},
-		{limit: 0, expectedBodyLength: 5, expectedBody: "dummy", err: nil, envLimit: "-1"},
-		{limit: 0, expectedBodyLength: 5, expectedBody: "dummy", err: nil, envLimit: "0"},
+		// limit arg
+		{name: "limit arg enforced", limit: 1, expectedBodyLength: 1, expectedBody: "d", expectErr: true},
+		{name: "limit arg not exceeded", limit: 1000000, expectedBodyLength: 5, expectedBody: "dummy"},
+		{name: "limit arg 0 disables", limit: 0, expectedBodyLength: 5, expectedBody: "dummy"},
+		// env var
+		{name: "env var enforced when limit arg is 0", limit: 0, envLimit: "1", expectedBodyLength: 1, expectedBody: "d", expectErr: true},
+		{name: "env var not exceeded", limit: 0, envLimit: "1000000", expectedBodyLength: 5, expectedBody: "dummy"},
+		{name: "invalid env var ignored", limit: 0, envLimit: "-1", expectedBodyLength: 5, expectedBody: "dummy"},
+		{name: "zero env var ignored", limit: 0, envLimit: "0", expectedBodyLength: 5, expectedBody: "dummy"},
+		// grafana config (context) priority
+		{name: "grafana config wins over env var", limit: 0, ctxLimit: ptr(int64(3)), envLimit: "1000000", expectedBodyLength: 1, expectedBody: "d", expectErr: true},
+		{name: "grafana config 0 disables even when env var is set", limit: 0, ctxLimit: ptr(int64(0)), envLimit: "3", expectedBodyLength: 5, expectedBody: "dummy"},
+		{name: "no limit when nothing is set", limit: 0, expectedBodyLength: 5, expectedBody: "dummy"},
 	}
 	for _, tc := range tcs {
-		t.Run(fmt.Sprintf("Test ResponseLimitMiddleware with limit: %d and envLimit: %s", tc.limit, tc.envLimit), func(t *testing.T) {
-			finalRoundTripper := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
-			})
-
+		t.Run(tc.name, func(t *testing.T) {
 			if tc.envLimit != "" {
 				t.Setenv(responseLimitEnvVar, tc.envLimit)
 			}
 
 			mw := ResponseLimitMiddleware(tc.limit)
-			rt := mw.CreateMiddleware(Options{}, finalRoundTripper)
-			require.NotNil(t, rt)
+			rt := mw.CreateMiddleware(Options{}, RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
+			}))
+
 			middlewareName, ok := mw.(MiddlewareName)
 			require.True(t, ok)
 			require.Equal(t, ResponseLimitMiddlewareName, middlewareName.MiddlewareName())
 
-		req, err := http.NewRequest(http.MethodGet, "http://", nil)
-		require.NoError(t, err)
+			ctx := context.Background()
+			if tc.ctxLimit != nil {
+				ctx = WithResponseLimitContext(ctx, *tc.ctxLimit)
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.com/query", nil)
+			require.NoError(t, err)
 
-		res, err := rt.RoundTrip(req)
-		require.NoError(t, err)
-		require.NotNil(t, res)
+			res, err := rt.RoundTrip(req)
+			require.NoError(t, err)
 
-		body, err := io.ReadAll(res.Body)
-		require.Error(t, err)
-		require.Equal(t, "error: http: response body too large, response limit is set to: 1", err.Error())
-		require.Equal(t, "d", string(body))
-		require.NoError(t, res.Body.Close())
-	})
+			bodyBytes, err := io.ReadAll(res.Body)
+			require.NoError(t, res.Body.Close())
 
-	t.Run("should prefer static even when context limit is set", func(t *testing.T) {
-		next := &mockRoundTripper{
-			response: &http.Response{
-				Body: io.NopCloser(strings.NewReader("dummy")),
-			},
-		}
-
-		middleware := ResponseLimitMiddleware(1000) // High static limit
-		rt := middleware.CreateMiddleware(Options{}, next)
-
-		req, err := http.NewRequest(http.MethodGet, "http://", nil)
-		require.NoError(t, err)
-
-		// Set a lower limit in the context
-		ctx := config.WithGrafanaConfig(req.Context(), config.NewGrafanaCfg(map[string]string{
-			config.ResponseLimit: "1",
-		}))
-		req = req.WithContext(ctx)
-
-		res, err := rt.RoundTrip(req)
-		require.NoError(t, err)
-		require.NotNil(t, res)
-
-		body, err := io.ReadAll(res.Body)
-		require.NoError(t, err)
-		require.Equal(t, "dummy", string(body))
-		require.NoError(t, res.Body.Close())
-	})
-
-	t.Run("should not limit response when limit is 0", func(t *testing.T) {
-		next := &mockRoundTripper{
-			response: &http.Response{
-				Body: io.NopCloser(strings.NewReader("dummy")),
-			},
-		}
-
-		middleware := ResponseLimitMiddleware(0)
-		rt := middleware.CreateMiddleware(Options{}, next)
-
-		req, err := http.NewRequest(http.MethodGet, "http://", nil)
-		require.NoError(t, err)
-
-		res, err := rt.RoundTrip(req)
-		require.NoError(t, err)
-		require.NotNil(t, res)
-
-		body, err := io.ReadAll(res.Body)
-		require.NoError(t, err)
-		require.Equal(t, "dummy", string(body))
-		require.NoError(t, res.Body.Close())
-	})
-
-	t.Run("should not limit response when status is switching protocols", func(t *testing.T) {
-		next := &mockRoundTripper{
-			response: &http.Response{
-				StatusCode: http.StatusSwitchingProtocols,
-				Body:       io.NopCloser(strings.NewReader("dummy")),
-			},
-		}
-
-		middleware := ResponseLimitMiddleware(1)
-		rt := middleware.CreateMiddleware(Options{}, next)
-
-		req, err := http.NewRequest(http.MethodGet, "http://", nil)
-		require.NoError(t, err)
-
-		res, err := rt.RoundTrip(req)
-		require.NoError(t, err)
-		require.NotNil(t, res)
-
-		body, err := io.ReadAll(res.Body)
-		require.NoError(t, err)
-		require.Equal(t, "dummy", string(body))
-		require.NoError(t, res.Body.Close())
-	})
-}
-
-type mockRoundTripper struct {
-	response *http.Response
-	err      error
-}
-
-func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
-	return m.response, m.err
-}
-
-func newRoundTripperWithBody(body string) http.RoundTripper {
-	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Request:    req,
-			Body:       io.NopCloser(strings.NewReader(body)),
-		}, nil
-	})
-}
-
-func newRequestWithCtx(t *testing.T, ctx context.Context) *http.Request {
-	t.Helper()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.com/query", nil)
-	require.NoError(t, err)
-	return req
-}
-
-func TestResponseLimitMiddlewarePriority(t *testing.T) {
-	t.Run("grafana config limit is applied first", func(t *testing.T) {
-		// env var is loose, context (cfg) is tight — context wins
-		t.Setenv(responseLimitEnvVar, "1000000")
-		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripperWithBody("dummy"))
-
-		ctx := WithResponseLimitContext(context.Background(), 3)
-		res, err := rt.RoundTrip(newRequestWithCtx(t, ctx))
-		require.NoError(t, err)
-
-		_, err = io.ReadAll(res.Body)
-		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
-	})
-
-	t.Run("env var is used when grafana config is not set", func(t *testing.T) {
-		t.Setenv(responseLimitEnvVar, "3")
-		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripperWithBody("dummy"))
-
-		res, err := rt.RoundTrip(newRequestWithCtx(t, context.Background()))
-		require.NoError(t, err)
-
-		_, err = io.ReadAll(res.Body)
-		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
-	})
-
-	t.Run("limit arg is used when grafana config and env var are not set", func(t *testing.T) {
-		rt := ResponseLimitMiddleware(3).CreateMiddleware(Options{}, newRoundTripperWithBody("dummy"))
-
-		res, err := rt.RoundTrip(newRequestWithCtx(t, context.Background()))
-		require.NoError(t, err)
-
-		_, err = io.ReadAll(res.Body)
-		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
-	})
-
-	t.Run("grafana config 0 disables limiting even when env var is set", func(t *testing.T) {
-		t.Setenv(responseLimitEnvVar, "3")
-		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripperWithBody("dummy"))
-
-		ctx := WithResponseLimitContext(context.Background(), 0)
-		res, err := rt.RoundTrip(newRequestWithCtx(t, ctx))
-		require.NoError(t, err)
-
-		bodyBytes, err := io.ReadAll(res.Body)
-		require.NoError(t, err)
-		require.Equal(t, "dummy", string(bodyBytes))
-	})
-
-	t.Run("no limit when nothing is set", func(t *testing.T) {
-		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripperWithBody("dummy"))
-
-		res, err := rt.RoundTrip(newRequestWithCtx(t, context.Background()))
-		require.NoError(t, err)
-
-		bodyBytes, err := io.ReadAll(res.Body)
-		require.NoError(t, err)
-		require.Equal(t, "dummy", string(bodyBytes))
-	})
+			if tc.expectErr {
+				require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Len(t, bodyBytes, tc.expectedBodyLength)
+			require.Equal(t, tc.expectedBody, string(bodyBytes))
+		})
+	}
 }

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -32,7 +32,7 @@ func TestResponseLimitMiddleware(t *testing.T) {
 		{name: "invalid env var ignored", limit: 0, envLimit: "-1", expectedBodyLength: 5, expectedBody: "dummy"},
 		{name: "zero env var ignored", limit: 0, envLimit: "0", expectedBodyLength: 5, expectedBody: "dummy"},
 		// grafana config (context) priority
-		{name: "grafana config wins over env var", limit: 0, ctxLimit: ptr(int64(3)), envLimit: "1000000", expectedBodyLength: 1, expectedBody: "d", expectErr: true},
+		{name: "grafana config wins over env var", limit: 0, ctxLimit: ptr(int64(3)), envLimit: "1000000", expectedBodyLength: 3, expectedBody: "dum", expectErr: true},
 		{name: "grafana config 0 disables even when env var is set", limit: 0, ctxLimit: ptr(int64(0)), envLimit: "3", expectedBodyLength: 5, expectedBody: "dummy"},
 		{name: "no limit when nothing is set", limit: 0, expectedBodyLength: 5, expectedBody: "dummy"},
 	}

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/grafana/grafana-plugin-sdk-go/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +35,7 @@ func TestResponseLimitMiddleware(t *testing.T) {
 		{name: "zero env var ignored", limit: 0, envLimit: "0", expectedBodyLength: 5, expectedBody: "dummy"},
 		// grafana config (context) priority
 		{name: "grafana config wins over env var", limit: 0, ctxLimit: ptr(int64(3)), envLimit: "1000000", expectedBodyLength: 3, expectedBody: "dum", expectErr: true},
-		{name: "grafana config 0 disables even when env var is set", limit: 0, ctxLimit: ptr(int64(0)), envLimit: "3", expectedBodyLength: 5, expectedBody: "dummy"},
+		{name: "grafana config 0 falls back to env var", limit: 0, ctxLimit: ptr(int64(0)), envLimit: "3", expectedBodyLength: 3, expectedBody: "dum", expectErr: true},
 		{name: "no limit when nothing is set", limit: 0, expectedBodyLength: 5, expectedBody: "dummy"},
 	}
 	for _, tc := range tcs {
@@ -53,7 +55,9 @@ func TestResponseLimitMiddleware(t *testing.T) {
 
 			ctx := context.Background()
 			if tc.ctxLimit != nil {
-				ctx = WithResponseLimitContext(ctx, *tc.ctxLimit)
+				ctx = config.WithGrafanaConfig(ctx, config.NewGrafanaCfg(map[string]string{
+					config.ResponseLimit: strconv.FormatInt(*tc.ctxLimit, 10),
+				}))
 			}
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.com/query", nil)
 			require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

This PR will add response limit middleware to the default Middleware but unless the `GF_DATASOURCE_RESPONSE_LIMIT` is set it there will be no functional difference if a datasource updates. 

The context around this change is we want to begin rolling out limits in our cloud environment for datasources which can occasionally return very very large responses. 

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

I would like to be able to configure this via settings but I am not sure if this is the best approach. 