### PR TITLE
E2E: Move e2e mage targets to new package

### DIFF
--- a/backend/setup.go
+++ b/backend/setup.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
-	"github.com/grafana/grafana-plugin-sdk-go/build"
+	"github.com/grafana/grafana-plugin-sdk-go/build/info"
 	"github.com/grafana/grafana-plugin-sdk-go/internal/tracerprovider"
 )
 
@@ -165,7 +165,7 @@ func getTracerCustomAttributes(pluginID string) []attribute.KeyValue {
 	// Try to get plugin version from build info
 	// If not available, fallback to environment variable
 	var pluginVersion string
-	buildInfo, err := build.GetBuildInfo()
+	buildInfo, err := info.GetBuildInfo()
 	if err != nil {
 		Logger.Debug("Failed to get build info", "error", err)
 	} else {
@@ -186,7 +186,7 @@ func getTracerCustomAttributes(pluginID string) []attribute.KeyValue {
 // SetupTracer sets up the global OTEL trace provider and tracer.
 func SetupTracer(pluginID string, tracingOpts tracing.Opts) error {
 	// Set up tracing
-	tracingCfg := getTracingConfig(build.GetBuildInfo)
+	tracingCfg := getTracingConfig(info.GetBuildInfo)
 	if tracingCfg.isEnabled() {
 		// Append custom attributes to the default ones
 		tracingOpts.CustomAttributes = append(getTracerCustomAttributes(pluginID), tracingOpts.CustomAttributes...)
@@ -244,7 +244,7 @@ func (c tracingConfig) isEnabled() bool {
 }
 
 // getTracingConfig returns a new tracingConfig based on the current environment variables.
-func getTracingConfig(buildInfoGetter build.InfoGetter) tracingConfig {
+func getTracingConfig(buildInfoGetter info.Getter) tracingConfig {
 	var otelAddr, otelPropagation, samplerRemoteURL, samplerParamString string
 	var samplerType tracerprovider.SamplerType
 	var samplerParam float64
@@ -289,7 +289,7 @@ func getTracingConfig(buildInfoGetter build.InfoGetter) tracingConfig {
 // remoteSamplerServiceName returns the service name for the remote tracing sampler.
 // It attempts to get it from the provided buildinfo getter. If unsuccessful or empty,
 // defaultRemoteSamplerServiceName is returned instead.
-func remoteSamplerServiceName(buildInfoGetter build.InfoGetter) string {
+func remoteSamplerServiceName(buildInfoGetter info.Getter) string {
 	// Use plugin id as service name, if possible. Otherwise, use a generic default value.
 	bi, err := buildInfoGetter.GetInfo()
 	if err != nil {

--- a/backend/setup_test.go
+++ b/backend/setup_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
-	"github.com/grafana/grafana-plugin-sdk-go/build"
+	"github.com/grafana/grafana-plugin-sdk-go/build/info"
 	"github.com/grafana/grafana-plugin-sdk-go/internal/tracerprovider"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
@@ -15,7 +15,7 @@ func TestGetTracingConfig(t *testing.T) {
 		name string
 
 		env             map[string]string
-		buildInfoGetter build.InfoGetter
+		buildInfoGetter info.Getter
 
 		expEnabled bool
 		expCfg     tracingConfig
@@ -94,8 +94,8 @@ func TestGetTracingConfig(t *testing.T) {
 				PluginTracingSamplerParamEnv:                 "0.5",
 				PluginTracingSamplerRemoteURL:                "127.0.0.1:10001",
 			},
-			buildInfoGetter: build.InfoGetterFunc(func() (build.Info, error) {
-				return build.Info{PluginID: "my-example-datasource"}, nil
+			buildInfoGetter: info.GetterFunc(func() (info.Info, error) {
+				return info.Info{PluginID: "my-example-datasource"}, nil
 			}),
 			expEnabled: true,
 			expCfg: tracingConfig{
@@ -117,7 +117,7 @@ func TestGetTracingConfig(t *testing.T) {
 				t.Setenv(e, v)
 			}
 			if tc.buildInfoGetter == nil {
-				tc.buildInfoGetter = build.GetBuildInfo
+				tc.buildInfoGetter = info.GetBuildInfo
 			}
 			cfg := getTracingConfig(tc.buildInfoGetter)
 			require.Equal(t, tc.expEnabled, cfg.isEnabled())

--- a/build/common.go
+++ b/build/common.go
@@ -19,6 +19,7 @@ import (
 	bra "github.com/unknwon/bra/cmd"
 	"github.com/urfave/cli"
 
+	"github.com/grafana/grafana-plugin-sdk-go/build/info"
 	"github.com/grafana/grafana-plugin-sdk-go/build/utils"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e"
 	ca "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/certificate_authority"
@@ -157,7 +158,7 @@ func getBuildBackendCmdInfo(cfg Config) (Config, []string, error) {
 		"build", "-o", filepath.Join(outputPath, exePath),
 	}
 
-	info := Info{
+	info := info.Info{
 		Time: now().UnixNano() / int64(time.Millisecond),
 	}
 	pluginID, err := internal.GetStringValueFromJSON(filepath.Join(pluginJSONPath, "plugin.json"), "id")
@@ -172,7 +173,7 @@ func getBuildBackendCmdInfo(cfg Config) (Config, []string, error) {
 	args = append(args, "-tags", "arrow_json_stdlib")
 
 	flags := make(map[string]string, 10)
-	info.appendFlags(flags)
+	info.AppendFlags(flags)
 
 	if cfg.CustomVars != nil {
 		for k, v := range cfg.CustomVars {

--- a/build/common.go
+++ b/build/common.go
@@ -21,11 +21,6 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/build/info"
 	"github.com/grafana/grafana-plugin-sdk-go/build/utils"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e"
-	ca "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/certificate_authority"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/config"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/fixture"
-	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/storage"
 	"github.com/grafana/grafana-plugin-sdk-go/internal"
 )
 
@@ -444,60 +439,6 @@ func Clean() error {
 		return err
 	}
 	return nil
-}
-
-// E2E is a namespace.
-type E2E mg.Namespace
-
-// Append starts the E2E proxy in append mode.
-func (E2E) Append() error {
-	return e2eProxy(e2e.ProxyModeAppend)
-}
-
-// Overwrite starts the E2E proxy in overwrite mode.
-func (E2E) Overwrite() error {
-	return e2eProxy(e2e.ProxyModeOverwrite)
-}
-
-// Replay starts the E2E proxy in replay mode.
-func (E2E) Replay() error {
-	return e2eProxy(e2e.ProxyModeReplay)
-}
-
-// Certificate prints the CA certificate to stdout.
-func (E2E) Certificate() error {
-	cfg, err := config.LoadConfig("proxy.json")
-	if err != nil {
-		return err
-	}
-
-	if cert, _, err := ca.LoadKeyPair(cfg.CAConfig.Cert, cfg.CAConfig.PrivateKey); err == nil {
-		fmt.Print(string(cert))
-		return nil
-	}
-
-	fmt.Print(string(ca.CACertificate))
-	return nil
-}
-
-func e2eProxy(mode e2e.ProxyMode) error {
-	cfg, err := config.LoadConfig("proxy.json")
-	if err != nil {
-		return err
-	}
-	fixtures := make([]*fixture.Fixture, 0)
-	for _, s := range cfg.Storage {
-		switch s.Type {
-		case config.StorageTypeHAR:
-			store := storage.NewHARStorage(s.Path)
-			fixtures = append(fixtures, fixture.NewFixture(store))
-		case config.StorageTypeOpenAPI:
-			store := storage.NewOpenAPIStorage(s.Path)
-			fixtures = append(fixtures, fixture.NewFixture(store))
-		}
-	}
-	proxy := e2e.NewProxy(mode, fixtures, cfg)
-	return proxy.Start()
 }
 
 // checkLinuxPtraceScope verifies that ptrace is configured as required.

--- a/build/common_test.go
+++ b/build/common_test.go
@@ -153,7 +153,7 @@ func Test_getBuildBackendCmdInfo(t *testing.T) {
 				Env:            map[string]string{"CGO_ENABLED": "0", "GOARCH": "arm64", "GOOS": "darwin"},
 				PluginJSONPath: filepath.Join(tmpDir, "foobar-datasource"),
 			},
-			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, "gpx_foo_darwin_arm64"), "-tags", "arrow_json_stdlib", "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={.*}'", "./pkg"},
+			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, "gpx_foo_darwin_arm64"), "-tags", "arrow_json_stdlib", "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build/info.buildInfoJSON={.*}'", "./pkg"},
 			wantErr:      assert.NoError,
 		},
 		{
@@ -174,7 +174,7 @@ func Test_getBuildBackendCmdInfo(t *testing.T) {
 				Env:            map[string]string{"CGO_ENABLED": "0", "GOARCH": "arm64", "GOOS": "darwin"},
 				PluginJSONPath: filepath.Join(tmpDir, "foobar-app"),
 			},
-			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, defaultNestedDataSourcePath, "gpx_foo_darwin_arm64"), "-tags", "arrow_json_stdlib", "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={.*}'", "./pkg"},
+			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, defaultNestedDataSourcePath, "gpx_foo_darwin_arm64"), "-tags", "arrow_json_stdlib", "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build/info.buildInfoJSON={.*}'", "./pkg"},
 			wantErr:      assert.NoError,
 		},
 		{
@@ -195,7 +195,7 @@ func Test_getBuildBackendCmdInfo(t *testing.T) {
 				Env:            map[string]string{"CGO_ENABLED": "0", "GOARCH": "amd64", "GOOS": "windows"},
 				PluginJSONPath: filepath.Join(tmpDir, "foobarbaz-app"),
 			},
-			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, "gpx_foobarbaz_windows_amd64.exe"), "-tags", "arrow_json_stdlib", "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={.*}'", "./pkg"},
+			expectedArgs: []string{"build", "-o", filepath.Join(defaultOutputBinaryPath, "gpx_foobarbaz_windows_amd64.exe"), "-tags", "arrow_json_stdlib", "-ldflags", "-w -s -extldflags \"-static\" -X 'github.com/grafana/grafana-plugin-sdk-go/build/info.buildInfoJSON={.*}'", "./pkg"},
 			wantErr:      assert.NoError,
 		},
 	}

--- a/build/info.go
+++ b/build/info.go
@@ -1,60 +1,21 @@
 package build
 
 import (
-	"encoding/json"
-	"fmt"
 	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/build/info"
 )
 
-// set from -X
-var buildInfoJSON string
+var now = time.Now // allow override for testing
 
-// exposed for testing.
-var now = time.Now
+// Deprecated: Use github.com/grafana/grafana-plugin-sdk-go/build/info.Info instead.
+type Info = info.Info
 
-// Info See also PluginBuildInfo in https://github.com/grafana/grafana/blob/master/pkg/plugins/models.go
-type Info struct {
-	Time     int64  `json:"time,omitempty"`
-	PluginID string `json:"pluginID,omitempty"`
-	Version  string `json:"version,omitempty"`
-}
+// Deprecated: Use github.com/grafana/grafana-plugin-sdk-go/build/info.Getter instead.
+type InfoGetter = info.Getter
 
-// this will append build flags -- the keys are picked to match existing
-// grafana build flags from bra
-func (v Info) appendFlags(flags map[string]string) {
-	if v.PluginID != "" {
-		flags["main.pluginID"] = v.PluginID
-	}
-	if v.Version != "" {
-		flags["main.version"] = v.Version
-	}
+// Deprecated: Use github.com/grafana/grafana-plugin-sdk-go/build/info.GetterFunc instead.
+type InfoGetterFunc = info.GetterFunc
 
-	out, err := json.Marshal(v)
-	if err == nil {
-		flags["github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON"] = string(out)
-	}
-}
-
-// InfoGetter is an interface with a method for returning the build info.
-type InfoGetter interface {
-	// GetInfo returns the build info.
-	GetInfo() (Info, error)
-}
-
-// InfoGetterFunc can be used to adapt ordinary functions into types satisfying the InfoGetter interface .
-type InfoGetterFunc func() (Info, error)
-
-func (f InfoGetterFunc) GetInfo() (Info, error) {
-	return f()
-}
-
-// GetBuildInfo is the default InfoGetter that returns the build information that was compiled into the binary using:
-// -X `github.com/grafana/grafana-plugin-sdk-go/build.buildInfoJSON={...}`
-var GetBuildInfo = InfoGetterFunc(func() (Info, error) {
-	v := Info{}
-	if buildInfoJSON == "" {
-		return v, fmt.Errorf("build info was now set when this was compiled")
-	}
-	err := json.Unmarshal([]byte(buildInfoJSON), &v)
-	return v, err
-})
+// Deprecated: Use github.com/grafana/grafana-plugin-sdk-go/build/info.GetBuildInfo instead.
+var GetBuildInfo = info.GetBuildInfo

--- a/build/info/info.go
+++ b/build/info/info.go
@@ -1,0 +1,56 @@
+package info
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// set from -X
+var buildInfoJSON string
+
+// Info See also PluginBuildInfo in https://github.com/grafana/grafana/blob/master/pkg/plugins/models.go
+type Info struct {
+	Time     int64  `json:"time,omitempty"`
+	PluginID string `json:"pluginID,omitempty"`
+	Version  string `json:"version,omitempty"`
+}
+
+// this will append build flags -- the keys are picked to match existing
+// grafana build flags from bra
+func (v Info) AppendFlags(flags map[string]string) {
+	if v.PluginID != "" {
+		flags["main.pluginID"] = v.PluginID
+	}
+	if v.Version != "" {
+		flags["main.version"] = v.Version
+	}
+
+	out, err := json.Marshal(v)
+	if err == nil {
+		flags["github.com/grafana/grafana-plugin-sdk-go/build/info.buildInfoJSON"] = string(out)
+	}
+}
+
+// Getter is an interface with a method for returning the build info.
+type Getter interface {
+	// GetInfo returns the build info.
+	GetInfo() (Info, error)
+}
+
+// GetterFunc can be used to adapt ordinary functions into types satisfying the InfoGetter interface .
+type GetterFunc func() (Info, error)
+
+func (f GetterFunc) GetInfo() (Info, error) {
+	return f()
+}
+
+// GetBuildInfo is the default InfoGetter that returns the build information that was compiled into the binary using:
+// -X `github.com/grafana/grafana-plugin-sdk-go/build/info.buildInfoJSON={...}`
+var GetBuildInfo = GetterFunc(func() (Info, error) {
+	v := Info{}
+	if buildInfoJSON == "" {
+		return v, fmt.Errorf("build info was now set when this was compiled")
+	}
+	err := json.Unmarshal([]byte(buildInfoJSON), &v)
+	return v, err
+})

--- a/experimental/e2e/README.md
+++ b/experimental/e2e/README.md
@@ -38,20 +38,33 @@ The goal of the proxy is to provide a way to record and replay HTTP interactions
 
 2. Add the proxy's CA certificate to your environment ([instructions](#ca-certificate-setup)).
 
-3. Start proxy using one of the [commands listed below](#mage-commands). For example:
+3. Add the E2E mage targets to your `Magefile.go` imports.
 
+```diff
+package main
+ 
+import (
+	// mage:import
+	build "github.com/grafana/grafana-plugin-sdk-go/build"
++	// mage:import
++	_ "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/mage"
+)
 ```
+
+4. Start proxy using one of the [commands listed below](#mage-commands). For example:
+
+```bash
 mage e2e:append
 ```
 
-4. Point Grafana at the proxy by exporting the `HTTP_PROXY` and `HTTPS_PROXY` environment variables:
+5. Point Grafana at the proxy by exporting the `HTTP_PROXY` and `HTTPS_PROXY` environment variables:
 
-```
+```bash
 export HTTP_PROXY=127.0.0.1:9999
 export HTTPS_PROXY=127.0.0.1:9999
 ```
 
-5. Start Grafana
+6. Start Grafana
 
 **Note:** Only queries with **absolute time ranges** should be used with the proxy. Relative time ranges are not supported in the default matcher.
 
@@ -63,13 +76,13 @@ This step is needed so that the proxy can intercept HTTPS traffic. By default, t
 
 1. Add CA certificate:
 
-```
+```bash
 mage e2e:certificate && sudo tee /usr/share/ca-certificates/extra/ca.crt
 ```
 
 2. Update the CA store:
 
-```
+```bash
 sudo update-ca-certificates --fresh
 ```
 
@@ -77,13 +90,13 @@ sudo update-ca-certificates --fresh
 
 1. Create a temporary copy of the CA certificate:
 
-```
+```bash
 mage e2e:certificate > /tmp/grafana-e2e.crt
 ```
 
 2. Add CA certificate:
 
-```
+```bash
 sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain /tmp/grafana-e2e.crt
 ```
 
@@ -186,7 +199,7 @@ Example configuration:
 
 Append mode should be used to record interactions for any new tests. It will record requests and responses for any requests that haven't been seen before, and return recorded responses for any requests that match previously recorded interactions.
 
-```
+```bash
 mage e2e:append
 ```
 
@@ -194,7 +207,7 @@ mage e2e:append
 
 Overwrite mode should be used if previously recorded interactions need to be replaced with new data.
 
-```
+```bash
 mage e2e:overwrite
 ```
 
@@ -202,7 +215,7 @@ mage e2e:overwrite
 
 Replay mode should be used in CI or locally if only playback of recorded data is needed. Replay mode will return recorded responses for any matching requests, and pass any requests that don't match recorded interactions to the target API.
 
-```
+```bash
 mage e2e:replay
 ```
 
@@ -210,7 +223,7 @@ mage e2e:replay
 
 This command prints the CA certificate to stdout so that it can be added to the local test environment. For more information, see the [CA Setup](#ca-certificate-setup) section above.
 
-```
+```bash
 mage e2e:certificate
 ```
 
@@ -300,7 +313,7 @@ func CustomE2E() error {
 
 Start the proxy using the new `CustomE2E` mage target:
 
-```
+```bash
 mage CustomE2E
 ```
 

--- a/experimental/e2e/mage/e2e.go
+++ b/experimental/e2e/mage/e2e.go
@@ -1,0 +1,66 @@
+package mage
+
+import (
+	"fmt"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e"
+	ca "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/certificate_authority"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/config"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/fixture"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/storage"
+	"github.com/magefile/mage/mg"
+)
+
+// E2e is a namespace.
+type E2e mg.Namespace
+
+// Append starts the E2E proxy in append mode.
+func (E2e) Append() error {
+	return e2eProxy(e2e.ProxyModeAppend)
+}
+
+// Overwrite starts the E2E proxy in overwrite mode.
+func (E2e) Overwrite() error {
+	return e2eProxy(e2e.ProxyModeOverwrite)
+}
+
+// Replay starts the E2E proxy in replay mode.
+func (E2e) Replay() error {
+	return e2eProxy(e2e.ProxyModeReplay)
+}
+
+// Certificate prints the CA certificate to stdout.
+func (E2e) Certificate() error {
+	cfg, err := config.LoadConfig("proxy.json")
+	if err != nil {
+		return err
+	}
+
+	if cert, _, err := ca.LoadKeyPair(cfg.CAConfig.Cert, cfg.CAConfig.PrivateKey); err == nil {
+		fmt.Print(string(cert))
+		return nil
+	}
+
+	fmt.Print(string(ca.CACertificate))
+	return nil
+}
+
+func e2eProxy(mode e2e.ProxyMode) error {
+	cfg, err := config.LoadConfig("proxy.json")
+	if err != nil {
+		return err
+	}
+	fixtures := make([]*fixture.Fixture, 0)
+	for _, s := range cfg.Storage {
+		switch s.Type {
+		case config.StorageTypeHAR:
+			store := storage.NewHARStorage(s.Path)
+			fixtures = append(fixtures, fixture.NewFixture(store))
+		case config.StorageTypeOpenAPI:
+			store := storage.NewOpenAPIStorage(s.Path)
+			fixtures = append(fixtures, fixture.NewFixture(store))
+		}
+	}
+	proxy := e2e.NewProxy(mode, fixtures, cfg)
+	return proxy.Start()
+}

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/grafana/grafana-plugin-sdk-go/build"
+	"github.com/grafana/grafana-plugin-sdk-go/build/info"
 )
 
 var (
@@ -27,7 +27,7 @@ func RunInfoMode() error {
 	if !InfoModeEnabled() {
 		return errors.New("build info mode not enabled")
 	}
-	bi, err := build.GetBuildInfo()
+	bi, err := info.GetBuildInfo()
 	if err != nil {
 		return fmt.Errorf("get build info: %w", err)
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

This moves `mage e2e:*` targets from `build/common.go` to `experimental/e2e/mage/e2e.go` as a follow up to to some cleanup in `build` in #1399.

Plugin developers that currently rely on the `mage e2e:*` targets will need to add a new import to their `Magefile.go`. Everything else should work as it did before once the new import is added.

```diff
package main

import (
	// mage:import
	build "github.com/grafana/grafana-plugin-sdk-go/build"
+	// mage:import
+	_ "github.com/grafana/grafana-plugin-sdk-go/experimental/e2e/mage"
)
```

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
