### PR TITLE
remove the cache key with pdc bytes and check the expiry instead

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -150,12 +150,7 @@ func (c *GrafanaCfg) shouldRefreshProxyClientCert() bool {
 	}
 
 	// Check if the certificate will expire in less than 6 hours
-	sixHoursFromNow := time.Now().Add(6 * time.Hour)
-	if cert.NotAfter.Before(sixHoursFromNow) {
-		return true
-	}
-
-	return false
+	return cert.NotAfter.Before(time.Now().Add(6 * time.Hour))
 }
 
 // Diff returns the names of config fields that differ between this config and c2.

--- a/backend/config.go
+++ b/backend/config.go
@@ -104,9 +104,9 @@ func (c *GrafanaCfg) Equal(c2 *GrafanaCfg) bool {
 	}
 
 	// By Default, we will always fetch the current config from cloud-config -> hosted-grafana api.
-	//  This will generate a new set of keys / certificates in c2.config.
+	// This will generate a new set of keys / certificates in c2.config.
 	// Since these new keys are always different we would never cache a datasource instance and cause a memory leak.
-	// We test them seperately and if the existing cached config keys are still valid we will continue to use them if not we will refresh the keys.
+	// We test them separately and if the existing cached config keys are still valid we will continue to use them if not we will refresh the keys.
 	if v, ok := c.config[proxy.PluginSecureSocksProxyEnabled]; ok && v == strconv.FormatBool(true) {
 		return !c.isProxyCertificateExpiring() // if the certificate is expiring, we need to refresh the keys
 	}

