### PR TITLE
experimental: apis: do not default to refid=A

### DIFF
--- a/experimental/apis/data/v0alpha1/conversions.go
+++ b/experimental/apis/data/v0alpha1/conversions.go
@@ -69,9 +69,6 @@ func toBackendDataQuery(q DataQuery, defaultTimeRange *backend.TimeRange) (backe
 	if err != nil {
 		return bq, err
 	}
-	if bq.RefID == "" {
-		bq.RefID = "A"
-	}
 	if bq.MaxDataPoints == 0 {
 		bq.MaxDataPoints = 100
 	}

--- a/experimental/apis/data/v0alpha1/conversions_test.go
+++ b/experimental/apis/data/v0alpha1/conversions_test.go
@@ -12,7 +12,11 @@ func TestConversionsDefaults(t *testing.T) {
 
 	require.NoError(t, err)
 
-	require.Equal(t, "A", res.RefID)
+	// we used to default the refId to "A",
+	// we do not do that anymore,
+	// we verify the new behavior
+	require.Equal(t, "", res.RefID)
+
 	require.Equal(t, int64(100), res.MaxDataPoints)
 	require.Equal(t, time.Second, res.Interval)
 }


### PR DESCRIPTION
fixes https://github.com/grafana/grafana-plugin-sdk-go/issues/1331

this new behavior is how this works in the current `/api/ds/query`.

technically this is a change in behavior, but it is in the `experimental` package, where such things are allowed.