### PR TITLE
httpclient: add support for tls.Config.GetClientCertificate

### DIFF
--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -153,6 +153,10 @@ func GetTLSConfig(opts ...Options) (*tls.Config, error) {
 		config.Certificates = []tls.Certificate{cert}
 	}
 
+	if tlsOpts.GetClientCertificate != nil {
+		config.GetClientCertificate = tlsOpts.GetClientCertificate
+	}
+
 	if tlsOpts.MinVersion > 0 {
 		config.MinVersion = tlsOpts.MinVersion
 	}

--- a/backend/httpclient/options.go
+++ b/backend/httpclient/options.go
@@ -118,6 +118,10 @@ type TLSOptions struct {
 
 	// MaxVersion configures the tls.Config.MaxVersion.
 	MaxVersion uint16
+
+	// GetClientCertificate optionally provides a callback
+	// for getting client certificates.
+	GetClientCertificate func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
 }
 
 // SigV4Config AWS SigV4 options.


### PR DESCRIPTION
**What this PR does / why we need it**:

Expose tls.Config.GetClientCertificate to allow supplying a callback that loads the client certificate and key on each request. This enables mTLS setups where certificates are rotated automatically without restarting the application.

Inspired by the etcd approach: https://github.com/etcd-io/etcd/pull/7829

**Which issue(s) this PR fixes**:

Needed for: https://github.com/grafana/grafana/pull/113982
Related to https://github.com/grafana/grafana/discussions/44296