### PR TITLE
Fix interval check for 2y case in gtime.go

### DIFF
--- a/backend/gtime/gtime.go
+++ b/backend/gtime/gtime.go
@@ -313,7 +313,7 @@ func RoundInterval(interval time.Duration) time.Duration {
 	case interval <= 1814400000*time.Millisecond:
 		return time.Millisecond * 604800000 // 1w
 	// 2y
-	case interval < 3628800000*time.Millisecond:
+	case interval < 63072000000*time.Millisecond:
 		return time.Millisecond * 2592000000 // 30d
 	default:
 		return time.Millisecond * 31536000000 // 1y

--- a/backend/gtime/gtime_test.go
+++ b/backend/gtime/gtime_test.go
@@ -203,7 +203,8 @@ func TestRoundInterval(t *testing.T) {
 		{input: 600000000 * time.Millisecond, expected: time.Millisecond * 86400000},
 		{input: 1500000000 * time.Millisecond, expected: time.Millisecond * 604800000},
 		{input: 3500000000 * time.Millisecond, expected: time.Millisecond * 2592000000},
-		{input: 40000000000 * time.Millisecond, expected: time.Millisecond * 31536000000},
+		{input: 40000000000 * time.Millisecond, expected: time.Millisecond * 2592000000},
+		{input: 70000000000 * time.Millisecond, expected: time.Millisecond * 31536000000},
 	}
 	for i, tc := range tcs {
 		t.Run(fmt.Sprintf("testcase %d", i), func(t *testing.T) {


### PR DESCRIPTION
Original PR was created by @mertyldrm here https://github.com/grafana/grafana-plugin-sdk-go/pull/1422

But we couldn't merge it beucase of the CLA issue and couldn't get any input in time from @mertyldrm so I'm creating this PR instead. 

---

What this PR does / why we need it: Round IntervalFunction under gtime.go file had a faulty condition for 2 years range, since the condition was set to 42 days in ms, every interval longer than 42 days was set to 1 years of interval.

Which issue(s) this PR fixes: This PR fixes the case for 2 years by fixing the condition to 2 years in ms

Fixes
I updated the condition to 63072000000 ms which is 2 years.