### PR TITLE
Feat: add session token support for sigv4 to support auth service

### DIFF
--- a/backend/http_settings.go
+++ b/backend/http_settings.go
@@ -45,6 +45,7 @@ type HTTPSettings struct {
 	SigV4Profile       string
 	SigV4AccessKey     string
 	SigV4SecretKey     string
+	SigV4SessionToken  string
 
 	JSONData       map[string]interface{}
 	SecureJSONData map[string]string
@@ -93,6 +94,7 @@ func (s *HTTPSettings) HTTPClientOptions() httpclient.Options {
 			Profile:       s.SigV4Profile,
 			AccessKey:     s.SigV4AccessKey,
 			SecretKey:     s.SigV4SecretKey,
+			SessionToken:  s.SigV4SessionToken,
 			AssumeRoleARN: s.SigV4AssumeRoleARN,
 			ExternalID:    s.SigV4ExternalID,
 			Region:        s.SigV4Region,
@@ -273,6 +275,9 @@ func parseHTTPSettings(jsonData json.RawMessage, secureJSONData map[string]strin
 		}
 		if v, exists := secureJSONData["sigV4SecretKey"]; exists {
 			s.SigV4SecretKey = v
+		}
+		if v, exists := secureJSONData["sigV4SessionToken"]; exists {
+			s.SigV4SessionToken = v
 		}
 	}
 

--- a/backend/http_settings_test.go
+++ b/backend/http_settings_test.go
@@ -55,6 +55,7 @@ func TestParseHTTPSettings(t *testing.T) {
 			"tlsClientKey":      "tlsClientKey3",
 			"sigV4AccessKey":    "sigV4AccessKey4",
 			"sigV4SecretKey":    "sigV4SecretKey5",
+			"sigV4SessionToken": "sigV4SessionToken6",
 			"httpHeaderValue1":  "SecretOne",
 			"httpHeaderValue2":  "SecretTwo",
 			"httpHeaderValue3":  "SecretThree",
@@ -99,6 +100,7 @@ func TestParseHTTPSettings(t *testing.T) {
 			SigV4Profile:          "ghi",
 			SigV4AccessKey:        "sigV4AccessKey4",
 			SigV4SecretKey:        "sigV4SecretKey5",
+			SigV4SessionToken:     "sigV4SessionToken6",
 			JSONData:              jsonMap,
 			SecureJSONData:        secureData,
 		}, s)
@@ -141,6 +143,7 @@ func TestParseHTTPSettings(t *testing.T) {
 					Profile:       "ghi",
 					AccessKey:     "sigV4AccessKey4",
 					SecretKey:     "sigV4SecretKey5",
+					SessionToken:  "sigV4SessionToken6",
 				},
 				Labels:        map[string]string{},
 				CustomOptions: map[string]interface{}{},

--- a/backend/httpclient/options.go
+++ b/backend/httpclient/options.go
@@ -127,6 +127,7 @@ type SigV4Config struct {
 	Service       string
 	AccessKey     string
 	SecretKey     string
+	SessionToken  string
 	AssumeRoleARN string
 	ExternalID    string
 	Region        string


### PR DESCRIPTION
**What this PR does / why we need it**:
The new implementation of Grafana Assume Role using the auth service requires a session token to be passed to the datasource. This is not intented for (nor useful for) use from the UI.