### PR TITLE
build(deps): update HAR library

### DIFF
--- a/experimental/e2e/storage/har.go
+++ b/experimental/e2e/storage/har.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -246,7 +247,7 @@ func (s *HAR) saveUnsafe() error {
 	if err != nil {
 		return err
 	}
-	raw, err := s.har.MarshalJSON()
+	raw, err := json.Marshal(s.har)
 	if err != nil {
 		return err
 	}
@@ -265,7 +266,8 @@ func (s *HAR) loadUnsafe() error {
 	if err != nil {
 		return err
 	}
-	return s.har.UnmarshalJSON(raw)
+
+	return json.Unmarshal(raw, &s.har)
 }
 
 // Match returns the stored http.Response for the given request.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.1
 require (
 	github.com/apache/arrow-go/v18 v18.2.0
 	github.com/cheekybits/genny v1.0.0
-	github.com/chromedp/cdproto v0.0.0-20220208224320-6efb837e6bc2
+	github.com/chromedp/cdproto v0.0.0-20250429231605-6ed5b53462d4
 	github.com/elazarl/goproxy v1.7.2
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/go-openapi/loads v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitf
 github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
 github.com/chromedp/cdproto v0.0.0-20220208224320-6efb837e6bc2 h1:XCdvHbz3LhewBHN7+mQPx0sg/Hxil/1USnBmxkjHcmY=
 github.com/chromedp/cdproto v0.0.0-20220208224320-6efb837e6bc2/go.mod h1:At5TxYYdxkbQL0TSefRjhLE3Q0lgvqKKMSFUglJ7i1U=
+github.com/chromedp/cdproto v0.0.0-20250429231605-6ed5b53462d4 h1:UZdrvid2JFwnvPlUSEFlE794XZL4Jmrj8fuxfcLECJE=
+github.com/chromedp/cdproto v0.0.0-20250429231605-6ed5b53462d4/go.mod h1:NItd7aLkcfOA/dcMXvl8p1u+lQqioRMq/SqDp71Pb/k=
 github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moAV0xufSww=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=


### PR DESCRIPTION
The HAR library as we use it here depends on implementation details. Instead of the `UnmarshalJSON` and `MarshalJSON` functions that are (no longer) defined in the library, we should use `encoding/json` directly and let it do the indirection instead.

I discovered this while testing the viability of updating all dependencies in Grafana.