### PR TITLE
mt: add slug to secure_socks_requests_duration

### DIFF
--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -352,8 +352,6 @@ func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr strin
 			"network", n,
 			"addr", addr,
 			"code", code,
-			"datasource", d.datasourceName,
-			"datasource_type", d.datasourceType,
 			"slug", slug,
 			"duration", duration,
 			"error", err,

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -40,7 +40,7 @@ var (
 		Namespace: "grafana",
 		Name:      "secure_socks_requests_duration",
 		Help:      "Duration of requests to the secure socks proxy",
-	}, []string{"code", "datasource", "datasource_type", "slug"})
+	}, []string{"code", "datasource", "datasource_type"})
 	errUseOfHTTPDefaultTransport = errors.New("use of the http.DefaultTransport is not allowed with secure proxy")
 )
 
@@ -282,12 +282,14 @@ func (d *instrumentedSocksDialer) Dial(network, addr string) (net.Conn, error) {
 
 // DialContext -
 func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr string) (net.Conn, error) {
+	ctxLogger := log.DefaultLogger.FromContext(ctx)
 	if ctx.Err() != nil {
-		log.DefaultLogger.Debug("context cancelled or deadline exceeded, returning context error")
+		ctxLogger.Debug("context cancelled or deadline exceeded, returning context error")
 		return nil, ctx.Err()
 	}
 
 	start := time.Now()
+	slug := slugFromContext(ctx)
 	dialer, ok := d.dialer.(proxy.ContextDialer)
 	if !ok {
 		return nil, errors.New("unable to cast socks proxy dialer to context proxy dialer")
@@ -334,17 +336,29 @@ func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr strin
 		default:
 			code = "socks_unknown_error"
 		}
-		log.DefaultLogger.Error("received opErr from dialer", "network", n, "addr", addr, "opErr", opErr, "code", code)
 	default:
-		log.DefaultLogger.Error("received err from dialer", "network", n, "addr", addr, "err", err)
 		code = "dial_error"
 	}
 	if err != nil {
 		err = status.DownstreamError(err)
 	}
 
-	slug := slugFromContext(ctx)
-	secureSocksRequestsDuration.WithLabelValues(code, d.datasourceName, d.datasourceType, slug).Observe(time.Since(start).Seconds())
+	duration := time.Since(start)
+	secureSocksRequestsDuration.WithLabelValues(code, d.datasourceName, d.datasourceType).Observe(duration.Seconds())
+
+	if err != nil {
+		ctxLogger.Error("secure socks dial failed",
+			"eventName", "grafana-secure-socks-dial",
+			"network", n,
+			"addr", addr,
+			"code", code,
+			"datasource", d.datasourceName,
+			"datasource_type", d.datasourceType,
+			"slug", slug,
+			"duration", duration,
+			"error", err,
+		)
+	}
 	return c, err
 }
 

--- a/backend/proxy/secure_socks_proxy.go
+++ b/backend/proxy/secure_socks_proxy.go
@@ -40,7 +40,7 @@ var (
 		Namespace: "grafana",
 		Name:      "secure_socks_requests_duration",
 		Help:      "Duration of requests to the secure socks proxy",
-	}, []string{"code", "datasource", "datasource_type"})
+	}, []string{"code", "datasource", "datasource_type", "slug"})
 	errUseOfHTTPDefaultTransport = errors.New("use of the http.DefaultTransport is not allowed with secure proxy")
 )
 
