### PR TITLE
QueryTypeMux: Support experimental QueryChunkedData requests

### DIFF
--- a/backend/datasource/query_type_mux.go
+++ b/backend/datasource/query_type_mux.go
@@ -35,6 +35,11 @@ func (mux *QueryTypeMux) Handle(queryType string, handler backend.QueryDataHandl
 		panic("datasource: nil handler")
 	}
 
+	if mux.m == nil {
+		mux.m = map[string]backend.QueryDataHandler{}
+		mux.fallbackHandler = backend.QueryDataHandlerFunc(fallbackHandler)
+	}
+
 	if _, exist := mux.m[queryType]; exist {
 		panic("datasource: multiple registrations for " + queryType)
 	}
@@ -60,10 +65,10 @@ func (mux *QueryTypeMux) HandleFunc(queryType string, handler func(ctx context.C
 // HandleChunkedQueryType registers a chunked chandler function for a given query type.
 func (mux *QueryTypeMux) HandleChunkedQueryType(queryType string, handler backend.QueryChunkedDataHandlerFunc) {
 	if queryType == "" {
-		panic("chunked handler not supported for missing query type")
+		panic("ChunkedHandleFunc: requires query type")
 	}
 	if handler == nil {
-		panic("datasource: nil handler")
+		panic("ChunkedHandleFunc: nil handler")
 	}
 	if _, exist := mux.c[queryType]; exist {
 		panic("ChunkedHandleFunc: multiple registrations for " + queryType)


### PR DESCRIPTION
See: https://github.com/grafana/grafana/pull/118223

https://github.com/grafana/grafana/pull/118223/changes#diff-8247f66ee3e0e48e8af5c857b7285d305e9ce0c3e7e5f29dde9d5ed60a100c98


With this, any service using QueryTypeMux can now easily implement QueryChunkedData using:
```
func (s *Service) QueryChunkedData(ctx context.Context, req *backend.QueryChunkedDataRequest, w backend.ChunkedDataWriter) error {
	return s.queryMux.QueryChunkedData(ctx, req, w)
}
```
