### PR TITLE
Don't allow use of http.DefaultTransport with secure socks proxy

### DIFF
--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -41,6 +41,7 @@ var (
 		Name:      "secure_socks_requests_duration",
 		Help:      "Duration of requests to the secure socks proxy",
 	}, []string{"code", "datasource", "datasource_type"})
+	errUseOfHTTPDefaultTransport = errors.New("use of the http.DefaultTransport is not allowed with secure proxy")
 )
 
 // Client is the main Proxy Client interface.
@@ -90,11 +91,15 @@ func (p *cfgProxyWrapper) SecureSocksProxyEnabled() bool {
 	return true
 }
 
-// ConfigureSecureSocksHTTPProxy takes a http.DefaultTransport and wraps it in a socks5 proxy with TLS
+// ConfigureSecureSocksHTTPProxy takes a http.Transport and wraps it in a socks5 proxy with TLS
 // if it is enabled on the datasource and the grafana instance
 func (p *cfgProxyWrapper) ConfigureSecureSocksHTTPProxy(transport *http.Transport) error {
 	if !p.SecureSocksProxyEnabled() {
 		return nil
+	}
+
+	if transport == http.DefaultTransport {
+		return errUseOfHTTPDefaultTransport
 	}
 
 	dialSocksProxy, err := p.NewSecureSocksProxyContextDialer()

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -109,6 +109,13 @@ func TestNewSecureSocksProxy(t *testing.T) {
 		require.NoError(t, cli.ConfigureSecureSocksHTTPProxy(&http.Transport{}))
 	})
 
+	t.Run("New socks proxy should fail with expect error with using http.DefaultTransport", func(t *testing.T) {
+		defaultHTTPTransport, ok := http.DefaultTransport.(*http.Transport)
+		require.True(t, ok)
+		err := cli.ConfigureSecureSocksHTTPProxy(defaultHTTPTransport)
+		require.Equal(t, errUseOfHTTPDefaultTransport, err)
+	})
+
 	t.Run("Client cert must be valid", func(t *testing.T) {
 		clientCertBefore := opts.ClientCfg.ClientCertVal
 		opts.ClientCfg.ClientCertVal = ""


### PR DESCRIPTION
This PR adds a check that stops usage of `http.DefaultTransport` in secure socks proxy connections.