### PR TITLE
fix(sqlutil): fix FrameFromRows rowLimit handling across result sets and repeated calls

### DIFF
--- a/data/sqlutil/sql_test.go
+++ b/data/sqlutil/sql_test.go
@@ -364,6 +364,14 @@ func TestFrameFromRows(t *testing.T) {
 					data.NewField("b", nil, []*string{ptr("2"), ptr("5")}),
 					data.NewField("c", nil, []*string{ptr("3"), ptr("6")}),
 				},
+				Meta: &data.FrameMeta{
+					Notices: []data.Notice{
+						{
+							Severity: data.NoticeSeverityWarning,
+							Text:     "Results have been limited to 2 because the SQL row limit was reached",
+						},
+					},
+				},
 			},
 			err: nil,
 		},
@@ -378,6 +386,26 @@ func TestFrameFromRows(t *testing.T) {
 			converters: nil,
 			err:        sqlutil.ErrColumnTypeNotSupported{},
 		},
+		{
+			name: "empty rows",
+			rows: makeSingleResultSet( //nolint:rowserrcheck
+				[]string{
+					"a",
+					"b",
+					"c",
+				},
+			),
+			rowLimit:   100,
+			converters: nil,
+			frame: &data.Frame{
+				Fields: []*data.Field{
+					data.NewField("a", nil, []*string{}),
+					data.NewField("b", nil, []*string{}),
+					data.NewField("c", nil, []*string{}),
+				},
+			},
+			err: nil,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			frame, err := sqlutil.FrameFromRows(tt.rows, tt.rowLimit, tt.converters...)
@@ -387,6 +415,246 @@ func TestFrameFromRows(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tt.frame, frame)
 			}
