### PR TITLE
Add httpclient roundtripper response limiter

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/useragent"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/featuretoggles"
@@ -48,6 +49,11 @@ func GrafanaConfigFromContext(ctx context.Context) *GrafanaCfg {
 // WithGrafanaConfig injects supplied Grafana config into context.
 func WithGrafanaConfig(ctx context.Context, cfg *GrafanaCfg) context.Context {
 	ctx = context.WithValue(ctx, configKey{}, cfg)
+	if cfg != nil {
+		if limit := cfg.ResponseLimit(); limit > 0 {
+			ctx = httpclient.WithResponseLimitContext(ctx, limit)
+		}
+	}
 	return ctx
 }
 

--- a/backend/config.go
+++ b/backend/config.go
@@ -46,7 +46,10 @@ func GrafanaConfigFromContext(ctx context.Context) *GrafanaCfg {
 	return cfg
 }
 
-// WithGrafanaConfig injects supplied Grafana config into context.
+// WithGrafanaConfig injects the supplied Grafana config into the context.
+// When the config carries a response limit it is also stored via
+// httpclient.WithResponseLimitContext so that ResponseLimitMiddleware can apply it
+// per-request without importing the backend package (which would be a circular import).
 func WithGrafanaConfig(ctx context.Context, cfg *GrafanaCfg) context.Context {
 	ctx = context.WithValue(ctx, configKey{}, cfg)
 	if cfg != nil {

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -235,6 +235,7 @@ func DefaultMiddlewares() []Middleware {
 		CustomHeadersMiddleware(),
 		ContextualMiddleware(),
 		ErrorSourceMiddleware(),
+		ResponseLimitMiddleware(0),
 	}
 }
 

--- a/backend/httpclient/http_client_test.go
+++ b/backend/httpclient/http_client_test.go
@@ -70,13 +70,14 @@ func TestNewClient(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, client)
 
-		require.Len(t, usedMiddlewares, 6)
+		require.Len(t, usedMiddlewares, 7)
 		require.Equal(t, TracingMiddlewareName, usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 		require.Equal(t, DataSourceMetricsMiddlewareName, usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 		require.Equal(t, BasicAuthenticationMiddlewareName, usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 		require.Equal(t, CustomHeadersMiddlewareName, usedMiddlewares[3].(MiddlewareName).MiddlewareName())
 		require.Equal(t, ContextualMiddlewareName, usedMiddlewares[4].(MiddlewareName).MiddlewareName())
 		require.Equal(t, ErrorSourceMiddlewareName, usedMiddlewares[5].(MiddlewareName).MiddlewareName())
+		require.Equal(t, ResponseLimitMiddlewareName, usedMiddlewares[6].(MiddlewareName).MiddlewareName())
 	})
 
 	t.Run("New() with opts middleware should return expected http.Client", func(t *testing.T) {

--- a/backend/httpclient/provider_test.go
+++ b/backend/httpclient/provider_test.go
@@ -25,13 +25,14 @@ func TestProvider(t *testing.T) {
 			client, err := ctx.provider.New()
 			require.NoError(t, err)
 			require.NotNil(t, client)
-			require.Len(t, ctx.usedMiddlewares, 6)
+			require.Len(t, ctx.usedMiddlewares, 7)
 			require.Equal(t, TracingMiddlewareName, ctx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 			require.Equal(t, DataSourceMetricsMiddlewareName, ctx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 			require.Equal(t, BasicAuthenticationMiddlewareName, ctx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 			require.Equal(t, CustomHeadersMiddlewareName, ctx.usedMiddlewares[3].(MiddlewareName).MiddlewareName())
 			require.Equal(t, ContextualMiddlewareName, ctx.usedMiddlewares[4].(MiddlewareName).MiddlewareName())
 			require.Equal(t, ErrorSourceMiddlewareName, ctx.usedMiddlewares[5].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ResponseLimitMiddlewareName, ctx.usedMiddlewares[6].(MiddlewareName).MiddlewareName())
 		})
 
 		t.Run("Transport should use default middlewares", func(t *testing.T) {
@@ -39,13 +40,14 @@ func TestProvider(t *testing.T) {
 			transport, err := ctx.provider.GetTransport()
 			require.NoError(t, err)
 			require.NotNil(t, transport)
-			require.Len(t, ctx.usedMiddlewares, 6)
+			require.Len(t, ctx.usedMiddlewares, 7)
 			require.Equal(t, TracingMiddlewareName, ctx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 			require.Equal(t, DataSourceMetricsMiddlewareName, ctx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 			require.Equal(t, BasicAuthenticationMiddlewareName, ctx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 			require.Equal(t, CustomHeadersMiddlewareName, ctx.usedMiddlewares[3].(MiddlewareName).MiddlewareName())
 			require.Equal(t, ContextualMiddlewareName, ctx.usedMiddlewares[4].(MiddlewareName).MiddlewareName())
 			require.Equal(t, ErrorSourceMiddlewareName, ctx.usedMiddlewares[5].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ResponseLimitMiddlewareName, ctx.usedMiddlewares[6].(MiddlewareName).MiddlewareName())
 		})
 
 		t.Run("New() with options and no middleware should return expected http client and transport", func(t *testing.T) {
@@ -86,7 +88,7 @@ func TestProvider(t *testing.T) {
 			require.Equal(t, DefaultTimeoutOptions.Timeout, client.Timeout)
 
 			t.Run("Should use configured middlewares and implement MiddlewareName", func(t *testing.T) {
-				require.Len(t, pCtx.usedMiddlewares, 9)
+				require.Len(t, pCtx.usedMiddlewares, 10)
 				require.Equal(t, "mw1", pCtx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 				require.Equal(t, "mw2", pCtx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 				require.Equal(t, "mw3", pCtx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
@@ -96,6 +98,7 @@ func TestProvider(t *testing.T) {
 				require.Equal(t, CustomHeadersMiddlewareName, pCtx.usedMiddlewares[6].(MiddlewareName).MiddlewareName())
 				require.Equal(t, ContextualMiddlewareName, pCtx.usedMiddlewares[7].(MiddlewareName).MiddlewareName())
 				require.Equal(t, ErrorSourceMiddlewareName, pCtx.usedMiddlewares[8].(MiddlewareName).MiddlewareName())
+				require.Equal(t, ResponseLimitMiddlewareName, pCtx.usedMiddlewares[9].(MiddlewareName).MiddlewareName())
 			})
 
 			t.Run("When roundtrip should call expected middlewares", func(t *testing.T) {

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -1,6 +1,7 @@
 package httpclient
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -15,22 +16,42 @@ import (
 const ResponseLimitMiddlewareName = "response-limit"
 
 const (
-	responseLimitEnvVar    = "GF_RESPONSE_LIMIT"
-	defaultResponseLimit   = 200 * 1024 * 1024 // 200MB
+	responseLimitEnvVar  = "GF_RESPONSE_LIMIT"
+	defaultResponseLimit = 200 * 1024 * 1024 // 200MB
 )
 
+type responseLimitContextKey struct{}
+
+// WithResponseLimitContext stores a response limit in the context, to be picked up by
+// ResponseLimitMiddleware on each request. The backend package calls this from
+// WithGrafanaConfig so that GrafanaCfg.ResponseLimit() takes priority over the env var.
+func WithResponseLimitContext(ctx context.Context, limit int64) context.Context {
+	return context.WithValue(ctx, responseLimitContextKey{}, limit)
+}
+
+func responseLimitFromContext(ctx context.Context) int64 {
+	v, _ := ctx.Value(responseLimitContextKey{}).(int64)
+	return v
+}
+
 // ResponseLimitMiddleware creates a middleware that limits the size of the response body.
-// The effective limit is resolved in priority order:
-//  1. limit argument, if > 0 (e.g. passed from GrafanaCfg.ResponseLimit())
-//  2. GF_RESPONSE_LIMIT environment variable
-//  3. 200MB default
+// The effective limit is resolved per-request in priority order:
+//  1. GrafanaCfg.ResponseLimit() from context (set via WithResponseLimitContext)
+//  2. limit argument, if > 0
+//  3. GF_RESPONSE_LIMIT environment variable
+//  4. 200MB default
 func ResponseLimitMiddleware(limit int64) Middleware {
 	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
-		effectiveLimit := resolveResponseLimit(limit)
+		fallbackLimit := resolveResponseLimit(limit)
 		dsUID := opts.Labels["datasource_uid"]
 		dsName := opts.Labels["datasource_name"]
 
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			effectiveLimit := fallbackLimit
+			if ctxLimit := responseLimitFromContext(req.Context()); ctxLimit > 0 {
+				effectiveLimit = ctxLimit
+			}
+
 			res, err := next.RoundTrip(req)
 			if err != nil {
 				return nil, err

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -1,29 +1,84 @@
 package httpclient
 
 import (
+	"errors"
+	"io"
 	"net/http"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 // ResponseLimitMiddlewareName is the middleware name used by ResponseLimitMiddleware.
 const ResponseLimitMiddlewareName = "response-limit"
 
+const (
+	responseLimitEnvVar    = "GF_RESPONSE_LIMIT"
+	defaultResponseLimit   = 200 * 1024 * 1024 // 200MB
+)
+
+// ResponseLimitMiddleware creates a middleware that limits the size of the response body.
+// The effective limit is resolved in priority order:
+//  1. limit argument, if > 0 (e.g. passed from GrafanaCfg.ResponseLimit())
+//  2. GF_RESPONSE_LIMIT environment variable
+//  3. 200MB default
 func ResponseLimitMiddleware(limit int64) Middleware {
-	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(_ Options, next http.RoundTripper) http.RoundTripper {
+	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
+		effectiveLimit := resolveResponseLimit(limit)
+		dsUID := opts.Labels["datasource_uid"]
+		dsName := opts.Labels["datasource_name"]
+
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			res, err := next.RoundTrip(req)
 			if err != nil {
 				return nil, err
 			}
 
-			if limit <= 0 {
-				return res, nil
-			}
-
 			if res != nil && res.StatusCode != http.StatusSwitchingProtocols {
-				res.Body = MaxBytesReader(res.Body, limit)
+				res.Body = &responseLimitBody{
+					ReadCloser: MaxBytesReader(res.Body, effectiveLimit),
+					limit:      effectiveLimit,
+					dsUID:      dsUID,
+					dsName:     dsName,
+				}
 			}
 
 			return res, nil
 		})
 	})
+}
+
+func resolveResponseLimit(limit int64) int64 {
+	if limit > 0 {
+		return limit
+	}
+	if v, err := strconv.ParseInt(os.Getenv(responseLimitEnvVar), 10, 64); err == nil && v > 0 {
+		return v
+	}
+	return defaultResponseLimit
+}
+
+// responseLimitBody wraps MaxBytesReader to log when the response limit is exceeded.
+type responseLimitBody struct {
+	io.ReadCloser
+	limit  int64
+	dsUID  string
+	dsName string
+	once   sync.Once
+}
+
+func (b *responseLimitBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if err != nil && errors.Is(err, ErrResponseBodyTooLarge) {
+		b.once.Do(func() {
+			log.DefaultLogger.Warn("downstream response body exceeded limit",
+				"datasource_uid", b.dsUID,
+				"datasource_name", b.dsName,
+				"limit_bytes", b.limit,
+			)
+		})
+	}
+	return n, err
 }

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -15,16 +15,21 @@ import (
 // ResponseLimitMiddlewareName is the middleware name used by ResponseLimitMiddleware.
 const ResponseLimitMiddlewareName = "response-limit"
 
-const responseLimitEnvVar = "GF_RESPONSE_LIMIT"
+// responseLimitEnvVar can be set directly on the plugin server to cap response sizes
+// regardless of what Grafana's config system sends. This is useful when running a plugin
+// on a separate server in Cloud environments where you want per-pod control.
+const responseLimitEnvVar = "GF_DATAPROXY_RESPONSE_LIMIT"
 
 type responseLimitContextKey struct{}
 
-// WithResponseLimitContext stores a response limit in the context, to be picked up by
-// ResponseLimitMiddleware on each request. It is called by the backend package from
-// WithGrafanaConfig so that GrafanaCfg.ResponseLimit() takes priority over the env var.
-// A limit of 0 explicitly disables limiting for the request, regardless of any fallback.
-// Note: WithGrafanaConfig only calls this when the cfg limit is > 0, so a zero cfg value
-// falls through to the env var / 200MB default rather than disabling limiting entirely.
+// WithResponseLimitContext injects a response limit into the context so that
+// ResponseLimitMiddleware can apply it per-request. A value of 0 explicitly disables
+// context-based limiting for that request.
+//
+// This is called by WithGrafanaConfig in the backend package — plugins do not need to
+// call it directly. Note that WithGrafanaConfig only forwards limits > 0, so when
+// GrafanaCfg carries no limit the middleware falls back to the limit argument or disables
+// entirely.
 func WithResponseLimitContext(ctx context.Context, limit int64) context.Context {
 	return context.WithValue(ctx, responseLimitContextKey{}, &limit)
 }
@@ -37,23 +42,25 @@ func responseLimitFromContext(ctx context.Context) (int64, bool) {
 	return *v, true
 }
 
-// ResponseLimitMiddleware creates a middleware that limits the size of the response body.
-// The effective limit is resolved per-request in priority order:
-//  1. GrafanaCfg.ResponseLimit() from context (set via WithResponseLimitContext)
-//  2. limit argument, if > 0
-//  3. GF_RESPONSE_LIMIT environment variable
-//  4. 200MB default
+// ResponseLimitMiddleware limits the size of downstream response bodies.
+// When the limit is exceeded the response body returns ErrResponseBodyTooLarge and a
+// warning is logged with the datasource identifiers from opts.Labels.
+//
+// The limit is resolved per-request in the following priority order:
+//  1. GF_DATAPROXY_RESPONSE_LIMIT environment variable — read once at client construction,
+//     takes highest priority so plugin server operators can override Grafana's config
+//  2. GrafanaCfg.ResponseLimit() injected via WithGrafanaConfig (sourced from Grafana's config)
+//  3. The limit argument passed to this function, if > 0
+//
+// If none of the above are set, limiting is disabled for that request.
 func ResponseLimitMiddleware(limit int64) Middleware {
 	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
-		fallbackLimit := resolveResponseLimit(limit)
+		envLimit := parseEnvResponseLimit()
 		dsUID := opts.Labels["datasource_uid"]
 		dsName := opts.Labels["datasource_name"]
 
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			effectiveLimit := fallbackLimit
-			if ctxLimit, ok := responseLimitFromContext(req.Context()); ok {
-				effectiveLimit = ctxLimit
-			}
+			effectiveLimit := resolveResponseLimit(envLimit, limit, req.Context())
 
 			res, err := next.RoundTrip(req)
 			if err != nil {
@@ -79,16 +86,28 @@ func ResponseLimitMiddleware(limit int64) Middleware {
 	})
 }
 
-func resolveResponseLimit(limit int64) int64 {
-	if limit > 0 {
-		return limit
-	}
-	// GF_RESPONSE_LIMIT is read once at client construction time. Changes to the env var
-	// after the client is built will not take effect until the client is recreated.
-	if v, err := strconv.ParseInt(os.Getenv(responseLimitEnvVar), 10, 64); err == nil && v > 0 {
+// parseEnvResponseLimit reads GF_DATAPROXY_RESPONSE_LIMIT once at client construction time.
+// Changes to the env var after the client is built will not take effect until the client
+// is recreated.
+func parseEnvResponseLimit() int64 {
+	v, err := strconv.ParseInt(os.Getenv(responseLimitEnvVar), 10, 64)
+	if err == nil && v > 0 {
 		return v
 	}
 	return 0
+}
+
+// resolveResponseLimit determines the effective limit for a request.
+// envLimit wins if set, then the per-request context value from GrafanaCfg, then the
+// static limit argument. Returns 0 if none are set, which disables limiting.
+func resolveResponseLimit(envLimit, limit int64, ctx context.Context) int64 {
+	if envLimit > 0 {
+		return envLimit
+	}
+	if ctxLimit, ok := responseLimitFromContext(ctx); ok {
+		return ctxLimit
+	}
+	return limit
 }
 
 type responseLimitBody struct {

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -13,12 +13,10 @@ import (
 )
 
 // ResponseLimitMiddlewareName is the middleware name used by ResponseLimitMiddleware.
-const ResponseLimitMiddlewareName = "response-limit"
-
-// responseLimitEnvVar is read at client construction and takes priority over all other
-// limit sources. It is intended for plugin server operators who need per-pod control
-// independent of Grafana's config (e.g. when running plugins on separate servers in Cloud).
-const responseLimitEnvVar = "GF_DATAPROXY_RESPONSE_LIMIT"
+const (
+	ResponseLimitMiddlewareName = "response-limit"
+	responseLimitEnvVar         = "GF_DATAPROXY_RESPONSE_LIMIT"
+)
 
 type responseLimitContextKey struct{}
 
@@ -53,36 +51,39 @@ func responseLimitFromContext(ctx context.Context) (int64, bool) {
 //
 // If none are set, limiting is disabled.
 func ResponseLimitMiddleware(limit int64) Middleware {
-	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
-		envLimit := parseEnvResponseLimit()
-		dsUID := opts.Labels["datasource_uid"]
-		dsName := opts.Labels["datasource_name"]
+	return NamedMiddlewareFunc(
+		ResponseLimitMiddlewareName,
+		func(opts Options, next http.RoundTripper) http.RoundTripper {
+			envLimit := parseEnvResponseLimit()
+			dsUID := opts.Labels["datasource_uid"]
+			dsName := opts.Labels["datasource_name"]
 
-		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			effectiveLimit := resolveResponseLimit(envLimit, limit, req.Context())
+			return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				effectiveLimit := resolveResponseLimit(envLimit, limit, req.Context())
 
-			res, err := next.RoundTrip(req)
-			if err != nil {
-				return nil, err
-			}
-
-			if effectiveLimit <= 0 {
-				return res, nil
-			}
-
-			if res != nil && res.StatusCode != http.StatusSwitchingProtocols {
-				res.Body = &responseLimitBody{
-					ReadCloser: MaxBytesReader(res.Body, effectiveLimit),
-					ctx:        req.Context(),
-					limit:      effectiveLimit,
-					dsUID:      dsUID,
-					dsName:     dsName,
+				res, err := next.RoundTrip(req)
+				if err != nil {
+					return nil, err
 				}
-			}
 
-			return res, nil
-		})
-	})
+				if effectiveLimit <= 0 {
+					return res, nil
+				}
+
+				if res != nil && res.StatusCode != http.StatusSwitchingProtocols {
+					res.Body = &responseLimitBody{
+						ReadCloser: MaxBytesReader(res.Body, effectiveLimit),
+						ctx:        req.Context(),
+						limit:      effectiveLimit,
+						dsUID:      dsUID,
+						dsName:     dsName,
+					}
+				}
+
+				return res, nil
+			})
+		},
+	)
 }
 
 // parseEnvResponseLimit reads GF_DATAPROXY_RESPONSE_LIMIT once at client construction time.

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -15,21 +15,21 @@ import (
 // ResponseLimitMiddlewareName is the middleware name used by ResponseLimitMiddleware.
 const ResponseLimitMiddlewareName = "response-limit"
 
-// responseLimitEnvVar can be set directly on the plugin server to cap response sizes
-// regardless of what Grafana's config system sends. This is useful when running a plugin
-// on a separate server in Cloud environments where you want per-pod control.
+// responseLimitEnvVar is read at client construction and takes priority over all other
+// limit sources. It is intended for plugin server operators who need per-pod control
+// independent of Grafana's config (e.g. when running plugins on separate servers in Cloud).
 const responseLimitEnvVar = "GF_DATAPROXY_RESPONSE_LIMIT"
 
 type responseLimitContextKey struct{}
 
-// WithResponseLimitContext injects a response limit into the context so that
-// ResponseLimitMiddleware can apply it per-request. A value of 0 explicitly disables
-// context-based limiting for that request.
+// WithResponseLimitContext stores a response size limit in the context for
+// ResponseLimitMiddleware to apply per-request. Called by WithGrafanaConfig in the
+// backend package to propagate GrafanaCfg.ResponseLimit() — plugins do not need to call
+// this directly.
 //
-// This is called by WithGrafanaConfig in the backend package — plugins do not need to
-// call it directly. Note that WithGrafanaConfig only forwards limits > 0, so when
-// GrafanaCfg carries no limit the middleware falls back to the limit argument or disables
-// entirely.
+// Note: GF_DATAPROXY_RESPONSE_LIMIT takes priority over the context value. A context
+// value of 0 is only effective when the env var is unset — it disables the cfg-based
+// limit and falls through to the limit argument.
 func WithResponseLimitContext(ctx context.Context, limit int64) context.Context {
 	return context.WithValue(ctx, responseLimitContextKey{}, &limit)
 }
@@ -47,12 +47,11 @@ func responseLimitFromContext(ctx context.Context) (int64, bool) {
 // warning is logged with the datasource identifiers from opts.Labels.
 //
 // The limit is resolved per-request in the following priority order:
-//  1. GF_DATAPROXY_RESPONSE_LIMIT environment variable — read once at client construction,
-//     takes highest priority so plugin server operators can override Grafana's config
-//  2. GrafanaCfg.ResponseLimit() injected via WithGrafanaConfig (sourced from Grafana's config)
-//  3. The limit argument passed to this function, if > 0
+//  1. GF_DATAPROXY_RESPONSE_LIMIT env var — read once at client construction
+//  2. GrafanaCfg.ResponseLimit() from the request context, set by WithGrafanaConfig
+//  3. The limit argument, if > 0
 //
-// If none of the above are set, limiting is disabled for that request.
+// If none are set, limiting is disabled.
 func ResponseLimitMiddleware(limit int64) Middleware {
 	return NamedMiddlewareFunc(ResponseLimitMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
 		envLimit := parseEnvResponseLimit()

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -25,9 +25,9 @@ type responseLimitContextKey struct{}
 // backend package to propagate GrafanaCfg.ResponseLimit() — plugins do not need to call
 // this directly.
 //
-// Note: GF_DATAPROXY_RESPONSE_LIMIT takes priority over the context value. A context
-// value of 0 is only effective when the env var is unset — it disables the cfg-based
-// limit and falls through to the limit argument.
+// Note: when set, the context value takes priority over GF_DATAPROXY_RESPONSE_LIMIT.
+// A context value of 0 disables limiting entirely — the env var and limit argument are
+// not consulted.
 func WithResponseLimitContext(ctx context.Context, limit int64) context.Context {
 	return context.WithValue(ctx, responseLimitContextKey{}, &limit)
 }
@@ -45,8 +45,8 @@ func responseLimitFromContext(ctx context.Context) (int64, bool) {
 // warning is logged with the datasource identifiers from opts.Labels.
 //
 // The limit is resolved per-request in the following priority order:
-//  1. GF_DATAPROXY_RESPONSE_LIMIT env var — read once at client construction
-//  2. GrafanaCfg.ResponseLimit() from the request context, set by WithGrafanaConfig
+//  1. GrafanaCfg.ResponseLimit() from the request context, set by WithGrafanaConfig
+//  2. GF_DATAPROXY_RESPONSE_LIMIT env var — read once at client construction
 //  3. The limit argument, if > 0
 //
 // If none are set, limiting is disabled.
@@ -98,14 +98,14 @@ func parseEnvResponseLimit() int64 {
 }
 
 // resolveResponseLimit determines the effective limit for a request.
-// envLimit wins if set, then the per-request context value from GrafanaCfg, then the
-// static limit argument. Returns 0 if none are set, which disables limiting.
+// The per-request context value from GrafanaCfg wins if present, then the env var,
+// then the static limit argument. Returns 0 if none are set, which disables limiting.
 func resolveResponseLimit(envLimit, limit int64, ctx context.Context) int64 {
-	if envLimit > 0 {
-		return envLimit
-	}
 	if ctxLimit, ok := responseLimitFromContext(ctx); ok {
 		return ctxLimit
+	}
+	if envLimit > 0 {
+		return envLimit
 	}
 	return limit
 }

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -15,29 +15,26 @@ import (
 // ResponseLimitMiddlewareName is the middleware name used by ResponseLimitMiddleware.
 const ResponseLimitMiddlewareName = "response-limit"
 
-const (
-	responseLimitEnvVar  = "GF_RESPONSE_LIMIT"
-	defaultResponseLimit = 200 * 1024 * 1024 // 200MB
-)
+const responseLimitEnvVar = "GF_RESPONSE_LIMIT"
 
 type responseLimitContextKey struct{}
 
-type responseLimitContextValue struct {
-	limit int64
-}
-
 // WithResponseLimitContext stores a response limit in the context, to be picked up by
-// ResponseLimitMiddleware on each request. The backend package calls this from
+// ResponseLimitMiddleware on each request. It is called by the backend package from
 // WithGrafanaConfig so that GrafanaCfg.ResponseLimit() takes priority over the env var.
-// A limit of 0 explicitly disables limiting for the request.
+// A limit of 0 explicitly disables limiting for the request, regardless of any fallback.
+// Note: WithGrafanaConfig only calls this when the cfg limit is > 0, so a zero cfg value
+// falls through to the env var / 200MB default rather than disabling limiting entirely.
 func WithResponseLimitContext(ctx context.Context, limit int64) context.Context {
-	return context.WithValue(ctx, responseLimitContextKey{}, responseLimitContextValue{limit})
+	return context.WithValue(ctx, responseLimitContextKey{}, &limit)
 }
 
-// responseLimitFromContext returns the limit and whether it was explicitly set in context.
 func responseLimitFromContext(ctx context.Context) (int64, bool) {
-	v, ok := ctx.Value(responseLimitContextKey{}).(responseLimitContextValue)
-	return v.limit, ok
+	v, ok := ctx.Value(responseLimitContextKey{}).(*int64)
+	if !ok || v == nil {
+		return 0, false
+	}
+	return *v, true
 }
 
 // ResponseLimitMiddleware creates a middleware that limits the size of the response body.
@@ -70,6 +67,7 @@ func ResponseLimitMiddleware(limit int64) Middleware {
 			if res != nil && res.StatusCode != http.StatusSwitchingProtocols {
 				res.Body = &responseLimitBody{
 					ReadCloser: MaxBytesReader(res.Body, effectiveLimit),
+					ctx:        req.Context(),
 					limit:      effectiveLimit,
 					dsUID:      dsUID,
 					dsName:     dsName,
@@ -85,15 +83,17 @@ func resolveResponseLimit(limit int64) int64 {
 	if limit > 0 {
 		return limit
 	}
+	// GF_RESPONSE_LIMIT is read once at client construction time. Changes to the env var
+	// after the client is built will not take effect until the client is recreated.
 	if v, err := strconv.ParseInt(os.Getenv(responseLimitEnvVar), 10, 64); err == nil && v > 0 {
 		return v
 	}
-	return defaultResponseLimit
+	return 0
 }
 
-// responseLimitBody wraps MaxBytesReader to log when the response limit is exceeded.
 type responseLimitBody struct {
 	io.ReadCloser
+	ctx    context.Context
 	limit  int64
 	dsUID  string
 	dsName string
@@ -104,7 +104,7 @@ func (b *responseLimitBody) Read(p []byte) (int, error) {
 	n, err := b.ReadCloser.Read(p)
 	if err != nil && errors.Is(err, ErrResponseBodyTooLarge) {
 		b.once.Do(func() {
-			log.DefaultLogger.Warn("downstream response body exceeded limit",
+			log.DefaultLogger.FromContext(b.ctx).Warn("downstream response body exceeded limit",
 				"datasource_uid", b.dsUID,
 				"datasource_name", b.dsName,
 				"limit_bytes", b.limit,

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -22,16 +22,22 @@ const (
 
 type responseLimitContextKey struct{}
 
+type responseLimitContextValue struct {
+	limit int64
+}
+
 // WithResponseLimitContext stores a response limit in the context, to be picked up by
 // ResponseLimitMiddleware on each request. The backend package calls this from
 // WithGrafanaConfig so that GrafanaCfg.ResponseLimit() takes priority over the env var.
+// A limit of 0 explicitly disables limiting for the request.
 func WithResponseLimitContext(ctx context.Context, limit int64) context.Context {
-	return context.WithValue(ctx, responseLimitContextKey{}, limit)
+	return context.WithValue(ctx, responseLimitContextKey{}, responseLimitContextValue{limit})
 }
 
-func responseLimitFromContext(ctx context.Context) int64 {
-	v, _ := ctx.Value(responseLimitContextKey{}).(int64)
-	return v
+// responseLimitFromContext returns the limit and whether it was explicitly set in context.
+func responseLimitFromContext(ctx context.Context) (int64, bool) {
+	v, ok := ctx.Value(responseLimitContextKey{}).(responseLimitContextValue)
+	return v.limit, ok
 }
 
 // ResponseLimitMiddleware creates a middleware that limits the size of the response body.
@@ -48,13 +54,17 @@ func ResponseLimitMiddleware(limit int64) Middleware {
 
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			effectiveLimit := fallbackLimit
-			if ctxLimit := responseLimitFromContext(req.Context()); ctxLimit > 0 {
+			if ctxLimit, ok := responseLimitFromContext(req.Context()); ok {
 				effectiveLimit = ctxLimit
 			}
 
 			res, err := next.RoundTrip(req)
 			if err != nil {
 				return nil, err
+			}
+
+			if effectiveLimit <= 0 {
+				return res, nil
 			}
 
 			if res != nil && res.StatusCode != http.StatusSwitchingProtocols {

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -150,13 +150,13 @@ func TestResponseLimitMiddlewareContextPriority(t *testing.T) {
 		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
 	})
 
-	t.Run("env var takes priority over context limit", func(t *testing.T) {
-		t.Setenv(responseLimitEnvVar, "3")
+	t.Run("context limit takes priority over env var", func(t *testing.T) {
+		t.Setenv(responseLimitEnvVar, "1000000")
 
-		// context limit would allow the body; env var is tighter and wins
+		// env var would allow the body; context limit is tighter and wins
 		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
 
-		ctx := WithResponseLimitContext(context.Background(), 1000000)
+		ctx := WithResponseLimitContext(context.Background(), 3)
 		res, err := rt.RoundTrip(newRequestWithContext(t, ctx))
 		require.NoError(t, err)
 
@@ -164,7 +164,9 @@ func TestResponseLimitMiddlewareContextPriority(t *testing.T) {
 		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
 	})
 
-	t.Run("context limit 0 disables limiting when env var is unset", func(t *testing.T) {
+	t.Run("context limit 0 disables limiting even when env var is set", func(t *testing.T) {
+		t.Setenv(responseLimitEnvVar, "3")
+
 		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
 
 		ctx := WithResponseLimitContext(context.Background(), 0)
@@ -315,11 +317,11 @@ func TestResolveResponseLimit(t *testing.T) {
 		ctxLimit *int64
 		expected int64
 	}{
-		{name: "env var wins over context and limit arg", envLimit: 100, limit: 999, ctxLimit: ptr(int64(999)), expected: 100},
-		{name: "env var wins over context limit", envLimit: 100, ctxLimit: ptr(int64(999)), expected: 100},
+		{name: "context wins over env var and limit arg", envLimit: 100, limit: 999, ctxLimit: ptr(int64(50)), expected: 50},
+		{name: "context wins over env var", envLimit: 100, ctxLimit: ptr(int64(50)), expected: 50},
 		{name: "env var wins over limit arg", envLimit: 100, limit: 999, expected: 100},
-		{name: "context used when env var unset", limit: 999, ctxLimit: ptr(int64(50)), expected: 50},
-		{name: "context 0 disables when env var unset", ctxLimit: ptr(int64(0)), expected: 0},
+		{name: "context used when env var set", envLimit: 100, limit: 999, ctxLimit: ptr(int64(50)), expected: 50},
+		{name: "context 0 disables even when env var is set", envLimit: 100, ctxLimit: ptr(int64(0)), expected: 0},
 		{name: "limit arg used when env var and context unset", limit: 500, expected: 500},
 		{name: "no limit when all unset", expected: 0},
 	}

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -21,7 +21,6 @@ func TestResponseLimitMiddleware(t *testing.T) {
 	}{
 		{limit: 1, expectedBodyLength: 1, expectedBody: "d", err: errors.New("error: http: response body too large, response limit is set to: 1")},
 		{limit: 1000000, expectedBodyLength: 5, expectedBody: "dummy", err: nil},
-		{limit: 0, expectedBodyLength: 5, expectedBody: "dummy", err: nil},
 	}
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("Test ResponseLimitMiddleware with limit: %d", tc.limit), func(t *testing.T) {
@@ -55,4 +54,61 @@ func TestResponseLimitMiddleware(t *testing.T) {
 			require.Equal(t, string(bodyBytes), tc.expectedBody)
 		})
 	}
+}
+
+func TestResponseLimitMiddlewareFallback(t *testing.T) {
+	t.Run("uses env var when limit is 0", func(t *testing.T) {
+		t.Setenv(responseLimitEnvVar, "3")
+
+		finalRoundTripper := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
+		})
+
+		mw := ResponseLimitMiddleware(0)
+		rt := mw.CreateMiddleware(Options{}, finalRoundTripper)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com/query", nil)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(res.Body)
+		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	})
+
+	t.Run("uses 200MB default when limit is 0 and env var is not set", func(t *testing.T) {
+		finalRoundTripper := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
+		})
+
+		mw := ResponseLimitMiddleware(0)
+		rt := mw.CreateMiddleware(Options{}, finalRoundTripper)
+		require.Equal(t, int64(defaultResponseLimit), resolveResponseLimit(0))
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com/query", nil)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		bodyBytes, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "dummy", string(bodyBytes))
+	})
+
+	t.Run("explicit limit takes priority over env var", func(t *testing.T) {
+		t.Setenv(responseLimitEnvVar, "1000000")
+
+		finalRoundTripper := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
+		})
+
+		mw := ResponseLimitMiddleware(3)
+		rt := mw.CreateMiddleware(Options{}, finalRoundTripper)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com/query", nil)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(res.Body)
+		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	})
 }

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -106,8 +106,6 @@ func TestResponseLimitMiddlewareFallback(t *testing.T) {
 	})
 
 	t.Run("no limit when limit arg is 0 and env var is unset", func(t *testing.T) {
-		require.Equal(t, int64(0), resolveResponseLimit(0))
-
 		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
 		res, err := rt.RoundTrip(newRequest(t))
 		require.NoError(t, err)
@@ -117,9 +115,19 @@ func TestResponseLimitMiddlewareFallback(t *testing.T) {
 		require.Equal(t, "dummy", string(bodyBytes))
 	})
 
-	t.Run("explicit limit arg takes priority over env var", func(t *testing.T) {
-		t.Setenv(responseLimitEnvVar, "1000000")
+	t.Run("env var takes priority over explicit limit arg", func(t *testing.T) {
+		t.Setenv(responseLimitEnvVar, "3")
 
+		// limit arg would allow the body; env var is tighter and wins
+		rt := ResponseLimitMiddleware(1000000).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+		res, err := rt.RoundTrip(newRequest(t))
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(res.Body)
+		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	})
+
+	t.Run("explicit limit arg used when env var is unset", func(t *testing.T) {
 		rt := ResponseLimitMiddleware(3).CreateMiddleware(Options{}, newRoundTripper("dummy"))
 		res, err := rt.RoundTrip(newRequest(t))
 		require.NoError(t, err)
@@ -142,12 +150,13 @@ func TestResponseLimitMiddlewareContextPriority(t *testing.T) {
 		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
 	})
 
-	t.Run("context limit overrides env var", func(t *testing.T) {
-		t.Setenv(responseLimitEnvVar, "1000000")
+	t.Run("env var takes priority over context limit", func(t *testing.T) {
+		t.Setenv(responseLimitEnvVar, "3")
 
+		// context limit would allow the body; env var is tighter and wins
 		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
 
-		ctx := WithResponseLimitContext(context.Background(), 3)
+		ctx := WithResponseLimitContext(context.Background(), 1000000)
 		res, err := rt.RoundTrip(newRequestWithContext(t, ctx))
 		require.NoError(t, err)
 
@@ -155,21 +164,7 @@ func TestResponseLimitMiddlewareContextPriority(t *testing.T) {
 		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
 	})
 
-	t.Run("context limit 0 disables limiting", func(t *testing.T) {
-		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
-
-		ctx := WithResponseLimitContext(context.Background(), 0)
-		res, err := rt.RoundTrip(newRequestWithContext(t, ctx))
-		require.NoError(t, err)
-
-		bodyBytes, err := io.ReadAll(res.Body)
-		require.NoError(t, err)
-		require.Equal(t, "dummy", string(bodyBytes))
-	})
-
-	t.Run("context limit 0 disables limiting even when env var is set", func(t *testing.T) {
-		t.Setenv(responseLimitEnvVar, "3")
-
+	t.Run("context limit 0 disables limiting when env var is unset", func(t *testing.T) {
 		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
 
 		ctx := WithResponseLimitContext(context.Background(), 0)
@@ -290,30 +285,56 @@ func TestResponseLimitMiddlewareStatusCodes(t *testing.T) {
 	})
 }
 
-func TestResolveResponseLimit(t *testing.T) {
+func TestParseEnvResponseLimit(t *testing.T) {
 	tcs := []struct {
 		name     string
-		limit    int64
 		envVar   string
 		expected int64
 	}{
-		{name: "explicit limit used when positive", limit: 500, expected: 500},
-		{name: "env var used when limit is 0", limit: 0, envVar: "1024", expected: 1024},
-		{name: "no limit when limit is 0 and env var unset", limit: 0, expected: 0},
-		{name: "no limit when env var is invalid", limit: 0, envVar: "notanumber", expected: 0},
-		{name: "no limit when env var is 0", limit: 0, envVar: "0", expected: 0},
-		{name: "no limit when env var is negative", limit: 0, envVar: "-1", expected: 0},
-		{name: "explicit limit used even when env var is set", limit: 100, envVar: "9999", expected: 100},
+		{name: "parses valid positive value", envVar: "1024", expected: 1024},
+		{name: "returns 0 when unset", expected: 0},
+		{name: "returns 0 for invalid value", envVar: "notanumber", expected: 0},
+		{name: "returns 0 when env var is 0", envVar: "0", expected: 0},
+		{name: "returns 0 when env var is negative", envVar: "-1", expected: 0},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.envVar != "" {
 				t.Setenv(responseLimitEnvVar, tc.envVar)
 			}
-			require.Equal(t, tc.expected, resolveResponseLimit(tc.limit))
+			require.Equal(t, tc.expected, parseEnvResponseLimit())
 		})
 	}
 }
+
+func TestResolveResponseLimit(t *testing.T) {
+	tcs := []struct {
+		name     string
+		envLimit int64
+		limit    int64
+		ctxLimit *int64
+		expected int64
+	}{
+		{name: "env var wins over context and limit arg", envLimit: 100, limit: 999, ctxLimit: ptr(int64(999)), expected: 100},
+		{name: "env var wins over context limit", envLimit: 100, ctxLimit: ptr(int64(999)), expected: 100},
+		{name: "env var wins over limit arg", envLimit: 100, limit: 999, expected: 100},
+		{name: "context used when env var unset", limit: 999, ctxLimit: ptr(int64(50)), expected: 50},
+		{name: "context 0 disables when env var unset", ctxLimit: ptr(int64(0)), expected: 0},
+		{name: "limit arg used when env var and context unset", limit: 500, expected: 500},
+		{name: "no limit when all unset", expected: 0},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.ctxLimit != nil {
+				ctx = WithResponseLimitContext(ctx, *tc.ctxLimit)
+			}
+			require.Equal(t, tc.expected, resolveResponseLimit(tc.envLimit, tc.limit, ctx))
+		})
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
 
 func TestResponseLimitMiddlewareErrors(t *testing.T) {
 	t.Run("propagates round trip error without wrapping body", func(t *testing.T) {

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -94,17 +94,6 @@ func TestResponseLimitMiddleware(t *testing.T) {
 }
 
 func TestResponseLimitMiddlewareFallback(t *testing.T) {
-	t.Run("uses env var when limit arg is 0", func(t *testing.T) {
-		t.Setenv(responseLimitEnvVar, "3")
-
-		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
-		res, err := rt.RoundTrip(newRequest(t))
-		require.NoError(t, err)
-
-		_, err = io.ReadAll(res.Body)
-		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
-	})
-
 	t.Run("no limit when limit arg is 0 and env var is unset", func(t *testing.T) {
 		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
 		res, err := rt.RoundTrip(newRequest(t))
@@ -277,14 +266,6 @@ func TestResponseLimitMiddlewareStatusCodes(t *testing.T) {
 		require.Equal(t, "dummy", string(bodyBytes))
 	})
 
-	t.Run("wraps body for normal 200 response", func(t *testing.T) {
-		rt := ResponseLimitMiddleware(3).CreateMiddleware(Options{}, newRoundTripper("dummy"))
-		res, err := rt.RoundTrip(newRequest(t))
-		require.NoError(t, err)
-
-		_, err = io.ReadAll(res.Body)
-		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
-	})
 }
 
 func TestParseEnvResponseLimit(t *testing.T) {
@@ -318,10 +299,8 @@ func TestResolveResponseLimit(t *testing.T) {
 		expected int64
 	}{
 		{name: "context wins over env var and limit arg", envLimit: 100, limit: 999, ctxLimit: ptr(int64(50)), expected: 50},
-		{name: "context wins over env var", envLimit: 100, ctxLimit: ptr(int64(50)), expected: 50},
-		{name: "env var wins over limit arg", envLimit: 100, limit: 999, expected: 100},
-		{name: "context used when env var set", envLimit: 100, limit: 999, ctxLimit: ptr(int64(50)), expected: 50},
 		{name: "context 0 disables even when env var is set", envLimit: 100, ctxLimit: ptr(int64(0)), expected: 0},
+		{name: "env var wins over limit arg", envLimit: 100, limit: 999, expected: 100},
 		{name: "limit arg used when env var and context unset", limit: 500, expected: 500},
 		{name: "no limit when all unset", expected: 0},
 	}

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -9,84 +9,103 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// mockLogger captures Warn calls for assertion in tests.
+type mockLogger struct {
+	log.Logger
+	warns []mockLogCall
+}
+
+type mockLogCall struct {
+	msg  string
+	args []interface{}
+}
+
+func (m *mockLogger) Warn(msg string, args ...interface{}) {
+	m.warns = append(m.warns, mockLogCall{msg, args})
+}
+
+func newRoundTripper(body string) http.RoundTripper {
+	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Request:    req,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	})
+}
+
+func newRequest(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com/query", nil)
+	require.NoError(t, err)
+	return req
+}
+
+func newRequestWithContext(t *testing.T, ctx context.Context) *http.Request {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.com/query", nil)
+	require.NoError(t, err)
+	return req
+}
 
 func TestResponseLimitMiddleware(t *testing.T) {
 	tcs := []struct {
 		limit              int64
 		expectedBodyLength int
 		expectedBody       string
-		err                error
+		expectErr          bool
 	}{
-		{limit: 1, expectedBodyLength: 1, expectedBody: "d", err: errors.New("error: http: response body too large, response limit is set to: 1")},
-		{limit: 1000000, expectedBodyLength: 5, expectedBody: "dummy", err: nil},
+		{limit: 1, expectedBodyLength: 1, expectedBody: "d", expectErr: true},
+		{limit: 1000000, expectedBodyLength: 5, expectedBody: "dummy", expectErr: false},
 	}
 	for _, tc := range tcs {
-		t.Run(fmt.Sprintf("Test ResponseLimitMiddleware with limit: %d", tc.limit), func(t *testing.T) {
-			finalRoundTripper := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
-			})
-
+		t.Run(fmt.Sprintf("limit %d", tc.limit), func(t *testing.T) {
 			mw := ResponseLimitMiddleware(tc.limit)
-			rt := mw.CreateMiddleware(Options{}, finalRoundTripper)
-			require.NotNil(t, rt)
+			rt := mw.CreateMiddleware(Options{}, newRoundTripper("dummy"))
+
 			middlewareName, ok := mw.(MiddlewareName)
 			require.True(t, ok)
 			require.Equal(t, ResponseLimitMiddlewareName, middlewareName.MiddlewareName())
 
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com/query", nil)
+			res, err := rt.RoundTrip(newRequest(t))
 			require.NoError(t, err)
-			res, err := rt.RoundTrip(req)
-			require.NoError(t, err)
-			require.NotNil(t, res)
-			require.NotNil(t, res.Body)
 
 			bodyBytes, err := io.ReadAll(res.Body)
-			if err != nil {
-				require.EqualError(t, tc.err, err.Error())
-			} else {
-				require.NoError(t, tc.err)
-			}
 			require.NoError(t, res.Body.Close())
 
+			if tc.expectErr {
+				require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+			} else {
+				require.NoError(t, err)
+			}
 			require.Len(t, bodyBytes, tc.expectedBodyLength)
-			require.Equal(t, string(bodyBytes), tc.expectedBody)
+			require.Equal(t, tc.expectedBody, string(bodyBytes))
 		})
 	}
 }
 
 func TestResponseLimitMiddlewareFallback(t *testing.T) {
-	t.Run("uses env var when limit is 0", func(t *testing.T) {
+	t.Run("uses env var when limit arg is 0", func(t *testing.T) {
 		t.Setenv(responseLimitEnvVar, "3")
 
-		finalRoundTripper := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
-		})
-
-		mw := ResponseLimitMiddleware(0)
-		rt := mw.CreateMiddleware(Options{}, finalRoundTripper)
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com/query", nil)
-		require.NoError(t, err)
-		res, err := rt.RoundTrip(req)
+		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+		res, err := rt.RoundTrip(newRequest(t))
 		require.NoError(t, err)
 
 		_, err = io.ReadAll(res.Body)
 		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
 	})
 
-	t.Run("uses 200MB default when limit is 0 and env var is not set", func(t *testing.T) {
-		finalRoundTripper := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
-		})
-
-		mw := ResponseLimitMiddleware(0)
-		rt := mw.CreateMiddleware(Options{}, finalRoundTripper)
+	t.Run("uses 200MB default when limit arg is 0 and env var is unset", func(t *testing.T) {
 		require.Equal(t, int64(defaultResponseLimit), resolveResponseLimit(0))
 
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com/query", nil)
-		require.NoError(t, err)
-		res, err := rt.RoundTrip(req)
+		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+		res, err := rt.RoundTrip(newRequest(t))
 		require.NoError(t, err)
 
 		bodyBytes, err := io.ReadAll(res.Body)
@@ -94,21 +113,213 @@ func TestResponseLimitMiddlewareFallback(t *testing.T) {
 		require.Equal(t, "dummy", string(bodyBytes))
 	})
 
-	t.Run("explicit limit takes priority over env var", func(t *testing.T) {
+	t.Run("explicit limit arg takes priority over env var", func(t *testing.T) {
 		t.Setenv(responseLimitEnvVar, "1000000")
 
-		finalRoundTripper := RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
-		})
-
-		mw := ResponseLimitMiddleware(3)
-		rt := mw.CreateMiddleware(Options{}, finalRoundTripper)
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://test.com/query", nil)
-		require.NoError(t, err)
-		res, err := rt.RoundTrip(req)
+		rt := ResponseLimitMiddleware(3).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+		res, err := rt.RoundTrip(newRequest(t))
 		require.NoError(t, err)
 
 		_, err = io.ReadAll(res.Body)
 		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	})
+}
+
+func TestResponseLimitMiddlewareContextPriority(t *testing.T) {
+	t.Run("context limit overrides explicit limit arg", func(t *testing.T) {
+		// explicit limit would allow the body; context limit is tighter
+		rt := ResponseLimitMiddleware(1000000).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+
+		ctx := WithResponseLimitContext(context.Background(), 3)
+		res, err := rt.RoundTrip(newRequestWithContext(t, ctx))
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(res.Body)
+		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	})
+
+	t.Run("context limit overrides env var", func(t *testing.T) {
+		t.Setenv(responseLimitEnvVar, "1000000")
+
+		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+
+		ctx := WithResponseLimitContext(context.Background(), 3)
+		res, err := rt.RoundTrip(newRequestWithContext(t, ctx))
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(res.Body)
+		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	})
+
+	t.Run("context limit 0 disables limiting even with 200MB fallback", func(t *testing.T) {
+		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+
+		ctx := WithResponseLimitContext(context.Background(), 0)
+		res, err := rt.RoundTrip(newRequestWithContext(t, ctx))
+		require.NoError(t, err)
+
+		bodyBytes, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "dummy", string(bodyBytes))
+	})
+
+	t.Run("context limit 0 disables limiting even when env var is set", func(t *testing.T) {
+		t.Setenv(responseLimitEnvVar, "3")
+
+		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+
+		ctx := WithResponseLimitContext(context.Background(), 0)
+		res, err := rt.RoundTrip(newRequestWithContext(t, ctx))
+		require.NoError(t, err)
+
+		bodyBytes, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "dummy", string(bodyBytes))
+	})
+}
+
+func TestResponseLimitMiddlewareLogging(t *testing.T) {
+	t.Run("logs warning with datasource labels when limit exceeded", func(t *testing.T) {
+		logger := &mockLogger{}
+		log.DefaultLogger = logger
+		t.Cleanup(func() { log.DefaultLogger = log.New() })
+
+		opts := Options{
+			Labels: map[string]string{
+				"datasource_uid":  "abc-123",
+				"datasource_name": "My DS",
+			},
+		}
+		rt := ResponseLimitMiddleware(3).CreateMiddleware(opts, newRoundTripper("dummy"))
+		res, err := rt.RoundTrip(newRequest(t))
+		require.NoError(t, err)
+
+		_, _ = io.ReadAll(res.Body)
+
+		require.Len(t, logger.warns, 1)
+		call := logger.warns[0]
+		assert.Equal(t, "downstream response body exceeded limit", call.msg)
+		assert.Contains(t, call.args, "datasource_uid")
+		assert.Contains(t, call.args, "abc-123")
+		assert.Contains(t, call.args, "datasource_name")
+		assert.Contains(t, call.args, "My DS")
+		assert.Contains(t, call.args, "limit_bytes")
+		assert.Contains(t, call.args, int64(3))
+	})
+
+	t.Run("logs only once across multiple reads", func(t *testing.T) {
+		logger := &mockLogger{}
+		log.DefaultLogger = logger
+		t.Cleanup(func() { log.DefaultLogger = log.New() })
+
+		rt := ResponseLimitMiddleware(3).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+		res, err := rt.RoundTrip(newRequest(t))
+		require.NoError(t, err)
+
+		// read until we hit the limit, then keep reading
+		buf := make([]byte, 1)
+		for i := 0; i < 10; i++ {
+			_, _ = res.Body.Read(buf)
+		}
+
+		require.Len(t, logger.warns, 1)
+	})
+
+	t.Run("does not log when body is within limit", func(t *testing.T) {
+		logger := &mockLogger{}
+		log.DefaultLogger = logger
+		t.Cleanup(func() { log.DefaultLogger = log.New() })
+
+		rt := ResponseLimitMiddleware(1000000).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+		res, err := rt.RoundTrip(newRequest(t))
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Empty(t, logger.warns)
+	})
+
+	t.Run("does not log when limiting is disabled via context", func(t *testing.T) {
+		logger := &mockLogger{}
+		log.DefaultLogger = logger
+		t.Cleanup(func() { log.DefaultLogger = log.New() })
+
+		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+
+		ctx := WithResponseLimitContext(context.Background(), 0)
+		res, err := rt.RoundTrip(newRequestWithContext(t, ctx))
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Empty(t, logger.warns)
+	})
+}
+
+func TestResponseLimitMiddlewareStatusCodes(t *testing.T) {
+	t.Run("does not wrap body for 101 Switching Protocols", func(t *testing.T) {
+		rt := ResponseLimitMiddleware(1).CreateMiddleware(Options{}, RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusSwitchingProtocols,
+				Request:    req,
+				Body:       io.NopCloser(strings.NewReader("dummy")),
+			}, nil
+		}))
+
+		res, err := rt.RoundTrip(newRequest(t))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusSwitchingProtocols, res.StatusCode)
+
+		// body should not be wrapped — no limit error despite limit=1
+		bodyBytes, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "dummy", string(bodyBytes))
+	})
+
+	t.Run("wraps body for normal 200 response", func(t *testing.T) {
+		rt := ResponseLimitMiddleware(3).CreateMiddleware(Options{}, newRoundTripper("dummy"))
+		res, err := rt.RoundTrip(newRequest(t))
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(res.Body)
+		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	})
+}
+
+func TestResolveResponseLimit(t *testing.T) {
+	tcs := []struct {
+		name     string
+		limit    int64
+		envVar   string
+		expected int64
+	}{
+		{name: "explicit limit used when positive", limit: 500, expected: 500},
+		{name: "env var used when limit is 0", limit: 0, envVar: "1024", expected: 1024},
+		{name: "default used when limit is 0 and env var unset", limit: 0, expected: defaultResponseLimit},
+		{name: "default used when env var is invalid", limit: 0, envVar: "notanumber", expected: defaultResponseLimit},
+		{name: "default used when env var is 0", limit: 0, envVar: "0", expected: defaultResponseLimit},
+		{name: "default used when env var is negative", limit: 0, envVar: "-1", expected: defaultResponseLimit},
+		{name: "explicit limit used even when env var is set", limit: 100, envVar: "9999", expected: 100},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envVar != "" {
+				t.Setenv(responseLimitEnvVar, tc.envVar)
+			}
+			require.Equal(t, tc.expected, resolveResponseLimit(tc.limit))
+		})
+	}
+}
+
+func TestResponseLimitMiddlewareErrors(t *testing.T) {
+	t.Run("propagates round trip error without wrapping body", func(t *testing.T) {
+		expectedErr := errors.New("connection refused")
+		rt := ResponseLimitMiddleware(100).CreateMiddleware(Options{}, RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, expectedErr
+		}))
+
+		res, err := rt.RoundTrip(newRequest(t))
+		require.ErrorIs(t, err, expectedErr)
+		require.Nil(t, res)
 	})
 }

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -29,6 +29,10 @@ func (m *mockLogger) Warn(msg string, args ...interface{}) {
 	m.warns = append(m.warns, mockLogCall{msg, args})
 }
 
+func (m *mockLogger) FromContext(_ context.Context) log.Logger {
+	return m
+}
+
 func newRoundTripper(body string) http.RoundTripper {
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -101,8 +105,8 @@ func TestResponseLimitMiddlewareFallback(t *testing.T) {
 		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
 	})
 
-	t.Run("uses 200MB default when limit arg is 0 and env var is unset", func(t *testing.T) {
-		require.Equal(t, int64(defaultResponseLimit), resolveResponseLimit(0))
+	t.Run("no limit when limit arg is 0 and env var is unset", func(t *testing.T) {
+		require.Equal(t, int64(0), resolveResponseLimit(0))
 
 		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
 		res, err := rt.RoundTrip(newRequest(t))
@@ -151,7 +155,7 @@ func TestResponseLimitMiddlewareContextPriority(t *testing.T) {
 		require.ErrorIs(t, err, ErrResponseBodyTooLarge)
 	})
 
-	t.Run("context limit 0 disables limiting even with 200MB fallback", func(t *testing.T) {
+	t.Run("context limit 0 disables limiting", func(t *testing.T) {
 		rt := ResponseLimitMiddleware(0).CreateMiddleware(Options{}, newRoundTripper("dummy"))
 
 		ctx := WithResponseLimitContext(context.Background(), 0)
@@ -295,10 +299,10 @@ func TestResolveResponseLimit(t *testing.T) {
 	}{
 		{name: "explicit limit used when positive", limit: 500, expected: 500},
 		{name: "env var used when limit is 0", limit: 0, envVar: "1024", expected: 1024},
-		{name: "default used when limit is 0 and env var unset", limit: 0, expected: defaultResponseLimit},
-		{name: "default used when env var is invalid", limit: 0, envVar: "notanumber", expected: defaultResponseLimit},
-		{name: "default used when env var is 0", limit: 0, envVar: "0", expected: defaultResponseLimit},
-		{name: "default used when env var is negative", limit: 0, envVar: "-1", expected: defaultResponseLimit},
+		{name: "no limit when limit is 0 and env var unset", limit: 0, expected: 0},
+		{name: "no limit when env var is invalid", limit: 0, envVar: "notanumber", expected: 0},
+		{name: "no limit when env var is 0", limit: 0, envVar: "0", expected: 0},
+		{name: "no limit when env var is negative", limit: 0, envVar: "-1", expected: 0},
 		{name: "explicit limit used even when env var is set", limit: 100, envVar: "9999", expected: 100},
 	}
 	for _, tc := range tcs {


### PR DESCRIPTION
Round 2 on [this pr](https://github.com/grafana/grafana-plugin-sdk-go/pull/1283)

Basically we want to add a default response size to all datasource downstream http clients. We want to control this with a sane default so oss and cloud can enjoy the stability. The environment variable in my mind are mostly for cloud datasource pods so we can adjust on a datasource basis if we need to.

Right now we have limits but it uses the config_ini 

```
[dataproxy]
response_limit = 1000000
``` 

so to roll this out to all customers and datasources as it currently stands we would need to add the default there. 

We also log when we go over so we can find these issues easier.

Limit resolution uses a priority chain per-request: 
- GrafanaCfg.ResponseLimit() (highest) → (what is set on the dataproxy already, follows existing behaviour)
- GF_RESPONSE_LIMIT env var (so we can roll it out)
- Setting the limit to 0 via context explicitly disables limiting 

