### PR TITLE
feat: add QueryChunkedData endpoint constant and test support

### DIFF
--- a/backend/data.go
+++ b/backend/data.go
@@ -108,6 +108,9 @@ type DataQuery struct {
 	JSON json.RawMessage
 }
 
+// EndpointQueryChunkedData friendly name for the query chunked data endpoint/handler.
+const EndpointQueryChunkedData Endpoint = "queryChunkedData"
+
 // Experimental: QueryChunkedDataHandler defines the interface for handling chunked data requests.
 type QueryChunkedDataHandler interface {
 	// QueryChunkedData handles a chunked data request.

--- a/backend/handler_middleware.go
+++ b/backend/handler_middleware.go
@@ -67,7 +67,7 @@ func (h *MiddlewareHandler) QueryChunkedData(ctx context.Context, req *QueryChun
 		return errNilRequest
 	}
 
-	ctx = h.setupContext(ctx, req.PluginContext, EndpointQueryData)
+	ctx = h.setupContext(ctx, req.PluginContext, EndpointQueryChunkedData)
 	return h.handler.QueryChunkedData(ctx, req, w)
 }
 

--- a/backend/handlertest/handlertest.go
+++ b/backend/handlertest/handlertest.go
@@ -119,6 +119,8 @@ type HandlerMiddlewareTest struct {
 	MiddlewareHandler      *backend.MiddlewareHandler
 	QueryDataReq           *backend.QueryDataRequest
 	QueryDataCtx           context.Context
+	QueryChunkedDataReq    *backend.QueryChunkedDataRequest
+	QueryChunkedDataCtx    context.Context
 	CallResourceReq        *backend.CallResourceRequest
 	CallResourceCtx        context.Context
 	CheckHealthReq         *backend.CheckHealthRequest
@@ -157,6 +159,11 @@ func NewHandlerMiddlewareTest(t *testing.T, opts ...HandlerMiddlewareTestOption)
 			cdt.QueryDataReq = req
 			cdt.QueryDataCtx = ctx
 			return nil, nil
+		},
+		QueryChunkedDataFunc: func(ctx context.Context, req *backend.QueryChunkedDataRequest, w backend.ChunkedDataWriter) error {
+			cdt.QueryChunkedDataReq = req
+			cdt.QueryChunkedDataCtx = ctx
+			return nil
 		},
 		CallResourceFunc: func(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
 			cdt.CallResourceReq = req


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds proper endpoint identification for the `QueryChunkedData` handler and enhances test utilities to support chunked data testing.

**Changes**:
1. Introduces `EndpointQueryChunkedData` constant to properly identify the chunked data endpoint. Follows the existing pattern used for other endpoints like `EndpointQueryData`.
2. Corrects the endpoint parameter passed to `setupContext` in `QueryChunkedData` middleware. Previously incorrectly used `EndpointQueryData`, now uses the correct `EndpointQueryChunkedData`
3. Enables proper testing of chunked data handlers