### PR TITLE
Fix race condition panic in HARLogger

### DIFF
--- a/experimental/e2e/storage/types.go
+++ b/experimental/e2e/storage/types.go
@@ -78,10 +78,15 @@ func (f *files) get(path string) *file {
 	return f.files[path]
 }
 
-// add adds a new path to the files map.
+// add adds a new path to the files map, or returns existing if already present.
 func (f *files) add(path string) *file {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+
+	if h, ok := f.files[path]; ok {
+		return h
+	}
+
 	f.files[path] = &file{path: path}
 	return f.files[path]
 }

--- a/experimental/e2e/storage/types_test.go
+++ b/experimental/e2e/storage/types_test.go
@@ -1,0 +1,43 @@
+package storage
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddReturnsSameInstance(t *testing.T) {
+	testFiles := files{files: map[string]*file{}}
+	testPath := "/test/add/instance.har"
+
+	const numGoroutines = 100
+
+	results := make(chan *file, numGoroutines)
+	ready := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-ready
+			f := testFiles.add(testPath)
+			results <- f
+		}()
+	}
+
+	close(ready)
+	wg.Wait()
+	close(results)
+
+	var allFiles []*file
+	for f := range results {
+		allFiles = append(allFiles, f)
+	}
+
+	first := allFiles[0]
+	for i, f := range allFiles {
+		require.Same(t, first, f, "goroutine %d got different *file instance (got %p, want %p)", i, f, first)
+	}
+}

--- a/experimental/e2e/storage/types_test.go
+++ b/experimental/e2e/storage/types_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestAddReturnsSameInstance directly tests add() - this reliably catches the bug
+// because it bypasses get() and forces all goroutines through add().
 func TestAddReturnsSameInstance(t *testing.T) {
 	testFiles := files{files: map[string]*file{}}
 	testPath := "/test/add/instance.har"
@@ -22,7 +24,7 @@ func TestAddReturnsSameInstance(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-ready
-			f := testFiles.add(testPath)
+			f := testFiles.getOrAdd(testPath) // Call add() directly
 			results <- f
 		}()
 	}
@@ -39,5 +41,45 @@ func TestAddReturnsSameInstance(t *testing.T) {
 	first := allFiles[0]
 	for i, f := range allFiles {
 		require.Same(t, first, f, "goroutine %d got different *file instance (got %p, want %p)", i, f, first)
+	}
+}
+
+// TestConcurrentLockUnlockPanic verifies that concurrent rLock/rUnlock calls don't panic.
+// A panic like "sync: RUnlock of unlocked RWMutex" indicates that rLock() and rUnlock()
+// got different *file instances due to a race in getOrAdd().
+func TestConcurrentLockUnlockPanic(t *testing.T) {
+	for run := 0; run < 10; run++ {
+		testFiles := files{files: map[string]*file{}}
+		testPath := "/test/panic/repro.har"
+
+		const numGoroutines = 100
+
+		var wg sync.WaitGroup
+		ready := make(chan struct{})
+		panics := make(chan any, numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						panics <- r
+					}
+				}()
+				<-ready
+				testFiles.rLock(testPath)
+				testFiles.rUnlock(testPath)
+			}()
+		}
+
+		close(ready)
+		wg.Wait()
+		close(panics)
+
+		// Assert no panics occurred
+		for p := range panics {
+			require.Fail(t, "goroutine panicked", "panic: %v", p)
+		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:

In the databricks plugin in production we are seeing panics due to an unlock being called on a mutex that is not being locked. 

I believed its due to a race condition where the `add()` is being called inbetween geTorAdd() which will overwrite blindly the file struct on a given file path. 

This pr adds a condition to stop this panic by adding a a check for the path so we always get the same file struct.

<img width="1971" height="765" alt="image" src="https://github.com/user-attachments/assets/4ef2a2d3-1348-4ad3-9fdd-d30646a47883" />