--- a/backend/config.go
+++ b/backend/config.go
@@ -94,12 +94,16 @@ func (c *GrafanaCfg) Equal(c2 *GrafanaCfg) bool {
 	}
 
 	for k, v1 := range c.config {
+		v2, ok := c2.config[k]
+		if !ok {
+			return false
+		}
 		// Ignore secure socks proxy config values as they are always different.
-		if strings.Contains(k, "GF_SECURE_SOCKS_DATASOURCE_PROXY") {
+		if k == proxy.PluginSecureSocksProxyClientCertContents || k == proxy.PluginSecureSocksProxyClientKeyContents {
 			continue
 		}
 
-		if v2, ok := c2.config[k]; !ok || v1 != v2 {
+		if v1 != v2 {
 			return false
 		}
 	}

--- a/backend/config.go
+++ b/backend/config.go
@@ -194,8 +194,8 @@ func (c *GrafanaCfg) Diff(c2 *GrafanaCfg) []string {
 // giving a four character hash.
 //
 // Deprecated: Use Equal() instead for cache invalidation based on certificate expiration.
-func (c *GrafanaCfg) ProxyHash(jsonData []byte) string {
-	if c == nil || jsonData == nil {
+func (c *GrafanaCfg) ProxyHash() string {
+	if c == nil {
 		return ""
 	}
 

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -832,4 +832,19 @@ func TestGrafanaCfg_Equal(t *testing.T) {
 
 		require.False(t, cfg1.Equal(cfg2))
 	})
+
+	t.Run("Should return false when skipped key causes false positive", func(t *testing.T) {
+		validCert := createTestCertificate(time.Now().Add(12 * time.Hour))
+
+		cfg1 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyClientKeyContents: validCert,
+			"other_key": "value1",
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			"completely_different": "value1", // Same length (2 keys) but totally different key:value
+			"other_key":            "value1",
+		})
+
+		require.False(t, cfg1.Equal(cfg2))
+	})
 }

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -1,13 +1,20 @@
 package backend
 
 import (
+	"bytes"
 	"context"
+	"crypto"
+	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/pem"
-	"fmt"
-	mathrand "math/rand"
+	"math/big"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -502,20 +509,425 @@ func TestGrafanaCfg_Diff(t *testing.T) {
 	})
 }
 
-func BenchmarkProxyHash(b *testing.B) {
-	count := 0
-	kBytes := randomProxyContents()
-	cm := map[string]string{
-		proxy.PluginSecureSocksProxyClientKeyContents: string(kBytes),
+// pEMEncodeEd25519PrivateKey encodes an Ed25519 private key in PEM format
+func pEMEncodeEd25519PrivateKey(key crypto.PrivateKey) ([]byte, error) {
+	var b bytes.Buffer
+	kb, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, err
 	}
-	for i := 0; i < b.N; i++ {
-		kBytes[88] = b64chars[mathrand.Intn(64)] //nolint:gosec
-		cm[proxy.PluginSecureSocksProxyClientKeyContents] = string(kBytes)
-		cfg := NewGrafanaCfg(cm)
-		hash := cfg.ProxyHash()
-		if hash[0] == 'a' {
-			count++
+	err = pem.Encode(&b, &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: kb,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), err
+}
+
+// pEMEncodeCertificate encodes a certificate in PEM format
+func pEMEncodeCertificate(cert []byte) ([]byte, error) {
+	var b bytes.Buffer
+	err := pem.Encode(&b, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+// createTestCertificate generates a test X.509 certificate with Ed25519 key and the given expiry time
+// This aligns with the GenerateEd25519ClientKeys pattern used in production
+// Returns: (certPEM []byte, keyPEM []byte, error)
+func createTestCertificate(notAfter time.Time) ([]byte, []byte, error) {
+	// Generate Ed25519 key pair
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Generate SubjectKeyId by taking the SHA-1 hash of the ASN.1 encoding of the public key
+	// This follows RFC 5280 section 4.2.1.2
+	kb, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	//nolint:gosec
+	keyHash := sha1.Sum(kb)
+	ski := keyHash[:]
+
+	// Create certificate with realistic fields matching production pattern
+	clientCert := &x509.Certificate{
+		SerialNumber: big.NewInt(2024),
+		Subject: pkix.Name{
+			Organization: []string{"Grafana Labs"},
+			CommonName:   "test-client-cert",
+		},
+		NotBefore:    time.Now().Add(-24 * time.Hour),
+		NotAfter:     notAfter,
+		SubjectKeyId: ski,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	// Self-sign the certificate
+	certBytes, err := x509.CreateCertificate(rand.Reader, clientCert, clientCert, pubKey, privKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Encode both certificate and private key in PEM format using utility functions
+	certPEM, err := pEMEncodeCertificate(certBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keyPEM, err := pEMEncodeEd25519PrivateKey(privKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return certPEM, keyPEM, nil
+}
+
+func TestshouldRefreshProxyClientCert(t *testing.T) {
+	t.Run("returns false when proxy is nil", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{})
+		result := cfg.shouldRefreshProxyClientCert()
+		require.True(t, result)
+	})
+
+	t.Run("returns false when proxy is not enabled", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled: "false",
+		})
+		result := cfg.shouldRefreshProxyClientCert()
+		require.True(t, result)
+	})
+
+	t.Run("returns true when certificate is already expired", func(t *testing.T) {
+		expiredCert, _, err := createTestCertificate(time.Now().Add(-1 * time.Hour))
+		require.NoError(t, err)
+
+		cfg := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(expiredCert),
+		})
+		result := cfg.shouldRefreshProxyClientCert()
+		require.True(t, result)
+	})
+
+	t.Run("returns true when certificate expires within 6 hours", func(t *testing.T) {
+		soonExpiredCert, _, err := createTestCertificate(time.Now().Add(2 * time.Hour))
+		require.NoError(t, err)
+
+		cfg := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(soonExpiredCert),
+		})
+		result := cfg.shouldRefreshProxyClientCert()
+		require.True(t, result)
+	})
+
+	t.Run("returns false when certificate expires after 6 hours", func(t *testing.T) {
+		validCert, _, err := createTestCertificate(time.Now().Add(12 * time.Hour))
+		require.NoError(t, err)
+
+		cfg := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(validCert),
+		})
+		result := cfg.shouldRefreshProxyClientCert()
+		require.False(t, result)
+	})
+
+	t.Run("returns false when certificate expires just after 6 hour boundary", func(t *testing.T) {
+		// Expiry slightly after the 6 hour mark to avoid timing issues
+		justAfterBoundary := time.Now().Add(6*time.Hour + 1*time.Second)
+		cert, _, err := createTestCertificate(justAfterBoundary)
+		require.NoError(t, err)
+
+		cfg := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(cert),
+		})
+		result := cfg.shouldRefreshProxyClientCert()
+		// After the 6 hour boundary, should return false
+		require.False(t, result)
+	})
+
+	t.Run("returns true when certificate cert value is invalid base64", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: "not-valid-base64!@#$",
+		})
+		result := cfg.shouldRefreshProxyClientCert()
+		require.True(t, result)
+	})
+
+	t.Run("returns true when certificate cert value is invalid PEM", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString([]byte("not-a-pem-certificate")),
+		})
+		result := cfg.shouldRefreshProxyClientCert()
+		require.True(t, result)
+	})
+
+	t.Run("returns true when certificate parsing fails", func(t *testing.T) {
+		invalidCert := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: []byte("invalid-cert-bytes"),
+		})
+
+		cfg := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(invalidCert),
+		})
+		result := cfg.shouldRefreshProxyClientCert()
+		require.True(t, result)
+	})
+
+	t.Run("returns false when certificate is valid for more than 6 hours (1 month validity)", func(t *testing.T) {
+		validLongCert, _, err := createTestCertificate(time.Now().Add(24 * 30 * time.Hour))
+		require.NoError(t, err)
+
+		cfg := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(validLongCert),
+		})
+		result := cfg.shouldRefreshProxyClientCert()
+		require.False(t, result)
+	})
+}
+
+func TestGrafanaCfg_Equal(t *testing.T) {
+	t.Run("both configs nil should return true", func(t *testing.T) {
+		var cfg1, cfg2 *GrafanaCfg
+		result := cfg1.Equal(cfg2)
+		require.True(t, result)
+	})
+
+	t.Run("one config nil should return false", func(t *testing.T) {
+		cfg1 := NewGrafanaCfg(map[string]string{"key": "value"})
+		var cfg2 *GrafanaCfg
+		require.False(t, cfg1.Equal(cfg2))
+		require.False(t, cfg2.Equal(cfg1))
+	})
+
+	t.Run("empty configs should return true", func(t *testing.T) {
+		cfg1 := NewGrafanaCfg(map[string]string{})
+		cfg2 := NewGrafanaCfg(map[string]string{})
+		require.True(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("identical configs should return true", func(t *testing.T) {
+		config := map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+			"key3": "value3",
 		}
-	}
-	fmt.Printf("This should be about one in 64: %f\n", float64(count)/float64(b.N))
+		cfg1 := NewGrafanaCfg(config)
+		cfg2 := NewGrafanaCfg(config)
+		require.True(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("different values should return false", func(t *testing.T) {
+		cfg1 := NewGrafanaCfg(map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			"key1": "different_value",
+			"key2": "value2",
+		})
+		require.False(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("different sizes should return false", func(t *testing.T) {
+		cfg1 := NewGrafanaCfg(map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			"key1": "value1",
+		})
+		require.False(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("proxy enabled with valid certificate should return true", func(t *testing.T) {
+		validCert, _, err := createTestCertificate(time.Now().Add(12 * time.Hour))
+		require.NoError(t, err)
+
+		config := map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(validCert),
+			"other_key": "other_value",
+		}
+		cfg1 := NewGrafanaCfg(config)
+		cfg2 := NewGrafanaCfg(config)
+		require.True(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("proxy enabled with expiring certificate returns needsUpdate true", func(t *testing.T) {
+		expiringCert, _, err := createTestCertificate(time.Now().Add(2 * time.Hour))
+		require.NoError(t, err)
+
+		cfg1 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(expiringCert),
+			"other_key": "other_value",
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(expiringCert),
+			"other_key": "other_value",
+		})
+		// Since certificate is expiring, shouldRefreshProxyClientCert returns true
+		// When proxy is enabled AND expiring, Equal returns needsUpdate value
+		// Other keys are identical, so needsUpdate = true, Equal returns true
+		require.True(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("proxy enabled with expiring certificate returns needsUpdate true", func(t *testing.T) {
+		expiringCert, _, err := createTestCertificate(time.Now().Add(2 * time.Hour))
+		require.NoError(t, err)
+		newCert, _, err := createTestCertificate(time.Now().Add(1 * time.Hour))
+		require.NoError(t, err)
+
+		cfg1 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(expiringCert),
+			"other_key": "other_value",
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(newCert),
+			"other_key": "other_value",
+		})
+		// Since certificate is expiring, shouldRefreshProxyClientCert returns true
+		// When proxy is enabled AND expiring, Equal returns needsUpdate value
+		// Other keys are identical, so needsUpdate = true, Equal returns true
+		require.True(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("proxy disabled should ignore certificate expiration", func(t *testing.T) {
+		expiringCert, _, err := createTestCertificate(time.Now().Add(2 * time.Hour))
+		require.NoError(t, err)
+
+		cfg1 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "false",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(expiringCert),
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "false",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(expiringCert),
+		})
+		// Even though certificate is expiring, proxy is disabled so Equal should return true
+		require.True(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("secure socks proxy keys should be ignored in comparison", func(t *testing.T) {
+		cfg1 := NewGrafanaCfg(map[string]string{
+			"key1":                              "value1",
+			"GF_SECURE_SOCKS_DATASOURCE_PROXY":  "different_value_should_be_ignored",
+			"GF_SECURE_SOCKS_DATASOURCE_PROXY2": "also_ignored",
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			"key1":                              "value1",
+			"GF_SECURE_SOCKS_DATASOURCE_PROXY":  "different_value",
+			"GF_SECURE_SOCKS_DATASOURCE_PROXY2": "completely_different",
+		})
+		// Proxy keys should be ignored, other keys are the same
+		require.True(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("non-proxy keys should not be ignored", func(t *testing.T) {
+		cfg1 := NewGrafanaCfg(map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			"key1": "value1",
+			"key2": "different_value",
+		})
+		require.False(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("proxy enabled with expired certificate returns needsUpdate", func(t *testing.T) {
+		expiredCert, _, err := createTestCertificate(time.Now().Add(-1 * time.Hour))
+		require.NoError(t, err)
+
+		cfg1 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(expiredCert),
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(expiredCert),
+		})
+		// Certificate is expired, shouldRefreshProxyClientCert returns true
+		// All other keys are identical, needsUpdate = true
+		// Equal returns needsUpdate = true
+		require.True(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("proxy enabled with invalid certificate returns needsUpdate", func(t *testing.T) {
+		cfg1 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: "invalid-cert",
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: "invalid-cert",
+		})
+		// Invalid certificate causes shouldRefreshProxyClientCert to return true
+		// All other keys are identical, needsUpdate = true
+		// Equal returns needsUpdate = true
+		require.True(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("different non-proxy keys with expiring certificate returns false", func(t *testing.T) {
+		expiringCert, _, err := createTestCertificate(time.Now().Add(2 * time.Hour))
+		require.NoError(t, err)
+
+		cfg1 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(expiringCert),
+			"other_key": "value1",
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(expiringCert),
+			"other_key": "value2",
+		})
+		// Different non-proxy keys, so needsUpdate = false
+		// Certificate is expiring, so Equal returns needsUpdate = false
+		require.False(t, cfg1.Equal(cfg2))
+	})
+
+	t.Run("different non-proxy keys with valid certificate returns true", func(t *testing.T) {
+		validCert, _, err := createTestCertificate(time.Now().Add(12 * time.Hour))
+		require.NoError(t, err)
+
+		cfg1 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(validCert),
+			"other_key": "value1",
+		})
+		cfg2 := NewGrafanaCfg(map[string]string{
+			proxy.PluginSecureSocksProxyEnabled:            "true",
+			proxy.PluginSecureSocksProxyClientCertContents: base64.StdEncoding.EncodeToString(validCert),
+			"other_key": "value2",
+		})
+		// Different non-proxy keys, so needsUpdate = false
+		// But certificate is valid and proxy is enabled
+		// Equal returns true immediately (early return for valid certificate)
+		// This ignores the fact that other keys differ!
+		require.True(t, cfg1.Equal(cfg2))
+	})
 }

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/sha1" //nolint:gosec"
+	"crypto/sha1" //nolint:gosec
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -761,21 +761,6 @@ func TestGrafanaCfg_Equal(t *testing.T) {
 		require.True(t, cfg1.Equal(cfg2))
 	})
 
-	t.Run("secure socks proxy keys should be ignored in comparison", func(t *testing.T) {
-		cfg1 := NewGrafanaCfg(map[string]string{
-			"key1":                              "value1",
-			"GF_SECURE_SOCKS_DATASOURCE_PROXY":  "different_value_should_be_ignored",
-			"GF_SECURE_SOCKS_DATASOURCE_PROXY2": "also_ignored",
-		})
-		cfg2 := NewGrafanaCfg(map[string]string{
-			"key1":                              "value1",
-			"GF_SECURE_SOCKS_DATASOURCE_PROXY":  "different_value",
-			"GF_SECURE_SOCKS_DATASOURCE_PROXY2": "completely_different",
-		})
-		// Proxy keys should be ignored, other keys are the same
-		require.True(t, cfg1.Equal(cfg2))
-	})
-
 	t.Run("non-proxy keys should not be ignored", func(t *testing.T) {
 		cfg1 := NewGrafanaCfg(map[string]string{
 			"key1": "value1",

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha1" //nolint:gosec"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -720,7 +720,7 @@ func TestGrafanaCfg_Equal(t *testing.T) {
 
 		config := map[string]string{
 			proxy.PluginSecureSocksProxyEnabled:           "true",
-			proxy.PluginSecureSocksProxyClientKeyContents: string(validCert),
+			proxy.PluginSecureSocksProxyClientKeyContents: validCert,
 			"other_key": "other_value",
 		}
 		cfg1 := NewGrafanaCfg(config)
@@ -734,12 +734,12 @@ func TestGrafanaCfg_Equal(t *testing.T) {
 
 		cfg1 := NewGrafanaCfg(map[string]string{
 			proxy.PluginSecureSocksProxyEnabled:           "true",
-			proxy.PluginSecureSocksProxyClientKeyContents: string(expiringCert),
+			proxy.PluginSecureSocksProxyClientKeyContents: expiringCert,
 			"other_key": "other_value",
 		})
 		cfg2 := NewGrafanaCfg(map[string]string{
 			proxy.PluginSecureSocksProxyEnabled:           "true",
-			proxy.PluginSecureSocksProxyClientKeyContents: string(newCert),
+			proxy.PluginSecureSocksProxyClientKeyContents: newCert,
 			"other_key": "other_value",
 		})
 
@@ -751,11 +751,11 @@ func TestGrafanaCfg_Equal(t *testing.T) {
 
 		cfg1 := NewGrafanaCfg(map[string]string{
 			proxy.PluginSecureSocksProxyEnabled:           "false",
-			proxy.PluginSecureSocksProxyClientKeyContents: string(expiringCert),
+			proxy.PluginSecureSocksProxyClientKeyContents: expiringCert,
 		})
 		cfg2 := NewGrafanaCfg(map[string]string{
 			proxy.PluginSecureSocksProxyEnabled:           "false",
-			proxy.PluginSecureSocksProxyClientKeyContents: string(expiringCert),
+			proxy.PluginSecureSocksProxyClientKeyContents: expiringCert,
 		})
 		// Even though certificate is expiring, proxy is disabled so Equal should return true
 		require.True(t, cfg1.Equal(cfg2))
@@ -793,11 +793,11 @@ func TestGrafanaCfg_Equal(t *testing.T) {
 
 		cfg1 := NewGrafanaCfg(map[string]string{
 			proxy.PluginSecureSocksProxyEnabled:           "true",
-			proxy.PluginSecureSocksProxyClientKeyContents: string(expiredCert),
+			proxy.PluginSecureSocksProxyClientKeyContents: expiredCert,
 		})
 		cfg2 := NewGrafanaCfg(map[string]string{
 			proxy.PluginSecureSocksProxyEnabled:           "true",
-			proxy.PluginSecureSocksProxyClientKeyContents: string(expiredCert),
+			proxy.PluginSecureSocksProxyClientKeyContents: expiredCert,
 		})
 
 		require.False(t, cfg1.Equal(cfg2))
@@ -821,12 +821,12 @@ func TestGrafanaCfg_Equal(t *testing.T) {
 
 		cfg1 := NewGrafanaCfg(map[string]string{
 			proxy.PluginSecureSocksProxyEnabled:           "true",
-			proxy.PluginSecureSocksProxyClientKeyContents: string(expiringCert),
+			proxy.PluginSecureSocksProxyClientKeyContents: expiringCert,
 			"other_key": "value1",
 		})
 		cfg2 := NewGrafanaCfg(map[string]string{
 			proxy.PluginSecureSocksProxyEnabled:           "true",
-			proxy.PluginSecureSocksProxyClientKeyContents: string(expiringCert),
+			proxy.PluginSecureSocksProxyClientKeyContents: expiringCert,
 			"other_key": "value2",
 		})
 

--- a/backend/datasource/instance_provider.go
+++ b/backend/datasource/instance_provider.go
@@ -67,9 +67,9 @@ func (ip *instanceProvider) NeedsUpdate(ctx context.Context, pluginContext backe
 	cachedConfig := cachedInstance.PluginContext.GrafanaConfig
 	configUpdated := !cachedConfig.Equal(curConfig)
 
-	curDataSourceSettings := pluginContext.DataSourceInstanceSettings
-	cachedDataSourceSettings := cachedInstance.PluginContext.DataSourceInstanceSettings
-	dsUpdated := !curDataSourceSettings.Updated.Equal(cachedDataSourceSettings.Updated)
+	curDataSourceSettingsUpdatedTime := pluginContext.DataSourceInstanceSettings.Updated
+	cachedDataSourceSettingsUpdatedTime := cachedInstance.PluginContext.DataSourceInstanceSettings.Updated
+	dsUpdated := !curDataSourceSettingsUpdatedTime.Equal(cachedDataSourceSettingsUpdatedTime)
 
 	if dsUpdated || configUpdated {
 		logger := backend.Logger.FromContext(ctx)
@@ -95,7 +95,6 @@ func (ip *instanceProvider) NewInstance(ctx context.Context, pluginContext backe
 func instanceKey(ctx context.Context, pluginContext backend.PluginContext) string {
 	dsID := pluginContext.DataSourceInstanceSettings.ID
 	tenantID := tenant.IDFromContext(ctx)
-	proxyHash := pluginContext.GrafanaConfig.ProxyHash()
 
-	return fmt.Sprintf("%d#%s#%s", dsID, tenantID, proxyHash)
+	return fmt.Sprintf("%d#%s", dsID, tenantID)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

In core datasources at least we have a memory leak where we are always creating a new datasource instance. Currently we are using the ProxyHash() which takes the last 4 characters from the pdc key and uses it as a hash.

However, this is not working because each time we do a request we fetch the config from Cloud config, and then if the config is not cached get the new config, from the hosted grafana instance. The hosted grafana instance always generates a new key / cert so the new config is always different so the cache key is never consistent.

I checked the caches on cloud config and they only cache for 5 seconds as a way to reducing the load on hosted grafana, not as a reliable cache. If we put this cache too high it will take at least the expiry time of the cache for new datasource configurations to trickle through without some other way to invalidate it. 

We could also cache the keys / value in the hosted grafana instance but It seems like a less attractive option considering the whole MT migration.

**Which issue(s) this PR fixes**:

[fixes](https://github.com/grafana/plugins-private/issues/3671)
<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

Here is my exculidraw if its useful: 
<img width="2182" height="1094" alt="image" src="https://github.com/user-attachments/assets/3870ed98-40a0-4dbc-8922-15f1fba0c5ac" />

