### PR TITLE
feat(sqlutil): observe database rows scanned by FrameFromRows

### DIFF
--- a/data/sqlutil/dynamic_frame.go
+++ b/data/sqlutil/dynamic_frame.go
@@ -29,6 +29,7 @@ func findDataTypes(rows Rows, rowLimit int64, types []*sql.ColumnType) ([]Field,
 	fields := make(map[int]Field)
 
 	var returnData [][]interface{}
+	defer func() { observeRowsScanned(int64(len(returnData))) }()
 
 	for {
 		for rows.Next() {

--- a/data/sqlutil/metrics.go
+++ b/data/sqlutil/metrics.go
@@ -1,0 +1,32 @@
+package sqlutil
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// rowsScannedHistogram observes the number of database rows scanned by
+// FrameFromRows before any frame reshaping (e.g. LongToWide, LongToMulti).
+// This is the driver-side row count, distinct from frame-level row metrics
+// emitted downstream in sqlds.
+var rowsScannedHistogram = promauto.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: "plugins",
+		Name:      "sql_rows_scanned",
+		Help:      "Histogram of database rows scanned by FrameFromRows before any frame reshaping.",
+		Buckets: []float64{
+			1, 10, 100,
+			1_000, 10_000, 100_000,
+			1_000_000, 10_000_000, 100_000_000,
+		},
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: time.Hour,
+	},
+)
+
+func observeRowsScanned(n int64) {
+	rowsScannedHistogram.Observe(float64(n))
+}

--- a/data/sqlutil/metrics_test.go
+++ b/data/sqlutil/metrics_test.go
@@ -1,0 +1,131 @@
+package sqlutil_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+)
+
+const rowsScannedMetric = "plugins_sql_rows_scanned"
+
+func rowsScannedHistogram(t *testing.T) *dto.Histogram {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != rowsScannedMetric {
+			continue
+		}
+		metrics := mf.GetMetric()
+		require.Len(t, metrics, 1, "expected one unlabelled series")
+		return metrics[0].GetHistogram()
+	}
+	t.Fatalf("metric %s not registered", rowsScannedMetric)
+	return nil
+}
+
+type rowsScannedSample struct {
+	count uint64
+	sum   float64
+}
+
+func rowsScannedSampleValues(t *testing.T) rowsScannedSample {
+	t.Helper()
+	h := rowsScannedHistogram(t)
+	return rowsScannedSample{count: h.GetSampleCount(), sum: h.GetSampleSum()}
+}
+
+func TestFrameFromRows_ObservesRowsScanned(t *testing.T) {
+	t.Run("counts rows scanned on successful frame build", func(t *testing.T) {
+		rows := makeSingleResultSet( //nolint:rowserrcheck
+			[]string{"a"},
+			[]interface{}{1},
+			[]interface{}{2},
+			[]interface{}{3},
+			[]interface{}{4},
+			[]interface{}{5},
+		)
+
+		before := rowsScannedSampleValues(t)
+		_, err := sqlutil.FrameFromRows(rows, 100)
+		require.NoError(t, err)
+
+		got := rowsScannedSampleValues(t)
+		require.Equal(t, before.count+1, got.count, "exactly one observation")
+		require.InDelta(t, 5.0, got.sum-before.sum, 0, "observed value equals rows scanned")
+	})
+
+	t.Run("observes the truncated count when rowLimit is reached", func(t *testing.T) {
+		rows := makeSingleResultSet( //nolint:rowserrcheck
+			[]string{"a"},
+			[]interface{}{1},
+			[]interface{}{2},
+			[]interface{}{3},
+			[]interface{}{4},
+			[]interface{}{5},
+		)
+
+		before := rowsScannedSampleValues(t)
+		_, err := sqlutil.FrameFromRows(rows, 2)
+		require.NoError(t, err)
+
+		got := rowsScannedSampleValues(t)
+		require.Equal(t, before.count+1, got.count)
+		require.InDelta(t, 2.0, got.sum-before.sum, 0)
+	})
+
+	t.Run("observes zero for an empty result set", func(t *testing.T) {
+		rows := makeSingleResultSet( //nolint:rowserrcheck
+			[]string{"a"},
+		)
+
+		before := rowsScannedSampleValues(t)
+		_, err := sqlutil.FrameFromRows(rows, 100)
+		require.NoError(t, err)
+
+		got := rowsScannedSampleValues(t)
+		require.Equal(t, before.count+1, got.count)
+		require.InDelta(t, 0.0, got.sum-before.sum, 0)
+	})
+
+	t.Run("skips observation when pre-loop setup fails", func(t *testing.T) {
+		rows := makeSingleResultSetWithScanTypes( //nolint:rowserrcheck
+			[]string{"a"},
+			[]reflect.Type{nil},
+			[]interface{}{1},
+		)
+
+		before := rowsScannedSampleValues(t)
+		_, err := sqlutil.FrameFromRows(rows, 100)
+		require.Error(t, err)
+
+		got := rowsScannedSampleValues(t)
+		require.Equal(t, before.count, got.count, "no observation when MakeScanRow errors before the scan loop")
+	})
+
+	t.Run("counts rows scanned on the dynamic-converter path", func(t *testing.T) {
+		rows := makeSingleResultSet( //nolint:rowserrcheck
+			[]string{"a"},
+			[]interface{}{"x"},
+			[]interface{}{"y"},
+			[]interface{}{"z"},
+		)
+
+		before := rowsScannedSampleValues(t)
+		_, err := sqlutil.FrameFromRows(rows, 100, sqlutil.Converter{
+			Name:          "dynamic",
+			InputTypeName: "dynamic",
+			Dynamic:       true,
+		})
+		require.NoError(t, err)
+
+		got := rowsScannedSampleValues(t)
+		require.Equal(t, before.count+1, got.count)
+		require.InDelta(t, 3.0, got.sum-before.sum, 0)
+	})
+}

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -79,6 +79,7 @@ func frameFromRows(rows *sql.Rows, rowLimit int64, capacity int, converters ...C
 	converted := make([]interface{}, len(scannable))
 
 	var i int64
+	defer func() { observeRowsScanned(i) }()
 
 outer:
 	for i < rowLimit {


### PR DESCRIPTION
## Summary

Adds `plugins_sql_rows_scanned`, an unlabelled Prometheus histogram of the number of database rows consumed by `FrameFromRows` before any frame reshaping. Complements the frame-level row/cell metrics emitted downstream in sqlds and the transport-level `plugins_datasource_response_size_bytes` histogram.

- **Pre-conversion count.** Measures what the database handed the plugin, not what was emitted to Grafana. A plugin that scans 10M rows but emits 1k frame rows (e.g. `LongToMulti` reshaping) looks very different in this metric vs. frame-level ones — which is the point.
- **Generic across SQL datasources.** The observation sits inside `sqlutil.FrameFromRows`, which is shared by every plugin using the SDK's SQL helpers — sqlds-backed and otherwise.
- **Extends an existing pattern.** No new exported API; the histogram mirrors the native-histogram settings already used by `plugins_datasource_response_size_bytes`.

## Shape

```
plugins_sql_rows_scanned  histogram{}  buckets: 1, 10, 100, 1k, 10k, 100k, 1M, 10M, 100M
native histogram: bucket factor 1.1, max 100 buckets, 1h reset
```

No labels in this first cut. If operators want `datasource_type`, a non-breaking `FrameFromRowsWithOpts`-style overload can add it later — flagged in review rather than speculatively plumbed through.

## Implementation notes

- Observation emitted once per `FrameFromRows` invocation via `defer`, so the normal path, the `rowLimit`-reached path, and the `rows.Err()` path all emit what was scanned.
- Pre-loop errors (`rows.ColumnTypes()`, `rows.Columns()`, `MakeScanRow()`) return before the deferred emission is registered, so no spurious 0-observations for queries that failed before scanning started.
- The dynamic-converter path (`frameDynamic` -> `findDataTypes`) is instrumented separately using `len(returnData)`. The existing local counter `i` there stops incrementing once all column types have been discovered — subsequent scan iterations hit a `continue` that skips the `i++` — so using `i` would undercount on larger result sets.

## Context

Part of the response-size observability effort for SQL datasources: **grafana/data-sources#288**. The aim is to make the shape of what plugins pull from the database visible fleet-wide, so queries that drive memory pressure on multi-tenant API servers can be spotted from metrics rather than by inspecting pods.

This PR is the SDK-layer, pre-conversion DB-rows signal in a multi-PR design:

- `plugins_sql_response_rows` / `plugins_sql_response_cells` — post-conversion, frame-level histograms (grafana/sqlds#241, merged).
- `plugins_sql_rows_scanned` — pre-conversion, DB-level histogram (**this PR**).
- Structured threshold log + large-response counter — grafana/sqlds#242, grafana/sqlds#243.
