### PR TITLE
ChunkedDataWriter: Expose access to raw chunks

### DIFF
--- a/backend/chunked.go
+++ b/backend/chunked.go
@@ -26,7 +26,8 @@ type ChunkedDataWriter interface {
 	WriteError(ctx context.Context, refID string, status Status, err error) error
 
 	// Allow clients direct access to the raw response
-	// This can avoid an additional encode/decode cycle
+	// Implementing this method in a client can avoid an additional encode/decode cycle
+	// When writing a datasource plugin (server), this method should not be used
 	WriteChunk(chunk *pluginv2.QueryChunkedDataResponse) error
 }
 

--- a/backend/chunked.go
+++ b/backend/chunked.go
@@ -24,6 +24,10 @@ type ChunkedDataWriter interface {
 
 	// WriteError writes an error associated with the specified refID.
 	WriteError(ctx context.Context, refID string, status Status, err error) error
+
+	// Allow clients direct access to the raw response
+	// This can avoid an additional encode/decode cycle
+	WriteChunk(chunk *pluginv2.QueryChunkedDataResponse) error
 }
 
 func NewChunkedDataWriter(format DataFrameFormat, write ChunkedDataCallback) ChunkedDataWriter {
@@ -96,5 +100,10 @@ func (c *chunkedDataWriter) WriteFrame(ctx context.Context, refID string, frameI
 		return err
 	}
 
+	return c.write(chunk)
+}
+
+// WriteFrame implements [ChunkedDataWriter].
+func (c *chunkedDataWriter) WriteChunk(chunk *pluginv2.QueryChunkedDataResponse) error {
 	return c.write(chunk)
 }


### PR DESCRIPTION
Adds access to the raw protobuf message from ChunkedDataWriter. This lets a client intercept the messages directly rather than always depending on the parsed flavors in WriteFrame and WriteError.

In a server/plugin implementation, this method should be ignored