### PR TITLE
QueryTypeMux: support QueryChunkedData dispatch

### DIFF
--- a/backend/chunked.go
+++ b/backend/chunked.go
@@ -1,0 +1,99 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
+)
+
+// Experimental: QueryChunkedQueryRawClient allows raw access to the chunked results
+type QueryChunkedQueryRawClient interface {
+	QueryChunkedRaw(ctx context.Context, req *QueryChunkedDataRequest, cb func(evt *pluginv2.QueryChunkedDataResponse) error) error
+}
+
+// Experimental: ChunkedDataWriter defines the interface for writing data frames and errors
+// back to the client in chunks.
+type ChunkedDataWriter interface {
+	// WriteFrame writes a data frame (f) for the given query refID.
+	// The first time the frameID is written, the metadata and rows will be included.
+	// Subsequent calls with the same frameID will append the rows to the existing frame
+	// with a matching frameID. The metadata structure must match the initial request.
+	WriteFrame(ctx context.Context, refID string, frameID string, f *data.Frame) error
+
+	// WriteError writes an error associated with the specified refID.
+	WriteError(ctx context.Context, refID string, status Status, err error) error
+}
+
+var (
+	_ ChunkedDataWriter = (*chunkedDataCallback)(nil)
+)
+
+type chunkedDataCallback struct {
+	mu     sync.Mutex // thread safety
+	cb     func(evt *pluginv2.QueryChunkedDataResponse) error
+	sent   map[string]bool
+	asJSON bool
+}
+
+func NewChunkedDataCallback(req *QueryChunkedDataRequest, cb func(evt *pluginv2.QueryChunkedDataResponse) error) ChunkedDataWriter {
+	return &chunkedDataCallback{cb: cb, asJSON: false, sent: make(map[string]bool)}
+}
+
+// WriteError implements [ChunkedDataWriter].
+func (c *chunkedDataCallback) WriteError(ctx context.Context, refID string, status Status, err error) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	chunk := &pluginv2.QueryChunkedDataResponse{
+		RefId:  refID,
+		Status: int32(status), //nolint:gosec // disable G115
+	}
+	if err != nil {
+		chunk.Error = err.Error()
+	}
+	return c.cb(chunk)
+}
+
+// WriteFrame implements [ChunkedDataWriter].
+func (c *chunkedDataCallback) WriteFrame(ctx context.Context, refID string, frameID string, f *data.Frame) (err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if refID == "" {
+		return fmt.Errorf("missing refID identifier")
+	}
+
+	if frameID == "" {
+		return fmt.Errorf("missing frame identifier")
+	}
+
+	f.SetRefID(refID)
+
+	chunk := &pluginv2.QueryChunkedDataResponse{
+		RefId:   refID,
+		FrameId: frameID,
+		Status:  http.StatusOK,
+	}
+
+	if c.asJSON {
+		// Only send the schema the first time we see the frame identifier
+		include := data.IncludeDataOnly
+		key := fmt.Sprintf("%s-%s", refID, frameID)
+		if !c.sent[key] {
+			include = data.IncludeAll
+			c.sent[key] = true
+		}
+		chunk.Frame, err = data.FrameToJSON(f, include)
+	} else {
+		chunk.Frame, err = f.MarshalArrow()
+	}
+	if err != nil {
+		return err
+	}
+
+	return c.cb(chunk)
+}

--- a/backend/chunked.go
+++ b/backend/chunked.go
@@ -10,9 +10,11 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 )
 
+type ChunkedDataCallback = func(evt *pluginv2.QueryChunkedDataResponse) error
+
 // Experimental: QueryChunkedQueryRawClient allows raw access to the chunked results
 type QueryChunkedQueryRawClient interface {
-	QueryChunkedRaw(ctx context.Context, req *QueryChunkedDataRequest, cb func(evt *pluginv2.QueryChunkedDataResponse) error) error
+	QueryChunkedRaw(ctx context.Context, req *QueryChunkedDataRequest, cb ChunkedDataCallback) error
 }
 
 // Experimental: ChunkedDataWriter defines the interface for writing data frames and errors

--- a/backend/data.go
+++ b/backend/data.go
@@ -124,7 +124,7 @@ type QueryChunkedDataHandler interface {
 
 // Experimental: QueryChunkedQueryRawClient allows raw access to the chunked results
 type QueryChunkedQueryRawClient interface {
-	QueryChunked(ctx context.Context, req *QueryChunkedDataRequest, cb func(ctx context.Context, evt *pluginv2.QueryChunkedDataResponse)) error
+	QueryChunkedRaw(ctx context.Context, req *QueryChunkedDataRequest, cb func(evt *pluginv2.QueryChunkedDataResponse) error) error
 }
 
 // Experimental: ChunkedDataWriter defines the interface for writing data frames and errors

--- a/backend/data.go
+++ b/backend/data.go
@@ -10,7 +10,6 @@ import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 )
 
 // EndpointQueryData friendly name for the query data endpoint/handler.
@@ -120,24 +119,6 @@ type QueryChunkedDataHandler interface {
 	// and errors back to the client.
 	// The ChunkedDataWriter ensures efficient buffering and handles the transmission details.
 	QueryChunkedData(ctx context.Context, req *QueryChunkedDataRequest, w ChunkedDataWriter) error
-}
-
-// Experimental: QueryChunkedQueryRawClient allows raw access to the chunked results
-type QueryChunkedQueryRawClient interface {
-	QueryChunkedRaw(ctx context.Context, req *QueryChunkedDataRequest, cb func(evt *pluginv2.QueryChunkedDataResponse) error) error
-}
-
-// Experimental: ChunkedDataWriter defines the interface for writing data frames and errors
-// back to the client in chunks.
-type ChunkedDataWriter interface {
-	// WriteFrame writes a data frame (f) for the given query refID.
-	// The first time the frameID is written, the metadata and rows will be included.
-	// Subsequent calls with the same frameID will append the rows to the existing frame
-	// with a matching frameID. The metadata structure must match the initial request.
-	WriteFrame(ctx context.Context, refID string, frameID string, f *data.Frame) error
-
-	// WriteError writes an error associated with the specified refID.
-	WriteError(ctx context.Context, refID string, status Status, err error) error
 }
 
 // Experimental: QueryChunkedDataHandlerFunc is an adapter to allow the use of

