### PR TITLE
http_logger: collect information from failed round trips

### DIFF
--- a/experimental/e2e/fixture/fixture.go
+++ b/experimental/e2e/fixture/fixture.go
@@ -32,11 +32,7 @@ func NewFixture(store storage.Storage) *Fixture {
 // Add processes the http.Request and http.Response with the Fixture's RequestProcessor and ResponseProcessor and adds them to the Fixure's Storage.
 func (f *Fixture) Add(originalReq *http.Request, originalRes *http.Response) error {
 	req := f.processRequest(originalReq)
-	var res *http.Response
-	if originalRes != nil {
-		// only process a response that is not nil
-		res = f.processResponse(originalRes)
-	}
+	res := f.processResponse(originalRes)
 	defer res.Body.Close()
 	return f.store.Add(req, res)
 }

--- a/experimental/e2e/fixture/fixture.go
+++ b/experimental/e2e/fixture/fixture.go
@@ -32,7 +32,11 @@ func NewFixture(store storage.Storage) *Fixture {
 // Add processes the http.Request and http.Response with the Fixture's RequestProcessor and ResponseProcessor and adds them to the Fixure's Storage.
 func (f *Fixture) Add(originalReq *http.Request, originalRes *http.Response) error {
 	req := f.processRequest(originalReq)
-	res := f.processResponse(originalRes)
+	var res *http.Response
+	if originalRes != nil {
+		// only process a response that is not nil
+		res = f.processResponse(originalRes)
+	}
 	defer res.Body.Close()
 	return f.store.Add(req, res)
 }

--- a/experimental/http_logger/http_logger.go
+++ b/experimental/http_logger/http_logger.go
@@ -73,6 +73,7 @@ func (hl *HTTPLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		if !skipSaving {
 			// save information from the request and failed response (if anything is available)
+			// nolint:errcheck - if there is a problem writing the error, we move on and just return the http error
 			hl.fixture.Add(req, res)
 		}
 		return res, err

--- a/experimental/http_logger/http_logger.go
+++ b/experimental/http_logger/http_logger.go
@@ -73,8 +73,9 @@ func (hl *HTTPLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		if !skipSaving {
 			// save information from the request and failed response (if anything is available)
-			if res == nil {
-				res = &http.Response{
+			resToAdd := res
+			if resToAdd == nil {
+				resToAdd = &http.Response{
 					Status:        "ERROR",
 					StatusCode:    0,
 					Proto:         "",
@@ -87,7 +88,7 @@ func (hl *HTTPLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 				}
 			}
 			// nolint:errcheck
-			hl.fixture.Add(req, res)
+			hl.fixture.Add(req, resToAdd)
 			// re: errcheck - if there is a err this call, we move on and just return the http error
 		}
 		return res, err

--- a/experimental/http_logger/http_logger.go
+++ b/experimental/http_logger/http_logger.go
@@ -73,6 +73,19 @@ func (hl *HTTPLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		if !skipSaving {
 			// save information from the request and failed response (if anything is available)
+			if res == nil {
+				res = &http.Response{
+					Status:        "ERROR",
+					StatusCode:    0,
+					Proto:         "",
+					ProtoMajor:    0,
+					ProtoMinor:    0,
+					Body:          io.NopCloser(bytes.NewBufferString(err.Error())),
+					ContentLength: int64(len(err.Error())),
+					Request:       req,
+					Header:        make(http.Header, 0),
+				}
+			}
 			// nolint:errcheck
 			hl.fixture.Add(req, res)
 			// re: errcheck - if there is a err this call, we move on and just return the http error

--- a/experimental/http_logger/http_logger.go
+++ b/experimental/http_logger/http_logger.go
@@ -73,8 +73,9 @@ func (hl *HTTPLogger) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		if !skipSaving {
 			// save information from the request and failed response (if anything is available)
-			// nolint:errcheck - if there is a problem writing the error, we move on and just return the http error
+			// nolint:errcheck
 			hl.fixture.Add(req, res)
+			// re: errcheck - if there is a err this call, we move on and just return the http error
 		}
 		return res, err
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

To collect information about requests that yield Error.
If available, collect information from the response as well.

If the response is nil, a fake response is constructed from the error object.
Here is an example extracted from an unexpected EOF error:

```json
"response": {
  "status": 0,
  "statusText": "ERROR",
  "httpVersion": "",
  "cookies": [],
  "headers": [],
  "content": {
    "size": 3,
    "mimeType": "",
    "text": "EOF"
  },
  "redirectURL": "",
  "headersSize": -1,
  "bodySize": 3
},
"cache": {
  "comment": "Not cached"
},
"timings": {
  "send": 0,
  "wait": 0,
  "receive": 0
},


```


<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

**Special notes for your reviewer**:
- [ ] Needs tests
- [ ] Needs to be able to handle nil response