### PR TITLE
ParseHTTPSettings: Add guards for boolean fields

### DIFF
--- a/backend/http_settings.go
+++ b/backend/http_settings.go
@@ -127,7 +127,9 @@ func parseHTTPSettings(jsonData json.RawMessage, secureJSONData map[string]strin
 
 	// Basic auth
 	if v, exists := dat["basicAuth"]; exists {
-		s.BasicAuthEnabled = v.(bool)
+		if basicAuth, ok := v.(bool); ok {
+			s.BasicAuthEnabled = basicAuth
+		}
 	}
 	if s.BasicAuthEnabled {
 		if v, exists := dat["basicAuthUser"]; exists {
@@ -245,7 +247,9 @@ func parseHTTPSettings(jsonData json.RawMessage, secureJSONData map[string]strin
 
 	// SigV4
 	if v, exists := dat["sigV4Auth"]; exists {
-		s.SigV4Auth = v.(bool)
+		if sigV4Auth, ok := v.(bool); ok {
+			s.SigV4Auth = sigV4Auth
+		}
 	}
 
 	if s.SigV4Auth {

--- a/backend/http_settings.go
+++ b/backend/http_settings.go
@@ -213,13 +213,25 @@ func parseHTTPSettings(jsonData json.RawMessage, secureJSONData map[string]strin
 
 	// TLS
 	if v, exists := dat["tlsAuth"]; exists {
-		s.TLSClientAuth = v.(bool)
+		if tlsClientAuth, ok := v.(bool); ok {
+			s.TLSClientAuth = tlsClientAuth
+		} else {
+			return nil, DownstreamError(fmt.Errorf("tlsAuth must be a boolean"))
+		}
 	}
 	if v, exists := dat["tlsAuthWithCACert"]; exists {
-		s.TLSAuthWithCACert = v.(bool)
+		if tslAuthCert, ok := v.(bool); ok {
+			s.TLSAuthWithCACert = tslAuthCert
+		} else {
+			return nil, DownstreamError(fmt.Errorf("tlsAuthWithCACert must be a boolean"))
+		}
 	}
 	if v, exists := dat["tlsSkipVerify"]; exists {
-		s.TLSSkipVerify = v.(bool)
+		if tlsSkipVerify, ok := v.(bool); ok {
+			s.TLSSkipVerify = tlsSkipVerify
+		} else {
+			return nil, DownstreamError(fmt.Errorf("tlsSkipVerify must be a boolean"))
+		}
 	}
 
 	if s.TLSClientAuth || s.TLSAuthWithCACert {

--- a/backend/http_settings.go
+++ b/backend/http_settings.go
@@ -215,22 +215,16 @@ func parseHTTPSettings(jsonData json.RawMessage, secureJSONData map[string]strin
 	if v, exists := dat["tlsAuth"]; exists {
 		if tlsClientAuth, ok := v.(bool); ok {
 			s.TLSClientAuth = tlsClientAuth
-		} else {
-			return nil, DownstreamError(fmt.Errorf("tlsAuth must be a boolean"))
 		}
 	}
 	if v, exists := dat["tlsAuthWithCACert"]; exists {
 		if tslAuthCert, ok := v.(bool); ok {
 			s.TLSAuthWithCACert = tslAuthCert
-		} else {
-			return nil, DownstreamError(fmt.Errorf("tlsAuthWithCACert must be a boolean"))
 		}
 	}
 	if v, exists := dat["tlsSkipVerify"]; exists {
 		if tlsSkipVerify, ok := v.(bool); ok {
 			s.TLSSkipVerify = tlsSkipVerify
-		} else {
-			return nil, DownstreamError(fmt.Errorf("tlsSkipVerify must be a boolean"))
 		}
 	}
 

--- a/backend/http_settings_test.go
+++ b/backend/http_settings_test.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -150,56 +149,18 @@ func TestParseHTTPSettings(t *testing.T) {
 		})
 	})
 }
-func TestParseHTTTPSettingsWithInvalidOptions(t *testing.T) {
-	for _, tc := range []struct {
-		name       string
-		err        error
-		jsonString string
-	}{
-		{
-			name: "invalid tlsAuth",
-			jsonString: `{
-							"access": "browser",
-							"url": "http://domain.com",
-							"basicAuth": true,
-							"basicAuthUser": "user",
+func TestParseHTTTPSettingsWithInvalidTLSOptions(t *testing.T) {
+	t.Run("ignore TSL options if they are not boolean", func(t *testing.T) {
+		jsonData := `{
 							"tlsAuth": "true",
-							"tlsAuthWithCACert": true,
-							"tlsSkipVerify": true
-							}`,
-			err: DownstreamError(fmt.Errorf("tlsAuth must be a boolean")),
-		},
-		{
-			name: "invalid tlsSkipVerify",
-			jsonString: `{
-							"access": "browser",
-							"url": "http://domain.com",
-							"basicAuth": true,
-							"basicAuthUser": "user",
-							"tlsAuth": true,
-							"tlsAuthWithCACert": true,
+							"tlsAuthWithCACert": "true",
 							"tlsSkipVerify": "true"
-							}`,
-			err: DownstreamError(fmt.Errorf("tlsSkipVerify must be a boolean")),
-		},
-		{
-			name: "invalid tlsAuthWithCACert",
-			jsonString: `{
-				"access": "browser",
-				"url": "http://domain.com",
-				"basicAuth": true,
-				"basicAuthUser": "user",
-				"tlsAuth": true,
-				"tlsAuthWithCACert": "true",
-				"tlsSkipVerify": true
-				}`,
-			err: DownstreamError(fmt.Errorf("tlsAuthWithCACert must be a boolean")),
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			secureData := map[string]string{}
-			_, err := parseHTTPSettings([]byte(tc.jsonString), secureData)
-			require.Equal(t, tc.err, err)
-		})
-	}
+							}`
+		secureData := map[string]string{}
+		res, err := parseHTTPSettings([]byte(jsonData), secureData)
+		require.NoError(t, err)
+		require.False(t, res.TLSClientAuth)
+		require.False(t, res.TLSAuthWithCACert)
+		require.False(t, res.TLSSkipVerify)
+	})
 }

--- a/backend/http_settings_test.go
+++ b/backend/http_settings_test.go
@@ -149,12 +149,14 @@ func TestParseHTTPSettings(t *testing.T) {
 		})
 	})
 }