@@ -242,7 +242,7 @@ func (p *cfgProxyWrapper) getTLSDialerFromFiles() (*tls.Dialer, error) {
 
 // SecureSocksProxyEnabledOnDS checks the datasource json data for `enableSecureSocksProxy`
 // to determine if the secure socks proxy should be enabled on it
-func SecureSocksProxyEnabledOnDS(jsonData map[string]interface{}) bool {
+func SecureSocksProxyEnabledOnDS(jsonData map[string]any) bool {
 	res, enabled := jsonData["enableSecureSocksProxy"]
 	if !enabled {
 		return false
@@ -343,6 +343,31 @@ func (d *instrumentedSocksDialer) DialContext(ctx context.Context, n, addr strin
 		err = status.DownstreamError(err)
 	}
 
-	secureSocksRequestsDuration.WithLabelValues(code, d.datasourceName, d.datasourceType).Observe(time.Since(start).Seconds())
+	slug := slugFromContext(ctx)
+	secureSocksRequestsDuration.WithLabelValues(code, d.datasourceName, d.datasourceType, slug).Observe(time.Since(start).Seconds())
 	return c, err
+}
+
+func slugFromContext(ctx context.Context) string {
+	if slug := getContextualLogAttribute(log.ContextualAttributesFromContext(ctx), "slug"); slug != "" {
+		return slug
+	}
+	return getContextualLogAttribute(log.ContextualAttributesFromIncomingContext(ctx), "slug")
+}
+
+func getContextualLogAttribute(attrs []any, key string) string {
+	if len(attrs) < 2 {
+		return ""
+	}
+
+	for i := 0; i+1 < len(attrs); i += 2 {
+		if k, ok := attrs[i].(string); ok && k == key {
+			if v, ok := attrs[i+1].(string); ok {
+				return v
+			}
+			return ""
+		}
+	}
+
+	return ""
 }

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -18,9 +18,13 @@ import (
 	"testing"
 	"time"
 
+	sdklog "github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/proxy"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestNewSecureSocksProxyContextDialerInsecureProxy(t *testing.T) {
@@ -365,6 +369,64 @@ func TestInstrumentedSocksDialer(t *testing.T) {
 	})
 }
 
+func TestInstrumentedSocksDialerMetricsIncludeSlug(t *testing.T) {
+	datasourceName := "name_" + strings.ReplaceAll(t.Name(), "/", "_")
+	datasourceType := "type_" + strings.ReplaceAll(t.Name(), "/", "_")
+	slug := "slug_" + strings.ReplaceAll(t.Name(), "/", "_")
+
+	d := newInstrumentedSocksDialer(fakeConn{}, datasourceName, datasourceType)
+	cd, ok := d.(proxy.ContextDialer)
+	require.True(t, ok)
+
+	withSlugLabels := map[string]string{
+		"code":            "0",
+		"datasource":      datasourceName,
+		"datasource_type": datasourceType,
+		"slug":            slug,
+	}
+	beforeWithSlug := getSecureSocksRequestCount(t, withSlugLabels)
+
+	_, err := cd.DialContext(sdklog.WithContextualAttributes(context.Background(), []any{"slug", slug}), "n", "addr")
+	require.NoError(t, err)
+
+	afterWithSlug := getSecureSocksRequestCount(t, withSlugLabels)
+	assert.Equal(t, beforeWithSlug+1, afterWithSlug)
+
+	withoutSlugLabels := map[string]string{
+		"code":            "0",
+		"datasource":      datasourceName,
+		"datasource_type": datasourceType,
+		"slug":            "",
+	}
+	beforeWithoutSlug := getSecureSocksRequestCount(t, withoutSlugLabels)
+
+	_, err = cd.DialContext(context.Background(), "n", "addr")
+	require.NoError(t, err)
+
+	afterWithoutSlug := getSecureSocksRequestCount(t, withoutSlugLabels)
+	assert.Equal(t, beforeWithoutSlug+1, afterWithoutSlug)
+}
+
+func TestSlugFromContext(t *testing.T) {
+	t.Run("returns slug from contextual attributes", func(t *testing.T) {
+		ctx := sdklog.WithContextualAttributes(context.Background(), []any{"slug", "stack-slug"})
+		assert.Equal(t, "stack-slug", slugFromContext(ctx))
+	})
+
+	t.Run("returns slug from incoming context metadata", func(t *testing.T) {
+		outgoing := sdklog.WithContextualAttributesForOutgoingContext(context.Background(), []any{"slug", "incoming-slug"})
+		md, ok := metadata.FromOutgoingContext(outgoing)
+		require.True(t, ok)
+
+		incoming := metadata.NewIncomingContext(context.Background(), md)
+		assert.Equal(t, "incoming-slug", slugFromContext(incoming))
+	})
+
+	t.Run("returns empty string when slug is missing", func(t *testing.T) {
+		assert.Equal(t, "", slugFromContext(context.Background()))
+	})
+}
+
 func Test_getTLSDialer(t *testing.T) {
 	t.Run("Prefer client config certificate raw value fields over filepath fields", func(t *testing.T) {
 		caPrivKey1, err := rsa.GenerateKey(rand.Reader, 4096)
@@ -424,6 +486,42 @@ func Test_getTLSDialer(t *testing.T) {
 		require.True(t, ok)
 		require.False(t, dialer.Config.RootCAs.Equal(certPool))
 	})
+}
+
+func getSecureSocksRequestCount(t *testing.T, expectedLabels map[string]string) uint64 {
+	t.Helper()
+
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range metrics {
+		if mf.GetName() != "grafana_secure_socks_requests_duration" {
+			continue
+		}
+
+		for _, m := range mf.GetMetric() {
+			if hasLabels(m.GetLabel(), expectedLabels) {
+				return m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+
+	return 0
+}
+
+func hasLabels(labelPairs []*dto.LabelPair, expected map[string]string) bool {
+	actual := make(map[string]string, len(labelPairs))
+	for _, lp := range labelPairs {
+		actual[lp.GetName()] = lp.GetValue()
+	}
+
+	for k, v := range expected {
+		if actual[k] != v {
+			return false
+		}
+	}
+
+	return true
 }
 
 func createRootCA(t *testing.T, pvtKey *rsa.PrivateKey) (*x509.Certificate, string, error) {

--- a/backend/proxy/secure_socks_proxy_test.go
+++ b/backend/proxy/secure_socks_proxy_test.go
@@ -20,7 +20,6 @@ import (
 
 	sdklog "github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/proxy"
@@ -369,7 +368,7 @@ func TestInstrumentedSocksDialer(t *testing.T) {
 	})
 }
 
-func TestInstrumentedSocksDialerMetricsIncludeSlug(t *testing.T) {
+func TestInstrumentedSocksDialerMetrics(t *testing.T) {
 	datasourceName := "name_" + strings.ReplaceAll(t.Name(), "/", "_")
 	datasourceType := "type_" + strings.ReplaceAll(t.Name(), "/", "_")
 	slug := "slug_" + strings.ReplaceAll(t.Name(), "/", "_")
@@ -378,33 +377,21 @@ func TestInstrumentedSocksDialerMetricsIncludeSlug(t *testing.T) {
 	cd, ok := d.(proxy.ContextDialer)
 	require.True(t, ok)
 
-	withSlugLabels := map[string]string{
+	labels := map[string]string{
 		"code":            "0",
 		"datasource":      datasourceName,
 		"datasource_type": datasourceType,
-		"slug":            slug,
 	}
-	beforeWithSlug := getSecureSocksRequestCount(t, withSlugLabels)
+	before := getSecureSocksRequestCount(t, labels)
 
 	_, err := cd.DialContext(sdklog.WithContextualAttributes(context.Background(), []any{"slug", slug}), "n", "addr")
 	require.NoError(t, err)
 
-	afterWithSlug := getSecureSocksRequestCount(t, withSlugLabels)
-	assert.Equal(t, beforeWithSlug+1, afterWithSlug)
-
-	withoutSlugLabels := map[string]string{
-		"code":            "0",
-		"datasource":      datasourceName,
-		"datasource_type": datasourceType,
-		"slug":            "",
-	}
-	beforeWithoutSlug := getSecureSocksRequestCount(t, withoutSlugLabels)
-
 	_, err = cd.DialContext(context.Background(), "n", "addr")
 	require.NoError(t, err)
 
-	afterWithoutSlug := getSecureSocksRequestCount(t, withoutSlugLabels)
-	assert.Equal(t, beforeWithoutSlug+1, afterWithoutSlug)
+	after := getSecureSocksRequestCount(t, labels)
+	assert.Equal(t, before+2, after)
 }
 
 func TestSlugFromContext(t *testing.T) {
@@ -500,7 +487,12 @@ func getSecureSocksRequestCount(t *testing.T, expectedLabels map[string]string) 
 		}
 
 		for _, m := range mf.GetMetric() {
-			if hasLabels(m.GetLabel(), expectedLabels) {
+			actualLabels := make(map[string]string, len(m.GetLabel()))
+			for _, lp := range m.GetLabel() {
+				actualLabels[lp.GetName()] = lp.GetValue()
+			}
+
+			if hasLabels(actualLabels, expectedLabels) {
 				return m.GetHistogram().GetSampleCount()
 			}
 		}
@@ -509,10 +501,9 @@ func getSecureSocksRequestCount(t *testing.T, expectedLabels map[string]string) 
 	return 0
 }
 
-func hasLabels(labelPairs []*dto.LabelPair, expected map[string]string) bool {
-	actual := make(map[string]string, len(labelPairs))
-	for _, lp := range labelPairs {
-		actual[lp.GetName()] = lp.GetValue()
+func hasLabels(actual map[string]string, expected map[string]string) bool {
+	if len(actual) != len(expected) {
+		return false
 	}
 
 	for k, v := range expected {

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,8 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // @grafana/grafana-app-platform-squad
 )
 
+require github.com/prometheus/client_model v0.6.2
+
 require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
@@ -116,7 +118,6 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.23 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/unknwon/com v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -55,8 +55,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // @grafana/grafana-app-platform-squad
 )
 
-require github.com/prometheus/client_model v0.6.2
-
 require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
@@ -118,6 +116,7 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.23 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/unknwon/com v1.0.1 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
Add slug as an additional label to the `secure_socks_requests_duration`