### PR TITLE
add logging to track memory leak in prometheus around instance manage…

### DIFF
--- a/backend/app/instance_provider.go
+++ b/backend/app/instance_provider.go
@@ -67,6 +67,10 @@ func (ip *instanceProvider) NeedsUpdate(_ context.Context, pluginContext backend
 	curAppSettings := pluginContext.AppInstanceSettings
 	appUpdated := !curAppSettings.Updated.Equal(cachedAppSettings.Updated)
 
+	if appUpdated || configUpdated {
+		backend.Logger.Debug("instance requires update", "appID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "appUpdated", appUpdated, "configUpdated", configUpdated)
+	}
+
 	return appUpdated || configUpdated
 }
 

--- a/backend/app/instance_provider.go
+++ b/backend/app/instance_provider.go
@@ -63,12 +63,16 @@ func (ip *instanceProvider) NeedsUpdate(_ context.Context, pluginContext backend
 	cachedConfig := cachedInstance.PluginContext.GrafanaConfig
 	configUpdated := !cachedConfig.Equal(curConfig)
 
+	if configUpdated {
+		backend.Logger.Debug("instance requires update due to config change", "appID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cached_config", cachedConfig, "current_config", curConfig)
+	}
+
 	cachedAppSettings := cachedInstance.PluginContext.AppInstanceSettings
 	curAppSettings := pluginContext.AppInstanceSettings
 	appUpdated := !curAppSettings.Updated.Equal(cachedAppSettings.Updated)
 
-	if appUpdated || configUpdated {
-		backend.Logger.Debug("instance requires update", "appID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "appUpdated", appUpdated, "configUpdated", configUpdated)
+	if appUpdated {
+		backend.Logger.Debug("instance requires update due to app change", "appID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cached_updated", cachedAppSettings.Updated, "current_updated", curAppSettings.Updated)
 	}
 
 	return appUpdated || configUpdated

--- a/backend/app/instance_provider.go
+++ b/backend/app/instance_provider.go
@@ -58,13 +58,13 @@ func (ip *instanceProvider) GetKey(ctx context.Context, pluginContext backend.Pl
 	return defaultKey, nil
 }
 
-func (ip *instanceProvider) NeedsUpdate(_ context.Context, pluginContext backend.PluginContext, cachedInstance instancemgmt.CachedInstance) bool {
+func (ip *instanceProvider) NeedsUpdate(ctx context.Context, pluginContext backend.PluginContext, cachedInstance instancemgmt.CachedInstance) bool {
 	curConfig := pluginContext.GrafanaConfig
 	cachedConfig := cachedInstance.PluginContext.GrafanaConfig
 	configUpdated := !cachedConfig.Equal(curConfig)
 
 	if configUpdated {
-		backend.Logger.Debug("instance requires update due to config change", "appID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cached_config", cachedConfig, "current_config", curConfig)
+		backend.Logger.FromContext(ctx).Debug("Instance requires update due to config change", "appID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cached_config", cachedConfig, "current_config", curConfig)
 	}
 
 	cachedAppSettings := cachedInstance.PluginContext.AppInstanceSettings
@@ -72,7 +72,7 @@ func (ip *instanceProvider) NeedsUpdate(_ context.Context, pluginContext backend
 	appUpdated := !curAppSettings.Updated.Equal(cachedAppSettings.Updated)
 
 	if appUpdated {
-		backend.Logger.Debug("instance requires update due to app change", "appID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cached_updated", cachedAppSettings.Updated, "current_updated", curAppSettings.Updated)
+		backend.Logger.FromContext(ctx).Debug("Instance requires update due to app change", "appID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cached_updated", cachedAppSettings.Updated, "current_updated", curAppSettings.Updated)
 	}
 
 	return appUpdated || configUpdated

--- a/backend/app/instance_provider.go
+++ b/backend/app/instance_provider.go
@@ -64,7 +64,7 @@ func (ip *instanceProvider) NeedsUpdate(ctx context.Context, pluginContext backe
 	configUpdated := !cachedConfig.Equal(curConfig)
 
 	if configUpdated {
-		backend.Logger.FromContext(ctx).Debug("Instance requires update due to config change", "appID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cached_config", cachedConfig, "current_config", curConfig)
+		backend.Logger.FromContext(ctx).Debug("Instance requires update due to config change", "cached_config", cachedConfig, "current_config", curConfig)
 	}
 
 	cachedAppSettings := cachedInstance.PluginContext.AppInstanceSettings
@@ -72,7 +72,7 @@ func (ip *instanceProvider) NeedsUpdate(ctx context.Context, pluginContext backe
 	appUpdated := !curAppSettings.Updated.Equal(cachedAppSettings.Updated)
 
 	if appUpdated {
-		backend.Logger.FromContext(ctx).Debug("Instance requires update due to app change", "appID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cached_updated", cachedAppSettings.Updated, "current_updated", curAppSettings.Updated)
+		backend.Logger.FromContext(ctx).Debug("Instance requires update due to app change", "cached_updated", cachedAppSettings.Updated, "current_updated", curAppSettings.Updated)
 	}
 
 	return appUpdated || configUpdated

--- a/backend/instancemgmt/instance_manager.go
+++ b/backend/instancemgmt/instance_manager.go
@@ -101,7 +101,7 @@ func (im *instanceManager) Get(ctx context.Context, pluginContext backend.Plugin
 	item, ok := im.cache.Load(cacheKey)
 	im.locker.RUnlock(cacheKey)
 
-	backend.Logger.Debug("getting datsource instance", "pluginID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cacheKey", cacheKey, "is_in_cache", ok)
+	backend.Logger.FromContext(ctx).Debug("Creating plugin instance", "pluginID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cacheKey", cacheKey, "is_in_cache", ok)
 
 	if ok {
 		ci := item.(CachedInstance)

--- a/backend/instancemgmt/instance_manager.go
+++ b/backend/instancemgmt/instance_manager.go
@@ -95,10 +95,13 @@ func (im *instanceManager) Get(ctx context.Context, pluginContext backend.Plugin
 	if err != nil {
 		return nil, err
 	}
+
 	// Double-checked locking for update/create criteria
 	im.locker.RLock(cacheKey)
 	item, ok := im.cache.Load(cacheKey)
 	im.locker.RUnlock(cacheKey)
+
+	backend.Logger.Debug("getting datsource instance", "pluginID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cacheKey", cacheKey, "is_in_cache", ok)
 
 	if ok {
 		ci := item.(CachedInstance)

--- a/backend/instancemgmt/instance_manager.go
+++ b/backend/instancemgmt/instance_manager.go
@@ -101,7 +101,7 @@ func (im *instanceManager) Get(ctx context.Context, pluginContext backend.Plugin
 	item, ok := im.cache.Load(cacheKey)
 	im.locker.RUnlock(cacheKey)
 
-	backend.Logger.FromContext(ctx).Debug("Creating plugin instance", "pluginID", pluginContext.PluginID, "orgID", pluginContext.OrgID, "cacheKey", cacheKey, "is_in_cache", ok)
+	backend.Logger.FromContext(ctx).Debug("Creating plugin instance", "cacheKey", cacheKey, "is_in_cache", ok)
 
 	if ok {
 		ci := item.(CachedInstance)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

This PR adds some Debug logging around instance management. Noticed a high number of instance creations in core datasources and I was not able to reproduce this locally. I suspect its something in the configurations sent in the context but it could also be the cache key.

Metrics values hidden to protect the innocent.

### Continual Memory increase in Prometheus
<img width="2122" height="364" alt="image" src="https://github.com/user-attachments/assets/e0d57a8f-d99d-47c4-9d36-5ba6dbc8d5e9" />


### mt_app_plugins_active_instances{} continually increase, more on clusters with more requests.
<img width="2125" height="211" alt="image" src="https://github.com/user-attachments/assets/8211e83a-d332-48e6-82ec-56e68302f2d1" />


**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