-func TestParseHTTTPSettingsWithInvalidTLSOptions(t *testing.T) {
-	t.Run("ignore TSL options if they are not boolean", func(t *testing.T) {
+func TestParseHTTTPSettingsWithInvalidOptions(t *testing.T) {
+	t.Run("ignore fields of type bool if they are not boolean", func(t *testing.T) {
 		jsonData := `{
 							"tlsAuth": "true",
 							"tlsAuthWithCACert": "true",
-							"tlsSkipVerify": "true"
+							"tlsSkipVerify": "true",
+							"sigV4Auth": "true",
+							"basicAuthEnabled": "true"
 							}`
 		secureData := map[string]string{}
 		res, err := parseHTTPSettings([]byte(jsonData), secureData)
@@ -162,5 +164,7 @@ func TestParseHTTTPSettingsWithInvalidTLSOptions(t *testing.T) {
 		require.False(t, res.TLSClientAuth)
 		require.False(t, res.TLSAuthWithCACert)
 		require.False(t, res.TLSSkipVerify)
+		require.False(t, res.SigV4Auth)
+		require.False(t, res.BasicAuthEnabled)
 	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
We got some internal server errors due to presumably wrong types in provisioning files, more info [here](https://github.com/grafana/data-sources/issues/419) and [here](https://raintank-corp.slack.com/archives/C0811LD8J30/p1731918137264909?thread_ts=1731917968.856339&cid=C0811LD8J30). 
This returns an error if these fields aren't boolean. 
I thought of trying to convert them to booleans, but I feel like we probably shouldn't ignore incorrect types in provisioning files. Though I'm not sure where this error message ends up and if it's visible to the user? Elsewhere in the file we just set the defaults if the type is wrong so maybe this wouldn't work