+		})
+	}
+}
+
+func TestFrameFromRows_MultipleTimes(t *testing.T) {
+	ptr := func(s string) *string {
+		return &s
+	}
+	for _, tt := range []struct {
+		name       string
+		rows       *sql.Rows
+		rowLimit   int64
+		converters []sqlutil.Converter
+		frames     []*data.Frame
+	}{
+		{
+			name: "rows not implements driver.RowsNextResultSet",
+			rows: makeSingleResultSet( //nolint:rowserrcheck
+				[]string{
+					"a",
+					"b",
+					"c",
+				},
+				[]interface{}{
+					1, 2, 3,
+				},
+				[]interface{}{
+					4, 5, 6,
+				},
+				[]interface{}{
+					7, 8, 9,
+				},
+			),
+			rowLimit:   1,
+			converters: nil,
+			frames: data.Frames{
+				&data.Frame{
+					Fields: []*data.Field{
+						data.NewField("a", nil, []*string{ptr("1")}),
+						data.NewField("b", nil, []*string{ptr("2")}),
+						data.NewField("c", nil, []*string{ptr("3")}),
+					},
+					Meta: &data.FrameMeta{
+						Notices: []data.Notice{
+							{
+								Severity: data.NoticeSeverityWarning,
+								Text:     "Results have been limited to 1 because the SQL row limit was reached",
+							},
+						},
+					},
+				},
+				&data.Frame{
+					Fields: []*data.Field{
+						data.NewField("a", nil, []*string{ptr("4")}),
+						data.NewField("b", nil, []*string{ptr("5")}),
+						data.NewField("c", nil, []*string{ptr("6")}),
+					},
+					Meta: &data.FrameMeta{
+						Notices: []data.Notice{
+							{
+								Severity: data.NoticeSeverityWarning,
+								Text:     "Results have been limited to 1 because the SQL row limit was reached",
+							},
+						},
+					},
+				},
+				&data.Frame{
+					Fields: []*data.Field{
+						data.NewField("a", nil, []*string{ptr("7")}),
+						data.NewField("b", nil, []*string{ptr("8")}),
+						data.NewField("c", nil, []*string{ptr("9")}),
+					},
+					Meta: &data.FrameMeta{
+						Notices: []data.Notice{
+							{
+								Severity: data.NoticeSeverityWarning,
+								Text:     "Results have been limited to 1 because the SQL row limit was reached",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rows implements driver.RowsNextResultSet, but contains only one result set",
+			rows: makeMultipleResultSets( //nolint:rowserrcheck
+				[]string{
+					"a",
+					"b",
+					"c",
+				},
+				[][]interface{}{
+					{
+						1, 2, 3,
+					},
+					{
+						4, 5, 6,
+					},
+					{
+						7, 8, 9,
+					},
+				},
+			),
+			rowLimit:   1,
+			converters: nil,
+			frames: data.Frames{
+				&data.Frame{
+					Fields: []*data.Field{
+						data.NewField("a", nil, []*string{ptr("1")}),
+						data.NewField("b", nil, []*string{ptr("2")}),
+						data.NewField("c", nil, []*string{ptr("3")}),
+					},
+					Meta: &data.FrameMeta{
+						Notices: []data.Notice{
+							{
+								Severity: data.NoticeSeverityWarning,
+								Text:     "Results have been limited to 1 because the SQL row limit was reached",
+							},
+						},
+					},
+				},
+				&data.Frame{
+					Fields: []*data.Field{
+						data.NewField("a", nil, []*string{ptr("4")}),
+						data.NewField("b", nil, []*string{ptr("5")}),
+						data.NewField("c", nil, []*string{ptr("6")}),
+					},
+					Meta: &data.FrameMeta{
+						Notices: []data.Notice{
+							{
+								Severity: data.NoticeSeverityWarning,
+								Text:     "Results have been limited to 1 because the SQL row limit was reached",
+							},
+						},
+					},
+				},
+				&data.Frame{
+					Fields: []*data.Field{
+						data.NewField("a", nil, []*string{ptr("7")}),
+						data.NewField("b", nil, []*string{ptr("8")}),
+						data.NewField("c", nil, []*string{ptr("9")}),
+					},
+					Meta: &data.FrameMeta{
+						Notices: []data.Notice{
+							{
+								Severity: data.NoticeSeverityWarning,
+								Text:     "Results have been limited to 1 because the SQL row limit was reached",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rows implements driver.RowsNextResultSet, but contains more then one result set",
+			rows: makeMultipleResultSets( //nolint:rowserrcheck
+				[]string{
+					"a",
+					"b",
+					"c",
+				},
+				[][]interface{}{
+					{
+						1, 2, 3,
+					},
+					{
+						4, 5, 6,
+					},
+				},
+				[][]interface{}{
+					{
+						7, 8, 9,
+					},
+				},
+			),
+			rowLimit:   1,
+			converters: nil,
+			frames: data.Frames{
+				&data.Frame{
+					Fields: []*data.Field{
+						data.NewField("a", nil, []*string{ptr("1")}),
+						data.NewField("b", nil, []*string{ptr("2")}),
+						data.NewField("c", nil, []*string{ptr("3")}),
+					},
+					Meta: &data.FrameMeta{
+						Notices: []data.Notice{
+							{
+								Severity: data.NoticeSeverityWarning,
+								Text:     "Results have been limited to 1 because the SQL row limit was reached",
+							},
+						},
+					},
+				},
+				&data.Frame{
+					Fields: []*data.Field{
+						data.NewField("a", nil, []*string{ptr("4")}),
+						data.NewField("b", nil, []*string{ptr("5")}),
+						data.NewField("c", nil, []*string{ptr("6")}),
+					},
+					Meta: &data.FrameMeta{
+						Notices: []data.Notice{
+							{
+								Severity: data.NoticeSeverityWarning,
+								Text:     "Results have been limited to 1 because the SQL row limit was reached",
+							},
+						},
+					},
+				},
+				&data.Frame{
+					Fields: []*data.Field{
+						data.NewField("a", nil, []*string{ptr("7")}),
+						data.NewField("b", nil, []*string{ptr("8")}),
+						data.NewField("c", nil, []*string{ptr("9")}),
+					},
+					Meta: &data.FrameMeta{
+						Notices: []data.Notice{
+							{
+								Severity: data.NoticeSeverityWarning,
+								Text:     "Results have been limited to 1 because the SQL row limit was reached",
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var frames []*data.Frame
+			for {
+				frame, err := sqlutil.FrameFromRows(tt.rows, tt.rowLimit, tt.converters...)
+				require.NoError(t, err)
+
+				if frame.Rows() == 0 {
+					break
+				}
+
+				frames = append(frames, frame)
+			}
+
+			require.Equal(t, tt.frames, frames)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes two bugs in `FrameFromRows` when handling SQL result sets with row limits:

1. **Missing limit warning for drivers with `driver.RowsNextResultSet`**: When the row limit was reached while iterating through multiple result sets, the "Results have been limited to..." notice was not being added to the frame because the break occurred before the notice could be appended.
1. **Row loss in consecutive frame iterations**: When calling `FrameFromRows` multiple times to receive consecutive frames of size `rowLimit`, rows were being lost between iterations. This happened because `rows.Next()` was called before checking if the limit had been reached, advancing past a row that would then be skipped on the next iteration.

**Which issue(s) this PR fixes**:
- Restructured the loop logic in `FrameFromRows` to check the row limit before calling `rows.Next()`
- Ensured the limit warning notice is always added when the row limit is reached, regardless of whether additional result sets are present

**Testing**
- Existing tests should continue to pass
- New tests added to ensure proper row counting and limit notices across multi-result set scenarios
