### PR TITLE
Build: add new targets (default windows/arm64, optional linux/s390x)

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -232,9 +232,19 @@ func (Build) LinuxARM64() error {
 	return buildBackend(newBuildConfig("linux", "arm64"))
 }
 
+// LinuxS390X builds the back-end plugin for Linux on s390x (IBM Z).
+func (Build) LinuxS390X() error {
+	return buildBackend(newBuildConfig("linux", "s390x"))
+}
+
 // Windows builds the back-end plugin for Windows.
 func (Build) Windows() error {
 	return buildBackend(newBuildConfig("windows", "amd64"))
+}
+
+// WindowsARM64 builds the back-end plugin for Windows on ARM64.
+func (Build) WindowsARM64() error {
+	return buildBackend(newBuildConfig("windows", "arm64"))
 }
 
 // Darwin builds the back-end plugin for OSX on AMD64.
@@ -339,10 +349,16 @@ func (Build) Backend() error {
 	return buildBackend(cfg)
 }
 
-// BuildAll builds production executables for all supported platforms.
+// BuildAll builds production executables for all default supported platforms.
 func BuildAll() { //revive:disable-line
 	b := Build{}
-	mg.Deps(b.Linux, b.Windows, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM)
+	mg.Deps(b.Linux, b.Windows, b.WindowsARM64, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM)
+}
+
+// BuildAllPlusS390X adds s390x to the above, for formerly-core datasources that have been externalized
+func BuildAllPlusS390X() { //revive:disable-line
+	b := Build{}
+	mg.Deps(b.Linux, b.Windows, b.WindowsARM64, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM, b.LinuxS390X)
 }
 
 //go:embed tmpl/*

--- a/build/common.go
+++ b/build/common.go
@@ -356,7 +356,7 @@ func BuildAll() { //revive:disable-line
 }
 
 // BuildAllPlusS390X adds s390x to the above, for formerly-core datasources that have been externalized
-func BuildAllPlusS390X() { //revive:disable-line
+func BuildWithS390X() { //revive:disable-line
 	b := Build{}
 	mg.Deps(b.Linux, b.Windows, b.WindowsARM64, b.Darwin, b.DarwinARM64, b.LinuxARM64, b.LinuxARM, b.LinuxS390X)
 }

--- a/build/common_test.go
+++ b/build/common_test.go
@@ -73,6 +73,36 @@ func Test_getExecutableNameForPlugin(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "Checking new s390x arch just in case",
+			args: args{
+				os:        "linux",
+				arch:      "s390x",
+				pluginDir: filepath.Join(rootDir, "bar-datasource"),
+			},
+			expected: "gpx_bar_linux_s390x",
+			expectedCache: map[string]string{
+				filepath.Join(rootDir, "foo-datasource"): "gpx_foo",
+				filepath.Join(rootDir, "baz-datasource"): "gpx_baz",
+				filepath.Join(rootDir, "bar-datasource"): "gpx_bar",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "Checking new windows/arm64 arch just in case",
+			args: args{
+				os:        "windows",
+				arch:      "arm64",
+				pluginDir: filepath.Join(rootDir, "bar-datasource"),
+			},
+			expected: "gpx_bar_windows_arm64.exe",
+			expectedCache: map[string]string{
+				filepath.Join(rootDir, "foo-datasource"): "gpx_foo",
+				filepath.Join(rootDir, "baz-datasource"): "gpx_baz",
+				filepath.Join(rootDir, "bar-datasource"): "gpx_bar",
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "Non existing plugin returns an error",
 			args: args{
 				os:        "linux",
@@ -83,6 +113,7 @@ func Test_getExecutableNameForPlugin(t *testing.T) {
 			expectedCache: map[string]string{
 				filepath.Join(rootDir, "foo-datasource"): "gpx_foo",
 				filepath.Join(rootDir, "baz-datasource"): "gpx_baz",
+				filepath.Join(rootDir, "bar-datasource"): "gpx_bar",
 			},
 			wantErr: assert.Error,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Now that we're bundling externalized (formerly core) plugins with Grafana builds, the `windows/arm64` and `linux/s390x` targets don't build correctly because these os/arch pairs aren't available in the plugin builds. This adds `windows/arm64` to the default builds as it's safer, and external plugins are already used on windows, where this eliminate emulation overhead on that platform, and adds a new build target for `linux/s390x` since it's more esoteric and we don't currently support external plugins there.