### PR TITLE
feat(backend): observe gRPC response sizes via unary interceptor

### DIFF
--- a/backend/grpc_response_size.go
+++ b/backend/grpc_response_size.go
@@ -1,0 +1,73 @@
+package backend
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	grpcRespSizeKB = 1024
+	grpcRespSizeMB = grpcRespSizeKB * grpcRespSizeKB
+	grpcRespSizeGB = grpcRespSizeMB * grpcRespSizeKB
+)
+
+var grpcResponseSizeHistogram = promauto.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Namespace: "plugins",
+		Name:      "grpc_response_size_bytes",
+		Help:      "Histogram of plugin gRPC response message sizes (uncompressed protobuf bytes) sent from the plugin to Grafana.",
+		Buckets: []float64{
+			128, 256, 512,
+			1 * grpcRespSizeKB, 2 * grpcRespSizeKB, 4 * grpcRespSizeKB, 8 * grpcRespSizeKB,
+			16 * grpcRespSizeKB, 32 * grpcRespSizeKB, 64 * grpcRespSizeKB, 128 * grpcRespSizeKB,
+			256 * grpcRespSizeKB, 512 * grpcRespSizeKB,
+			1 * grpcRespSizeMB, 2 * grpcRespSizeMB, 4 * grpcRespSizeMB, 8 * grpcRespSizeMB,
+			16 * grpcRespSizeMB, 32 * grpcRespSizeMB, 64 * grpcRespSizeMB, 128 * grpcRespSizeMB,
+			256 * grpcRespSizeMB, 512 * grpcRespSizeMB,
+			1 * grpcRespSizeGB, 2 * grpcRespSizeGB, 4 * grpcRespSizeGB, 8 * grpcRespSizeGB,
+		},
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: time.Hour,
+	},
+	[]string{"grpc_service", "grpc_method"},
+)
+
+// grpcResponseSizeInterceptor returns a unary server interceptor that
+// observes the uncompressed protobuf size of every gRPC response sent
+// from the plugin. Responses are only observed on successful handler
+// returns; error responses are skipped.
+func grpcResponseSizeInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		resp, err := handler(ctx, req)
+		if err != nil || resp == nil {
+			return resp, err
+		}
+		msg, ok := resp.(proto.Message)
+		if !ok {
+			return resp, err
+		}
+		service, method := splitGRPCFullMethod(info.FullMethod)
+		grpcResponseSizeHistogram.
+			WithLabelValues(service, method).
+			Observe(float64(proto.Size(msg)))
+		return resp, err
+	}
+}
+
+// splitGRPCFullMethod parses grpc.UnaryServerInfo.FullMethod ("/service/method")
+// into its service and method components. Falls back to empty strings on
+// unexpected formats rather than failing observation.
+func splitGRPCFullMethod(full string) (service, method string) {
+	s := strings.TrimPrefix(full, "/")
+	if svc, m, ok := strings.Cut(s, "/"); ok {
+		return svc, m
+	}
+	return "", s
+}

