### PR TITLE
Skip node_modules directory in manifest generation

### DIFF
--- a/build/utils/manifest.go
+++ b/build/utils/manifest.go
@@ -18,7 +18,7 @@ func GenerateManifest() (string, error) {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() && d.Name() == "node_modules" {
+		if d.IsDir() && path == "node_modules" {
 			return fs.SkipDir
 		}
 		if !d.IsDir() && strings.HasSuffix(path, ".go") {

--- a/build/utils/manifest.go
+++ b/build/utils/manifest.go
@@ -18,6 +18,9 @@ func GenerateManifest() (string, error) {
 		if err != nil {
 			return err
 		}
+		if d.IsDir() && d.Name() == "node_modules" {
+			return fs.SkipDir
+		}
 		if !d.IsDir() && strings.HasSuffix(path, ".go") {
 			hash, err := hashFileContent(path)
 			if err != nil {

--- a/build/utils/manifest_test.go
+++ b/build/utils/manifest_test.go
@@ -29,14 +29,14 @@ func chdir(t *testing.T, dir string) {
 
 func writeFile(t *testing.T, path string, data []byte) {
 	t.Helper()
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func mkdirAll(t *testing.T, path string) {
 	t.Helper()
-	if err := os.MkdirAll(path, 0755); err != nil {
+	if err := os.MkdirAll(path, 0750); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/build/utils/manifest_test.go
+++ b/build/utils/manifest_test.go
@@ -49,6 +49,34 @@ func TestGenerateManifest_SkipsNodeModules(t *testing.T) {
 	}
 }
 
+func TestGenerateManifest_OnlySkipsRootNodeModules(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	os.WriteFile("main.go", []byte("package main"), 0644)
+
+	// Root node_modules — should be excluded.
+	os.MkdirAll(filepath.Join("node_modules", "pkg"), 0755)
+	os.WriteFile(filepath.Join("node_modules", "pkg", "root.go"), []byte("package pkg"), 0644)
+
+	// Nested node_modules inside a subdirectory — should be included.
+	nestedNM := filepath.Join("vendor", "lib", "node_modules", "dep")
+	os.MkdirAll(nestedNM, 0755)
+	os.WriteFile(filepath.Join(nestedNM, "nested.go"), []byte("package dep"), 0644)
+
+	manifest, err := GenerateManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(manifest, "root.go") {
+		t.Error("manifest should not contain Go files from root node_modules")
+	}
+	if !strings.Contains(manifest, "nested.go") {
+		t.Error("manifest should contain Go files from nested node_modules")
+	}
+}
+
 func TestGenerateManifest_OnlyIncludesGoFiles(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)

--- a/build/utils/manifest_test.go
+++ b/build/utils/manifest_test.go
@@ -17,8 +17,26 @@ func chdir(t *testing.T, dir string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Chdir(prev) })
+	t.Cleanup(func() {
+		if err := os.Chdir(prev); err != nil {
+			t.Logf("failed to restore working directory: %v", err)
+		}
+	})
 	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0755); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -32,9 +50,9 @@ func TestGenerateManifest_SkipsNodeModules(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
 
-	os.WriteFile("main.go", []byte("package main"), 0644)
-	os.MkdirAll(filepath.Join("node_modules", "somepackage"), 0755)
-	os.WriteFile(filepath.Join("node_modules", "somepackage", "file.go"), []byte("package somepackage"), 0644)
+	writeFile(t, "main.go", []byte("package main"))
+	mkdirAll(t, filepath.Join("node_modules", "somepackage"))
+	writeFile(t, filepath.Join("node_modules", "somepackage", "file.go"), []byte("package somepackage"))
 
 	manifest, err := GenerateManifest()
 	if err != nil {
@@ -53,16 +71,16 @@ func TestGenerateManifest_OnlySkipsRootNodeModules(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
 
-	os.WriteFile("main.go", []byte("package main"), 0644)
+	writeFile(t, "main.go", []byte("package main"))
 
 	// Root node_modules — should be excluded.
-	os.MkdirAll(filepath.Join("node_modules", "pkg"), 0755)
-	os.WriteFile(filepath.Join("node_modules", "pkg", "root.go"), []byte("package pkg"), 0644)
+	mkdirAll(t, filepath.Join("node_modules", "pkg"))
+	writeFile(t, filepath.Join("node_modules", "pkg", "root.go"), []byte("package pkg"))
 
 	// Nested node_modules inside a subdirectory — should be included.
 	nestedNM := filepath.Join("vendor", "lib", "node_modules", "dep")
-	os.MkdirAll(nestedNM, 0755)
-	os.WriteFile(filepath.Join(nestedNM, "nested.go"), []byte("package dep"), 0644)
+	mkdirAll(t, nestedNM)
+	writeFile(t, filepath.Join(nestedNM, "nested.go"), []byte("package dep"))
 
 	manifest, err := GenerateManifest()
 	if err != nil {
@@ -81,10 +99,10 @@ func TestGenerateManifest_OnlyIncludesGoFiles(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
 
-	os.WriteFile("main.go", []byte("package main"), 0644)
-	os.WriteFile("readme.md", []byte("# readme"), 0644)
-	os.WriteFile("config.json", []byte("{}"), 0644)
-	os.WriteFile("script.sh", []byte("#!/bin/bash"), 0644)
+	writeFile(t, "main.go", []byte("package main"))
+	writeFile(t, "readme.md", []byte("# readme"))
+	writeFile(t, "config.json", []byte("{}"))
+	writeFile(t, "script.sh", []byte("#!/bin/bash"))
 
 	manifest, err := GenerateManifest()
 	if err != nil {
@@ -105,9 +123,9 @@ func TestGenerateManifest_IncludesNestedGoFiles(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
 
-	os.WriteFile("main.go", []byte("package main"), 0644)
-	os.MkdirAll(filepath.Join("pkg", "sub"), 0755)
-	os.WriteFile(filepath.Join("pkg", "sub", "helper.go"), []byte("package sub"), 0644)
+	writeFile(t, "main.go", []byte("package main"))
+	mkdirAll(t, filepath.Join("pkg", "sub"))
+	writeFile(t, filepath.Join("pkg", "sub", "helper.go"), []byte("package sub"))
 
 	manifest, err := GenerateManifest()
 	if err != nil {
@@ -127,7 +145,7 @@ func TestGenerateManifest_EntryFormat(t *testing.T) {
 	chdir(t, dir)
 
 	content := []byte("package main")
-	os.WriteFile("main.go", content, 0644)
+	writeFile(t, "main.go", content)
 
 	manifest, err := GenerateManifest()
 	if err != nil {
@@ -150,8 +168,8 @@ func TestGenerateManifest_UsesForwardSlashes(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
 
-	os.MkdirAll(filepath.Join("a", "b"), 0755)
-	os.WriteFile(filepath.Join("a", "b", "c.go"), []byte("package b"), 0644)
+	mkdirAll(t, filepath.Join("a", "b"))
+	writeFile(t, filepath.Join("a", "b", "c.go"), []byte("package b"))
 
 	manifest, err := GenerateManifest()
 	if err != nil {
@@ -176,4 +194,3 @@ func TestGenerateManifest_EmptyDirectory(t *testing.T) {
 		t.Errorf("expected empty manifest for directory with no .go files, got: %q", manifest)
 	}
 }
-

--- a/build/utils/manifest_test.go
+++ b/build/utils/manifest_test.go
@@ -1,0 +1,151 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// chdir changes to the given directory and registers a cleanup to restore the original.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(prev) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+func TestGenerateManifest_SkipsNodeModules(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	os.WriteFile("main.go", []byte("package main"), 0644)
+	os.MkdirAll(filepath.Join("node_modules", "somepackage"), 0755)
+	os.WriteFile(filepath.Join("node_modules", "somepackage", "file.go"), []byte("package somepackage"), 0644)
+
+	manifest, err := GenerateManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(manifest, "main.go") {
+		t.Error("manifest should contain main.go")
+	}
+	if strings.Contains(manifest, "node_modules") {
+		t.Error("manifest should not contain files from node_modules")
+	}
+}
+
+func TestGenerateManifest_OnlyIncludesGoFiles(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	os.WriteFile("main.go", []byte("package main"), 0644)
+	os.WriteFile("readme.md", []byte("# readme"), 0644)
+	os.WriteFile("config.json", []byte("{}"), 0644)
+	os.WriteFile("script.sh", []byte("#!/bin/bash"), 0644)
+
+	manifest, err := GenerateManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(manifest, "main.go") {
+		t.Error("manifest should contain main.go")
+	}
+	for _, name := range []string{"readme.md", "config.json", "script.sh"} {
+		if strings.Contains(manifest, name) {
+			t.Errorf("manifest should not contain non-Go file %s", name)
+		}
+	}
+}
+
+func TestGenerateManifest_IncludesNestedGoFiles(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	os.WriteFile("main.go", []byte("package main"), 0644)
+	os.MkdirAll(filepath.Join("pkg", "sub"), 0755)
+	os.WriteFile(filepath.Join("pkg", "sub", "helper.go"), []byte("package sub"), 0644)
+
+	manifest, err := GenerateManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(manifest, "main.go") {
+		t.Error("manifest should contain main.go")
+	}
+	if !strings.Contains(manifest, "pkg/sub/helper.go") {
+		t.Error("manifest should contain nested Go file pkg/sub/helper.go")
+	}
+}
+
+func TestGenerateManifest_EntryFormat(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	content := []byte("package main")
+	os.WriteFile("main.go", content, 0644)
+
+	manifest, err := GenerateManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedHash := sha256Hex(content)
+	expectedLine := fmt.Sprintf("%s:main.go", expectedHash)
+
+	lines := strings.Split(strings.TrimSpace(manifest), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 manifest line, got %d", len(lines))
+	}
+	if lines[0] != expectedLine {
+		t.Errorf("manifest line = %q, want %q", lines[0], expectedLine)
+	}
+}
+
+func TestGenerateManifest_UsesForwardSlashes(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	os.MkdirAll(filepath.Join("a", "b"), 0755)
+	os.WriteFile(filepath.Join("a", "b", "c.go"), []byte("package b"), 0644)
+
+	manifest, err := GenerateManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(manifest, "a/b/c.go") {
+		t.Errorf("manifest should use forward slashes, got: %s", manifest)
+	}
+}
+
+func TestGenerateManifest_EmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	manifest, err := GenerateManifest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if manifest != "" {
+		t.Errorf("expected empty manifest for directory with no .go files, got: %q", manifest)
+	}
+}
+


### PR DESCRIPTION
## What this PR does / why we need it

Excludes Go files located in the `node_modules` directory from the plugin manifest file generated during the build process. This prevents frontend dependencies from being included in the backend plugin manifest, which is important for plugins that have both frontend and backend components.

This fix validation errors produced when plugin has a frontend dependency on a package containing `.go` files.

```
❌ go-manifest-issue

Invalid Go manifest file: node_modules/flatted/golang/pkg/flatted/flatted.go

Details: node_modules/flatted/golang/pkg/flatted/flatted.go is in the manifest but not in source code
```

## Which issue(s) this PR fixes

Fixes #

## Special notes for your reviewer

All existing tests continue to pass and new tests verify the `node_modules` directory is properly excluded from the manifest.