### PR TITLE
Fix: return clone of http.DefaultTransport from GetTransport() with no arguments

### DIFF
--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -50,7 +50,7 @@ func New(opts ...Options) (*http.Client, error) {
 // Note: If more than one Options is provided a panic is raised.
 func GetTransport(opts ...Options) (http.RoundTripper, error) {
 	if opts == nil {
-		return http.DefaultTransport, nil
+		return GetDefaultTransport()
 	}
 
 	clientOpts := createOptions(opts...)
@@ -94,6 +94,16 @@ func GetTransport(opts ...Options) (http.RoundTripper, error) {
 	}
 
 	return roundTripperFromMiddlewares(clientOpts, clientOpts.Middlewares, transport)
+}
+
+// GetDefaultTransport returns a clone of http.DefaultTransport, if it's of the
+// correct type, or an error otherwise. There are a number of places where plugin
+// code uses http.DefaultTransport; this supports doing so in a safer way.
+func GetDefaultTransport() (http.RoundTripper, error) {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		return transport.Clone(), nil
+	}
+	return nil, fmt.Errorf("http.DefaultTransport is not *http.Transport but %T", http.DefaultTransport)
 }
 
 // GetTLSConfig creates a new tls.Config given provided options.

--- a/backend/httpclient/http_client_test.go
+++ b/backend/httpclient/http_client_test.go
@@ -241,3 +241,14 @@ func TestReverseMiddlewares(t *testing.T) {
 		require.Equal(t, "mw1", reversed[3].(MiddlewareName).MiddlewareName())
 	})
 }
+
+func TestDefaultTransport(t *testing.T) {
+	t.Run("Transport returned from GetTransport() with no arguments is not http.DefaultTransport", func(t *testing.T) {
+		transport, err := GetTransport()
+		require.NoError(t, err)
+		// This is essentially the same check added to secure_socks_proxy.go in
+		// https://github.com/grafana/grafana-plugin-sdk-go/pull/1295; since that's
+		// addressing the issue we're concerned with here, it should suffice.
+		require.NotEqual(t, transport, http.DefaultTransport.(*http.Transport))
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
For safety, we never want to return `http.DefaultTransport` to plugin clients in case the returned transport is mutated.