--- a/backend/grpc_response_size_test.go
+++ b/backend/grpc_response_size_test.go
@@ -1,0 +1,120 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2"
+)
+
+func TestSplitGRPCFullMethod(t *testing.T) {
+	tcs := []struct {
+		in             string
+		wantService    string
+		wantMethod     string
+	}{
+		{"/pluginv2.Data/QueryData", "pluginv2.Data", "QueryData"},
+		{"/pluginv2.Resource/CallResource", "pluginv2.Resource", "CallResource"},
+		{"/pluginv2.Diagnostics/CheckHealth", "pluginv2.Diagnostics", "CheckHealth"},
+		{"", "", ""},
+		{"bogus", "", "bogus"},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.in, func(t *testing.T) {
+			svc, m := splitGRPCFullMethod(tc.in)
+			require.Equal(t, tc.wantService, svc)
+			require.Equal(t, tc.wantMethod, m)
+		})
+	}
+}
+
+func TestGRPCResponseSizeInterceptor(t *testing.T) {
+	interceptor := grpcResponseSizeInterceptor()
+
+	t.Run("observes size of successful proto response", func(t *testing.T) {
+		const service, method = "pluginv2.Diagnostics", "CheckHealth"
+		resp := &pluginv2.CheckHealthResponse{
+			Status:  pluginv2.CheckHealthResponse_OK,
+			Message: "healthy-ish",
+		}
+		expectedSize := float64(proto.Size(resp))
+
+		before := sampleCount(t, service, method)
+		_, err := interceptor(context.Background(), nil,
+			&grpc.UnaryServerInfo{FullMethod: "/" + service + "/" + method},
+			func(_ context.Context, _ any) (any, error) { return resp, nil },
+		)
+		require.NoError(t, err)
+
+		got := latestSample(t, service, method)
+		require.Equal(t, before+1, got.count, "exactly one new observation")
+		require.Equal(t, expectedSize, got.sumDelta, "observed value matches proto.Size")
+	})
+
+	t.Run("skips observation when handler returns error", func(t *testing.T) {
+		const service, method = "pluginv2.Data", "QueryData"
+		before := sampleCount(t, service, method)
+		_, err := interceptor(context.Background(), nil,
+			&grpc.UnaryServerInfo{FullMethod: "/" + service + "/" + method},
+			func(_ context.Context, _ any) (any, error) {
+				return &pluginv2.QueryDataResponse{}, errors.New("boom")
+			},
+		)
+		require.Error(t, err)
+		require.Equal(t, before, sampleCount(t, service, method))
+	})
+
+	t.Run("skips observation on nil response", func(t *testing.T) {
+		const service, method = "pluginv2.Resource", "CallResource"
+		before := sampleCount(t, service, method)
+		_, err := interceptor(context.Background(), nil,
+			&grpc.UnaryServerInfo{FullMethod: "/" + service + "/" + method},
+			func(_ context.Context, _ any) (any, error) { return nil, nil },
+		)
+		require.NoError(t, err)
+		require.Equal(t, before, sampleCount(t, service, method))
+	})
+
+	t.Run("skips observation on non-proto response", func(t *testing.T) {
+		const service, method = "test.Svc", "NonProto"
+		before := sampleCount(t, service, method)
+		_, err := interceptor(context.Background(), nil,
+			&grpc.UnaryServerInfo{FullMethod: "/" + service + "/" + method},
+			func(_ context.Context, _ any) (any, error) { return "not a proto.Message", nil },
+		)
+		require.NoError(t, err)
+		require.Equal(t, before, sampleCount(t, service, method))
+	})
+}
+
+type histSample struct {
+	count    uint64
+	sumDelta float64
+}
+
+func histogramDTO(t *testing.T, service, method string) *dto.Histogram {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 1)
+	grpcResponseSizeHistogram.WithLabelValues(service, method).(prometheus.Histogram).Collect(ch)
+	close(ch)
+	m := <-ch
+	var pb dto.Metric
+	require.NoError(t, m.Write(&pb))
+	return pb.GetHistogram()
+}
+
+func sampleCount(t *testing.T, service, method string) uint64 {
+	return histogramDTO(t, service, method).GetSampleCount()
+}
+
+func latestSample(t *testing.T, service, method string) histSample {
+	h := histogramDTO(t, service, method)
+	return histSample{count: h.GetSampleCount(), sumDelta: h.GetSampleSum()}
+}

--- a/backend/grpc_response_size_test.go
+++ b/backend/grpc_response_size_test.go
@@ -111,10 +111,12 @@ func histogramDTO(t *testing.T, service, method string) *dto.Histogram {
 }
 
 func sampleCount(t *testing.T, service, method string) uint64 {
+	t.Helper()
 	return histogramDTO(t, service, method).GetSampleCount()
 }
 
 func latestSample(t *testing.T, service, method string) histSample {
+	t.Helper()
 	h := histogramDTO(t, service, method)
 	return histSample{count: h.GetSampleCount(), sumDelta: h.GetSampleSum()}
 }

--- a/backend/serve.go
+++ b/backend/serve.go
@@ -157,6 +157,7 @@ func defaultGRPCMiddlewares(opts ServeOpts) []grpc.ServerOption {
 		grpc.ChainUnaryInterceptor(
 			srvMetrics.UnaryServerInterceptor(),
 			recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(handlePanic)),
+			grpcResponseSizeInterceptor(),
 		),
 		grpc.ChainStreamInterceptor(
 			srvMetrics.StreamServerInterceptor(),

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,8 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // @grafana/grafana-app-platform-squad
 )
 
+require github.com/prometheus/client_model v0.6.2
+
 require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
@@ -115,7 +117,6 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.25 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/unknwon/com v1.0.1 // indirect


### PR DESCRIPTION
## Summary

- Adds `plugins_grpc_response_size_bytes`, a Prometheus histogram of uncompressed protobuf response bytes sent from plugins to Grafana, labelled by `grpc_service` and `grpc_method`.
- Implemented as a `grpc.UnaryServerInterceptor` using `proto.Size(msg)` — no re-marshalling, O(n) over the message tree.
- Wired as the **innermost** link in the existing `ChainUnaryInterceptor` (after `srvMetrics` and `recovery`) so it measures the raw handler response before any outer wrapping.
- Error responses, nil responses, and non-proto responses are skipped.
- Streaming methods (e.g. `QueryChunkedData`) are intentionally out of scope — unary only.

## Motivation

Complements the existing `plugins_datasource_response_size_bytes` (HTTP transport) with a gRPC-path equivalent, giving visibility into plugin → Grafana response-size pressure across both transports. Same bucket layout and native-histogram config as the HTTP sibling for consistent dashboards.

## Naming

Chose `plugins_grpc_response_size_bytes` over a `datasource`-prefixed name because the interceptor covers any plugin type (diagnostics, resource, data), not just datasources.