--- a/backend/data.go
+++ b/backend/data.go
@@ -10,6 +10,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 )
 
 // EndpointQueryData friendly name for the query data endpoint/handler.
@@ -119,6 +120,11 @@ type QueryChunkedDataHandler interface {
 	// and errors back to the client.
 	// The ChunkedDataWriter ensures efficient buffering and handles the transmission details.
 	QueryChunkedData(ctx context.Context, req *QueryChunkedDataRequest, w ChunkedDataWriter) error
+}
+
+// Experimental: QueryChunkedQueryRawClient allows raw access to the chunked results
+type QueryChunkedQueryRawClient interface {
+	QueryChunked(ctx context.Context, req *QueryChunkedDataRequest, cb func(ctx context.Context, evt *pluginv2.QueryChunkedDataResponse)) error
 }
 
 // Experimental: ChunkedDataWriter defines the interface for writing data frames and errors

--- a/backend/handler.go
+++ b/backend/handler.go
@@ -1,11 +1,16 @@
 package backend
 
-import "context"
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
+)
 
 // Handler interface for all handlers.
 type Handler interface {
 	QueryDataHandler
 	QueryChunkedDataHandler
+	QueryChunkedQueryRawClient
 	CheckHealthHandler
 	CallResourceHandler
 	CollectMetricsHandler
@@ -36,6 +41,10 @@ func (m BaseHandler) QueryData(ctx context.Context, req *QueryDataRequest) (*Que
 
 func (m BaseHandler) QueryChunkedData(ctx context.Context, req *QueryChunkedDataRequest, w ChunkedDataWriter) error {
 	return m.next.QueryChunkedData(ctx, req, w)
+}
+
+func (m *BaseHandler) QueryChunkedRaw(ctx context.Context, req *QueryChunkedDataRequest, cb func(evt *pluginv2.QueryChunkedDataResponse) error) error {
+	return m.next.QueryChunkedRaw(ctx, req, cb)
 }
 
 func (m BaseHandler) CallResource(ctx context.Context, req *CallResourceRequest, sender CallResourceResponseSender) error {
@@ -78,6 +87,7 @@ func (m *BaseHandler) ConvertObjects(ctx context.Context, req *ConversionRequest
 type Handlers struct {
 	QueryDataHandler
 	QueryChunkedDataHandler
+	QueryChunkedQueryRawClient
 	CheckHealthHandler
 	CallResourceHandler
 	CollectMetricsHandler

--- a/backend/handler_middleware_test.go
+++ b/backend/handler_middleware_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/handlertest"
-	"github.com/stretchr/testify/require"
 )
 
 func TestHandlerFromMiddlewares(t *testing.T) {
@@ -174,6 +175,13 @@ func (m *TestMiddleware) QueryData(ctx context.Context, req *backend.QueryDataRe
 func (m *TestMiddleware) QueryChunkedData(ctx context.Context, req *backend.QueryChunkedDataRequest, w backend.ChunkedDataWriter) error {
 	m.sCtx.QueryChunkedDataCallChain = append(m.sCtx.QueryChunkedDataCallChain, fmt.Sprintf("before %s", m.Name))
 	err := m.next.QueryChunkedData(ctx, req, w)
+	m.sCtx.QueryChunkedDataCallChain = append(m.sCtx.QueryChunkedDataCallChain, fmt.Sprintf("after %s", m.Name))
+	return err
+}
+
+func (m *TestMiddleware) QueryChunkedRaw(ctx context.Context, req *backend.QueryChunkedDataRequest, cb backend.ChunkedDataCallback) error {
+	m.sCtx.QueryChunkedDataCallChain = append(m.sCtx.QueryChunkedDataCallChain, fmt.Sprintf("before %s", m.Name))
+	err := m.next.QueryChunkedRaw(ctx, req, cb)
 	m.sCtx.QueryChunkedDataCallChain = append(m.sCtx.QueryChunkedDataCallChain, fmt.Sprintf("after %s", m.Name))
 	return err
 }

--- a/backend/handlertest/handlertest.go
+++ b/backend/handlertest/handlertest.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
 )
 
 var _ backend.Handler = &Handler{}
@@ -35,6 +36,14 @@ func (h Handler) QueryData(ctx context.Context, req *backend.QueryDataRequest) (
 func (h Handler) QueryChunkedData(ctx context.Context, req *backend.QueryChunkedDataRequest, w backend.ChunkedDataWriter) error {
 	if h.QueryChunkedDataFunc != nil {
 		return h.QueryChunkedDataFunc(ctx, req, w)
+	}
+
+	return nil
+}
+
+func (h Handler) QueryChunkedRaw(ctx context.Context, req *backend.QueryChunkedDataRequest, cb func(evt *pluginv2.QueryChunkedDataResponse) error) error {
+	if h.QueryChunkedDataFunc != nil {
+		return h.QueryChunkedDataFunc(ctx, req, backend.NewChunkedDataCallback(req, cb))
 	}
 
 	return nil


### PR DESCRIPTION
Adds support for the new experimental `QueryChunkedData` for anyone using `QueryTypeMux`

This is used by the grafana testdata datasource, and will have a parallel PR exercising it before we should consider merging