### PR TITLE
POC: experimental/mcp - embedded MCP server for datasource plugins

### DIFF
--- a/backend/datasource/manage.go
+++ b/backend/datasource/manage.go
@@ -1,12 +1,17 @@
 package datasource
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	sdklog "github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
 	"github.com/grafana/grafana-plugin-sdk-go/internal/automanagement"
 	"github.com/grafana/grafana-plugin-sdk-go/internal/buildinfo"
 )
@@ -27,6 +32,11 @@ type ManageOpts struct {
 
 	// Stateless query conversion handler
 	QueryConversionHandler backend.QueryConversionHandler
+
+	// MCPServer, if non-nil, is started alongside the gRPC plugin server and
+	// shut down on plugin termination. MCP startup failures are logged but do
+	// not prevent the plugin from running.
+	MCPServer *mcp.Server
 }
 
 // Manage starts serving the data source over gPRC with automatic instance management.
@@ -47,6 +57,18 @@ func Manage(pluginID string, instanceFactory InstanceFactoryFunc, opts ManageOpt
 		return fmt.Errorf("setup tracer: %w", err)
 	}
 	handler := automanagement.NewManager(NewInstanceManager(instanceFactory))
+
+	if opts.MCPServer != nil {
+		if err := startMCPServer(opts.MCPServer); err != nil {
+			sdklog.DefaultLogger.Warn("MCP server startup error", "err", err)
+		}
+		defer func() {
+			if err := stopMCPServer(opts.MCPServer); err != nil {
+				sdklog.DefaultLogger.Warn("MCP server shutdown error", "err", err)
+			}
+		}()
+	}
+
 	return backend.Manage(pluginID, backend.ServeOpts{
 		CheckHealthHandler:      handler,
 		CallResourceHandler:     handler,
@@ -58,4 +80,38 @@ func Manage(pluginID string, instanceFactory InstanceFactoryFunc, opts ManageOpt
 		GRPCSettings:            opts.GRPCSettings,
 		ConversionHandler:       opts.ConversionHandler,
 	})
+}
+
+// startMCPServer starts the MCP server. Errors are logged and swallowed; the
+// plugin continues without MCP if startup fails (e.g. port in use).
+func startMCPServer(s *mcp.Server) error {
+	if err := s.Start(context.Background()); err != nil {
+		sdklog.DefaultLogger.Warn("MCP server failed to start - continuing without MCP", "err", err)
+		return nil
+	}
+	return nil
+}
+
+func stopMCPServer(s *mcp.Server) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return s.Shutdown(ctx)
+}
+
+// PluginHandler is the union of handler interfaces an automanagement-backed
+// plugin handler implements. Plugins use this to bind the same handler to
+// both gRPC (via Manage) and MCP (via mcp.Server.Bind*).
+type PluginHandler interface {
+	backend.QueryDataHandler
+	backend.CallResourceHandler
+	backend.CheckHealthHandler
+	backend.StreamHandler
+}
+
+// NewAutomanagementHandler wraps the given InstanceManager with the SDK's
+// automanagement layer and returns the resulting handler. The returned value
+// implements PluginHandler. Plugins bind this to mcp.Server then pass the same
+// instance factory through datasource.Manage.
+func NewAutomanagementHandler(im instancemgmt.InstanceManager) PluginHandler {
+	return automanagement.NewManager(im)
 }

--- a/backend/datasource/manage.go
+++ b/backend/datasource/manage.go
@@ -69,12 +69,20 @@ func Manage(pluginID string, instanceFactory InstanceFactoryFunc, opts ManageOpt
 		}()
 	}
 
+	// When an MCP server is present, wrap the gRPC handler so that every
+	// incoming Grafana call registers the datasource PluginContext. MCP tool
+	// calls then look up the context by UID instead of receiving an empty one.
+	grpcHandler := PluginHandler(handler)
+	if opts.MCPServer != nil {
+		grpcHandler = &contextCapture{inner: handler, mcpServer: opts.MCPServer}
+	}
+
 	return backend.Manage(pluginID, backend.ServeOpts{
-		CheckHealthHandler:      handler,
-		CallResourceHandler:     handler,
-		QueryDataHandler:        handler,
+		CheckHealthHandler:      grpcHandler,
+		CallResourceHandler:     grpcHandler,
+		QueryDataHandler:        grpcHandler,
 		QueryChunkedDataHandler: handler,
-		StreamHandler:           handler,
+		StreamHandler:           grpcHandler,
 		QueryConversionHandler:  opts.QueryConversionHandler,
 		AdmissionHandler:        opts.AdmissionHandler,
 		GRPCSettings:            opts.GRPCSettings,
@@ -114,4 +122,46 @@ type PluginHandler interface {
 // instance factory through datasource.Manage.
 func NewAutomanagementHandler(im instancemgmt.InstanceManager) PluginHandler {
 	return automanagement.NewManager(im)
+}
+
+// contextCapture wraps a PluginHandler and registers each datasource's
+// PluginContext with the MCP server as gRPC calls arrive from Grafana.
+// This lets MCP tool calls look up the context (including decrypted credentials)
+// by datasource UID without manual configuration.
+type contextCapture struct {
+	inner     PluginHandler
+	mcpServer *mcp.Server
+}
+
+func (c *contextCapture) capture(pctx backend.PluginContext) {
+	if pctx.DataSourceInstanceSettings != nil {
+		c.mcpServer.RegisterPluginContext(pctx.DataSourceInstanceSettings.UID, pctx)
+	}
+}
+
+func (c *contextCapture) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	c.capture(req.PluginContext)
+	return c.inner.QueryData(ctx, req)
+}
+
+func (c *contextCapture) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	c.capture(req.PluginContext)
+	return c.inner.CallResource(ctx, req, sender)
+}
+
+func (c *contextCapture) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	c.capture(req.PluginContext)
+	return c.inner.CheckHealth(ctx, req)
+}
+
+func (c *contextCapture) SubscribeStream(ctx context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
+	return c.inner.SubscribeStream(ctx, req)
+}
+
+func (c *contextCapture) PublishStream(ctx context.Context, req *backend.PublishStreamRequest) (*backend.PublishStreamResponse, error) {
+	return c.inner.PublishStream(ctx, req)
+}
+
+func (c *contextCapture) RunStream(ctx context.Context, req *backend.RunStreamRequest, sender *backend.StreamSender) error {
+	return c.inner.RunStream(ctx, req, sender)
 }

--- a/backend/datasource/manage_mcp_test.go
+++ b/backend/datasource/manage_mcp_test.go
@@ -1,0 +1,52 @@
+package datasource
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartMCPServer_startsAndStops(t *testing.T) {
+	s := mcp.NewServer(mcp.ServerOpts{Name: "test", Version: "1.0", Addr: "127.0.0.1:0"})
+	require.NoError(t, startMCPServer(s))
+	addr := s.ListenAddr()
+	require.NotEmpty(t, addr)
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	require.NoError(t, err)
+	conn.Close()
+	require.NoError(t, stopMCPServer(s))
+}
+
+func TestStartMCPServer_logsAndContinuesOnError(t *testing.T) {
+	occupier, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer occupier.Close()
+
+	s := mcp.NewServer(mcp.ServerOpts{Name: "test", Version: "1.0", Addr: occupier.Addr().String()})
+	// Should not panic and should not fail Manage.
+	err = startMCPServer(s)
+	assert.NoError(t, err) // we swallow the error and log it
+	assert.Empty(t, s.ListenAddr())
+}
+
+func TestNewAutomanagementHandler_returnsHandler(t *testing.T) {
+	im := NewInstanceManager(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+		return struct{}{}, nil
+	})
+	h := NewAutomanagementHandler(im)
+	require.NotNil(t, h)
+	// The returned handler implements all four interfaces.
+	_, isQuery := any(h).(backend.QueryDataHandler)
+	_, isResource := any(h).(backend.CallResourceHandler)
+	_, isHealth := any(h).(backend.CheckHealthHandler)
+	assert.True(t, isQuery)
+	assert.True(t, isResource)
+	assert.True(t, isHealth)
+}

--- a/experimental/mcp/docs/2026-05-06-query-benchmark-design.md
+++ b/experimental/mcp/docs/2026-05-06-query-benchmark-design.md
@@ -1,0 +1,316 @@
+# MCP Datasource Query Benchmark — Design Spec
+
+## Background
+
+The MCP layer in `grafana-plugin-sdk-go/experimental/mcp` translates datasource plugin schema files (query types, examples, routes) into MCP tools and resources that an LLM agent can call. The information exposed via MCP — tool descriptions, schema annotations, query examples, resources, and custom tools — varies in richness depending on what the plugin author provides.
+
+It is not yet known which combinations of that information most improve the quality of queries an agent generates. This benchmark provides a repeatable, scored harness to measure that experimentally.
+
+## Goal
+
+Determine which MCP context dimensions have the most impact on query quality, by running a Claude agent against a live plugin MCP server under named configuration variants and scoring the resulting traces on three independent dimensions.
+
+## Quality Dimensions
+
+Three dimensions, scored separately:
+
+| Dimension | Meaning | Method |
+|---|---|---|
+| **Correctness** | Right tool called, required args present, query executes without error, result matches expected shape | Deterministic — no LLM |
+| **Semantic accuracy** | Result reflects what the user actually asked for | LLM-as-judge (separate Claude call) |
+| **Efficiency** | Agent reached a correct answer in the fewest tool calls | `OptimalCalls / ActualCalls`, capped at 1.0 |
+
+Composite score for summary reporting: `0.4×correctness + 0.4×semantic + 0.2×efficiency`. Weights are constants in `eval/scoring.go`.
+
+## Datasources in Scope
+
+- `github-datasource` — API-backed, rich query type variety (PRs, issues, commits, labels, milestones, deployments, contributors)
+- `redshift-datasource` — SQL-backed, requires schema discovery (tables, columns) to construct valid queries
+
+Both datasources run against live backends. The benchmark is not designed for replay against fixtures.
+
+The Redshift test cases reference specific table and column names (e.g. `orders`, `analytics`). These must be calibrated against the actual test database before the benchmark is run — the `ExpectedArgs` and `ResultShape` fields in `redshift.json` are placeholders until the schema is known.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Benchmark Runner                                            │
+│                                                             │
+│  1. Start plugin process with variant's MCP configuration   │
+│  2. Read dist/mcp.addr → connect MCP client                 │
+│  3. Inject test case prompt into Claude via Anthropic API   │
+│  4. Agent loop: Claude calls MCP tools until done/timeout   │
+│  5. Capture structured trace (tool calls, args, results)    │
+│  6. Score trace on 3 dimensions                             │
+│  7. Write result JSON                                        │
+└─────────────────────────────────────────────────────────────┘
+         │                         │
+         ▼                         ▼
+  Plugin process              Anthropic API
+  (github or redshift)        (claude-sonnet-4-6 as agent)
+  MCP server on :auto              │
+         │                         │ tool calls
+         └─────────────────────────┘
+```
+
+The benchmark runner drives one cell (variant × test case × datasource) at a time. Cells are independent and can be parallelised with `--parallel N`.
+
+## Directory Layout
+
+```
+benchmark/
+├── cmd/bench/main.go       # entry point, flag parsing, run orchestration
+├── variants/variants.go    # Variant type + named variant registry
+├── cases/
+│   ├── cases.go            # TestCase type + JSON loader
+│   ├── github.json         # test cases for github-datasource
+│   └── redshift.json       # test cases for redshift-datasource
+├── agent/loop.go           # Claude MCP client agent loop
+├── eval/
+│   ├── correctness.go      # deterministic correctness scorer
+│   ├── semantic.go         # LLM-as-judge scorer
+│   ├── efficiency.go       # tool call count scorer
+│   ├── scoring.go          # composite weights + Scores type
+│   └── judge_prompt.txt    # versioned judge prompt template
+├── trace/trace.go          # Trace + ToolCall types, JSON serialisation
+├── results/
+│   ├── store.go            # write/read result files
+│   └── compare.go          # diff two run directories, render summary table
+└── go.mod
+```
+
+## Configuration Variants
+
+```go
+type Variant struct {
+    Name                  string
+    RichToolDescriptions  bool  // hand-written descriptions vs auto-generated
+    FullSchemaAnnotations bool  // field descriptions, enums, required present
+    QueryExamples         bool  // examples://query resource + per-tool examples
+    SchemaResources       bool  // table/column/schema metadata as MCP resources
+    DescribeDatasource    bool  // explain-this-datasource tool
+}
+```
+
+Named variants — each adds exactly one dimension to the previous, so score deltas are attributable:
+
+| Variant | Rich descriptions | Full schema | Examples | Schema resources | Describe tool |
+|---|---|---|---|---|---|
+| `baseline` | | | | | |
+| `rich-descriptions` | ✓ | | | | |
+| `with-schema` | ✓ | ✓ | | | |
+| `with-examples` | ✓ | ✓ | ✓ | | |
+| `with-resources` | ✓ | ✓ | ✓ | ✓ | |
+| `full` | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+Arbitrary subsets can be selected via `--variants baseline,full` for targeted comparisons.
+
+## Test Cases
+
+### Structure
+
+```go
+type TestCase struct {
+    ID               string
+    Datasource       string         // "github" | "redshift"
+    Category         string         // see categories below
+    Prompt           string
+    ExpectedTool     string         // tool that must be called for correctness
+    ExpectedArgs     map[string]any // required arg values that must be present
+    ExpectedResult   ResultShape
+    OptimalToolCalls int
+}
+
+type ResultShape struct {
+    MinRows     int
+    FieldsExist []string
+    FilterCheck string  // JSONPath expression that must hold on every row
+}
+```
+
+### Categories
+
+| Category | Description | Correctness baseline | `OptimalToolCalls` |
+|---|---|---|---|
+| **Straightforward** | Right tool and args obvious from the prompt | All variants should pass | 1 |
+| **Schema-dependent** | Requires knowing exact field/column names | `baseline` likely fails | 1–2 |
+| **Multi-step discovery** | Must call one tool to get input for the next | Needs route tools or resources | 2–3 |
+| **Error-recovery** | Naive first attempt returns wrong/empty result; agent must self-correct | Needs describe tool or schema resources | 2 |
+
+### GitHub Datasource Cases
+
+| ID | Category | Prompt | Expected tool | What a weak variant gets wrong |
+|---|---|---|---|---|
+| `github-open-prs` | Straightforward | "Show me open pull requests in grafana/grafana" | `query_Pull_Requests` | — |
+| `github-recent-commits` | Straightforward | "List commits from the last 7 days in grafana/grafana" | `query_Commits` | — |
+| `github-pr-author-filter` | Schema-dependent | "Show me merged PRs authored by renovate-bot in grafana/grafana" | `query_Pull_Requests` | Guesses wrong field name (`user`, `creator` instead of `author`) |
+| `github-issue-label-filter` | Schema-dependent | "Find open issues with the 'type/bug' label in grafana/grafana" | `query_Issues` | Guesses wrong field name for label filtering |
+| `github-milestones-then-issues` | Multi-step discovery | "Show me issues belonging to the first open milestone in grafana/grafana" | `get_milestones` → `query_Issues` | Skips milestone discovery, passes wrong milestone ID |
+| `github-labels-then-query` | Multi-step discovery | "Pick a label that exists in grafana/grafana and show me its open issues" | `get_labels` → `query_Issues` | Invents a label name instead of fetching available ones |
+| `github-wrong-querytype` | Error-recovery | "Show me the deployment history for grafana/grafana" | `query_Deployments` | Tries `query_Commits` first; needs schema or describe tool to find correct type |
+| `github-nonexistent-field` | Error-recovery | "Show me pull requests with more than 5 review comments" | `query_Pull_Requests` | Attempts a field that may not exist; needs schema to recover or rephrase |
+
+### Redshift Datasource Cases
+
+| ID | Category | Prompt | Expected tool | What a weak variant gets wrong |
+|---|---|---|---|---|
+| `redshift-simple-select` | Straightforward | "Show me the first 10 rows from the orders table" | `query_sql` | — |
+| `redshift-count-by-status` | Straightforward | "Count orders grouped by status" | `query_sql` | — |
+| `redshift-exact-column` | Schema-dependent | "Show me orders where the total amount exceeds 1000" | `query_sql` | Guesses column name (`total_amount`? `amount`? `order_total`?) |
+| `redshift-date-column` | Schema-dependent | "Find orders created in the last 30 days" | `query_sql` | Guesses timestamp column name |
+| `redshift-discover-then-query` | Multi-step discovery | "Show me 5 rows from whichever table has the most columns" | `get_tables` → `get_columns` → `query_sql` | Skips schema discovery, invents a table name |
+| `redshift-schema-then-table` | Multi-step discovery | "List the tables in the analytics schema and query one of them" | `get_schemas` → `get_tables` → `query_sql` | Invents schema name |
+| `redshift-wrong-table` | Error-recovery | "Show me data from the transactions table" | `query_sql` | Queries non-existent table; needs `get_tables` to recover |
+| `redshift-ambiguous-column` | Error-recovery | "Find the most recent records" | `query_sql` | No obvious timestamp column; needs schema context to identify the right column |
+
+## Trace Structure
+
+One trace file per (variant × case). Written to `results/<run-id>/traces/<variant>/<datasource>/<case-id>.json`.
+
+```go
+type Trace struct {
+    RunID       string
+    Variant     string
+    Datasource  string
+    CaseID      string
+    Category    string
+    StartedAt   time.Time
+    DurationMs  int64
+    Prompt      string
+    ToolCalls   []ToolCall
+    FinalAnswer string
+    Scores      Scores
+}
+
+type ToolCall struct {
+    Seq        int
+    Tool       string
+    Args       map[string]any
+    ResultJSON string
+    DurationMs int64
+    IsError    bool
+}
+
+type Scores struct {
+    Correctness float64
+    Semantic    float64
+    Efficiency  float64
+    Composite   float64
+}
+```
+
+## Agent Loop
+
+`agent/loop.go` drives one trace to completion:
+
+1. Read `dist/mcp.addr` → connect to the running plugin process using `modelcontextprotocol/go-sdk`'s HTTP client (`mcpsdk.NewClient` + HTTP transport). The `mcptest` package is in-memory only and not suitable here.
+2. Call `tools/list` → build Anthropic API tool definitions
+3. Send prompt + tools to `claude-sonnet-4-6`
+4. Loop until done or `MaxTurns` (default 10) exceeded:
+   - `tool_use` blocks → call each tool via MCP, append `tool_result` messages
+   - Text-only response → extract final answer, stop
+   - Timeout → record as incomplete trace, stop
+
+`MaxTurns` is configurable per run. Error-recovery cases may warrant a higher limit than straightforward ones.
+
+## Scoring
+
+### Correctness (`eval/correctness.go`)
+
+Binary — 0 or 1. All four checks must pass:
+
+1. Expected tool was called at some point in the trace
+2. All `ExpectedArgs` key/value pairs are present in the matching tool call
+3. That tool call did not return an MCP error
+4. Result satisfies `ResultShape` (min rows, required fields, filter check)
+
+### Semantic Accuracy (`eval/semantic.go`)
+
+LLM-as-judge. A separate Claude API call (not part of the agent loop) receives:
+- The original prompt
+- The tool calls made (tool name + args only, not results)
+- The agent's final answer text
+
+The judge scores 0–3 on each of three axes, normalised to 0.0–1.0:
+- Did the agent query for the right thing?
+- Are the key filters and constraints from the prompt reflected in the args?
+- Does the final answer address what was asked?
+
+The judge prompt is stored in `eval/judge_prompt.txt` and version-controlled.
+
+### Efficiency (`eval/efficiency.go`)
+
+```
+score = min(1.0, OptimalToolCalls / len(ToolCalls))
+```
+
+Error-recovery cases have `OptimalToolCalls=2` by design — one discovery/recovery call plus one correct call — so a 2-call solution scores 1.0 even though the first attempt failed.
+
+### Composite
+
+```
+composite = 0.4×correctness + 0.4×semantic + 0.2×efficiency
+```
+
+Used only for summary reporting. Per-dimension scores are the primary analysis unit.
+
+## Results & CLI
+
+### Results Layout
+
+```
+results/
+└── <run-id>/
+    ├── meta.json          # variant list, datasources, start time, flags used
+    └── traces/
+        └── <variant>/
+            └── <datasource>/
+                └── <case-id>.json
+```
+
+### Summary Table (bench show / bench compare)
+
+```
+                          baseline   rich-desc   with-schema   with-examples   with-resources   full
+github-open-prs           C:1 S:.72  C:1 S:.81   ...
+github-pr-author-filter   C:0 S:.41  C:1 S:.79   ...
+redshift-wrong-table      C:0 S:.38  C:0 S:.44   ...
+...
+composite (avg)           0.51       0.63        ...
+```
+
+Efficiency shown with `--verbose`. Category subtotals shown with `--by-category`.
+
+### CLI
+
+```bash
+# run all variants against all cases for both datasources
+bench run --datasource both --all-variants
+
+# run specific variants
+bench run --datasource github --variants baseline,full
+
+# run a single case for debugging
+bench run --datasource github --variants with-examples --case github-open-prs
+
+# compare two runs
+bench compare <run-id-a> <run-id-b>
+
+# show results for a single run
+bench show <run-id> [--verbose] [--by-category]
+```
+
+Key flags for `bench run`:
+- `--max-turns N` — agent loop turn limit (default 10)
+- `--parallel N` — concurrent cells (default 1)
+- `--output dir` — results directory (default `./results`)
+
+## Success Criteria
+
+The benchmark is useful when:
+
+1. `baseline` vs `full` shows a measurable score difference on schema-dependent and error-recovery cases
+2. The additive variant structure isolates which single dimension drives each improvement
+3. Results are reproducible across runs (same variant + same case → scores within ±0.1)
+4. A new test case can be added by editing a JSON file with no Go changes required

--- a/experimental/mcp/docs/design.md
+++ b/experimental/mcp/docs/design.md
@@ -1,0 +1,378 @@
+# Datasource MCP POC - Design
+
+## Background
+
+Grafana datasource plugins expose runtime capabilities (query handling, `CallResourceHandler`, health checks) via gRPC, but those capabilities are not discoverable in a structured way for agents. Today, agent integrations either hardcode datasource-specific knowledge or rely on bespoke assistant tooling - that does not scale across the plugin ecosystem.
+
+A separate effort recently added static schema files for datasource plugins. Plugins ship them in their archive at:
+
+```
+dist/schema/{apiVersion}/query.types.{json|yaml}
+dist/schema/{apiVersion}/query.examples.{json|yaml}
+dist/schema/{apiVersion}/settings.{json|yaml}
+dist/schema/{apiVersion}/settings.examples.{json|yaml}
+dist/schema/{apiVersion}/routes.{json|yaml}
+```
+
+These are loaded via `experimental/pluginschema.NewCompositeFileSchemaProvider` into a `PluginSchema` struct (see `grafana-plugin-sdk-go` PR #1533). The github-datasource PR #291 wires the schema-builder for query types and examples.
+
+This design extends that work: the plugin SDK gains an embedded MCP server that translates the existing schema and runtime handlers into MCP `tools` and `resources`. Each plugin process exposes its own MCP endpoint on a local port. Plugins keep one source of truth (their schema files plus their existing handlers).
+
+## Problem
+
+Agents cannot reliably use datasource plugins without bespoke integration code because they do not know which capabilities a plugin exposes, what parameters those capabilities need, what query language is expected or where to find datasource-specific examples. This duplicates implementation work and limits agent support to a small set of hand-integrated datasources.
+
+## POC scope
+
+The POC proves the embedded MCP layer end-to-end at the protocol surface. It does **not** include live agent integration, MetaMCP, Grafana-side proxying or auth.
+
+In scope:
+
+- New `experimental/mcp` package in `grafana-plugin-sdk-go`
+- One MCP HTTP listener per plugin process, lifecycle-managed by the SDK
+- Schema-driven registration helpers covering: query types, query examples, `/resources/*` routes, health checks
+- Code-level registration for custom tools, custom resources and prompts (no schema source)
+- POC implementation in `github-datasource` and `redshift-datasource`
+- Verification via a CLI MCP client (e.g. `mcp-inspector`) against the running plugin processes
+
+Out of scope (deferred):
+
+- Settings and settings-examples schema mapping (settings as a resource is not part of this POC)
+- Grafana-side aggregation or proxy of plugin MCP endpoints
+- MetaMCP integration, auth, multi-tenancy
+- Live agent (Claude/Cursor) end-to-end demos
+- Overlay files for MCP-specific descriptions or hide-lists (`mcp.json`)
+- Schema-driven prompts (`prompts.json`)
+- Tool-level call-order enforcement
+- App plugins (datasource only)
+- Streaming query results over MCP (single-shot only)
+- `/proxy/*` routes (skipped - not meaningful as agent tools)
+
+## Goals
+
+1. Each datasource plugin can expose tools, resources and prompts over MCP without duplicating its existing handlers
+2. The existing `pluginschema` files are the only authored source of truth for query types, query examples and resource routes
+3. Plugin authors can layer custom tools, custom resources and prompts via code-level registration
+4. The MCP server's lifecycle is owned by the SDK and follows the existing plugin process lifecycle
+5. The MCP listener exposes the standard MCP protocol so any MCP client can connect
+
+## Non-goals
+
+- Replacing or refactoring the existing plugin gRPC runtime
+- Requiring every plugin to adopt MCP
+- Designing a new packaging format
+- Normalizing query languages across datasources
+- Solving auth, policy or multi-tenancy in the plugin (deferred to a gateway)
+
+## Architecture
+
+```
++--------------------------------------------------------------------+
+|  Plugin process (single OS process)                                |
+|                                                                    |
+|  +----------------------+        +-----------------------------+   |
+|  |  gRPC server         |        |  MCP server (HTTP)          |   |
+|  |  (existing)          |        |  (new, this POC)            |   |
+|  |                      |        |                             |   |
+|  |  - QueryData         |        |  - tools/list, tools/call   |   |
+|  |  - CallResource      |        |  - resources/list, read     |   |
+|  |  - CheckHealth       |        |  - prompts/list, get        |   |
+|  +-----------+----------+        +-------------+---------------+   |
+|              |                                 |                   |
+|              v                                 v                   |
+|  +---------------------------------------------------------------+ |
+|  |  Plugin handlers (QueryDataHandler, CallResourceHandler, ...) | |
+|  +---------------------------------------------------------------+ |
+|                                                                    |
++-----------+-----------------------------------+--------------------+
+            |                                   |
+            v unix socket (Grafana <-> plugin)  v TCP host:port
+       +---------+                        +-----------------+
+       | Grafana |                        | MCP client      |
+       +---------+                        | (inspector,     |
+                                          |  MetaMCP, ...)  |
+                                          +-----------------+
+```
+
+Key properties:
+
+- One process, two listeners. The MCP server runs in-process alongside the existing gRPC server.
+- MCP tool calls re-use the same handler implementations as gRPC (`QueryDataHandler`, `CallResourceHandler`, `CheckHealthHandler`). No duplicate logic.
+- The plugin's `main.go` is the explicit registration point - it constructs the MCP server, calls schema-driven helpers, and registers any custom additions.
+- The MCP listener binds to `127.0.0.1` by default. Auth and policy belong to a gateway that sits in front of the listener; the plugin trusts whatever reaches it.
+
+## SDK package layout
+
+A new `experimental/mcp` package in `grafana-plugin-sdk-go`:
+
+```
+experimental/mcp/
+├── server.go          # Server type, Start/Stop, transport wiring
+├── server_test.go
+├── tools.go           # Tool type + registration helpers
+├── resources.go       # Resource type + registration helpers
+├── prompts.go         # Prompt type + registration helpers
+├── fromschema/
+│   ├── querytypes.go  # PluginSchema.QueryTypes -> []Tool
+│   ├── routes.go      # PluginSchema.Routes -> []Tool
+│   ├── examples.go    # PluginSchema.QueryExamples -> Resource + tool examples
+│   └── healthcheck.go # CheckHealthHandler -> Tool
+└── mcptest/
+    └── client.go      # In-memory MCP client for unit tests
+```
+
+The package depends on `github.com/modelcontextprotocol/go-sdk` for protocol primitives. The Grafana-specific glue lives here: handler binding, schema walking, lifecycle integration.
+
+`mcp.Server` has a small surface (`Register*`, `Bind*`, `Start`, `Shutdown`). The schema-walking helpers in `fromschema` are opt-in and don't pollute the core API. A plugin that wants pure code-level registration ignores `fromschema` entirely.
+
+### Lifecycle integration
+
+`backend/datasource.ManageOpts` gains:
+
+```go
+type ManageOpts struct {
+    // ... existing fields ...
+    MCPServer *mcp.Server // optional
+}
+```
+
+When set, the SDK starts the MCP listener after the gRPC server is up, before `Manage` blocks. On `SIGINT`/`SIGTERM`, the SDK calls `mcpServer.Shutdown(ctx)` with a 5-second drain before the gRPC server stops.
+
+If MCP startup fails (e.g. port in use), the plugin logs the error but does **not** exit - gRPC continues serving. MCP is opt-in and must not take a plugin down.
+
+## Plugin author API
+
+The shape of `main.go` for a plugin that opts in:
+
+```go
+package main
+
+import (
+    "embed"
+    "os"
+
+    "github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+    "github.com/grafana/grafana-plugin-sdk-go/backend/log"
+    "github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+    "github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+    "github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+
+    ghds "github.com/grafana/github-datasource/pkg/github"
+)
+
+//go:embed schema/v0alpha1/*.json
+var schemaFS embed.FS
+
+func main() {
+    ds := ghds.NewDatasource(...)
+
+    schema, err := pluginschema.NewCompositeFileSchemaProvider(schemaFS).Get("v0alpha1")
+    if err != nil {
+        log.DefaultLogger.Error("schema load failed", "err", err)
+        os.Exit(1)
+    }
+
+    mcpServer := mcp.NewServer(mcp.ServerOpts{
+        Name:    "grafana-github-datasource",
+        Version: "1.0.0",
+    })
+
+    // bind handlers - these are how MCP tool calls reach the plugin
+    mcpServer.BindQueryDataHandler(ds)
+    mcpServer.BindCallResourceHandler(ds)
+    mcpServer.BindCheckHealthHandler(ds)
+
+    // schema-driven registration
+    fromschema.RegisterQueryTools(mcpServer, schema)
+    fromschema.RegisterRouteTools(mcpServer, schema)
+    fromschema.RegisterQueryExamples(mcpServer, schema)
+    fromschema.RegisterHealthCheckTool(mcpServer)
+
+    // custom code-level additions
+    mcpServer.RegisterPrompt(mcp.Prompt{
+        Name:        "investigate-pull-requests",
+        Description: "Walk through a recent PR investigation",
+        Template:    investigatePRTemplate,
+    })
+
+    if err := datasource.Manage(
+        "grafana-github-datasource",
+        ds.NewInstance,
+        datasource.ManageOpts{MCPServer: mcpServer},
+    ); err != nil {
+        log.DefaultLogger.Error("plugin exited", "err", err)
+        os.Exit(1)
+    }
+}
+```
+
+### Design decisions
+
+**Bind handlers, then register tools.** `BindQueryDataHandler` etc. don't register anything by themselves. They tell the MCP server *how to execute* tools that come from `QueryTypeDefinition`s. The `fromschema` helpers reuse the bound handler when generating tools. This separates "what to expose" (registration) from "how to execute" (handler binding).
+
+**`fromschema` is a separate sub-package, not on the server.** Keeps the core API small and lets plugins skip it when they want full code-level control.
+
+**Tool naming is deterministic.** `query_<discriminator-value>` for query types, `<method>_<sanitized-path>` for route tools, `check_health` for health. MCP clients can rely on these names across plugin versions.
+
+**Tool execution path.** When MCP calls `query_Pull_Requests`, the SDK constructs a `backend.QueryDataRequest` from the validated tool args, invokes the bound `QueryDataHandler`, then encodes the resulting `data.Frames` to JSON for the tool output.
+
+**Routes-as-tools execution path.** When MCP calls a route tool, the SDK constructs a synthetic `backend.CallResourceRequest` (path with params substituted, method, query string from remaining args, JSON body from `requestBody` arg) and invokes the bound `CallResourceHandler`. The first response chunk's body is decoded (JSON if `application/json`, else raw text) and returned.
+
+## Schema -> MCP mapping
+
+| Source | MCP primitive | Name pattern | Notes |
+|---|---|---|---|
+| `query.types.json` items | Tool | `query_<discriminator-value>` | InputSchema = the spec's JSON Schema, ungrafted |
+| `routes.json` paths (`/resources/*` only) | Tool | `<method>_<sanitized-path>` | InputSchema derived from OpenAPI parameters + requestBody; `/proxy/*` skipped |
+| `CheckHealthHandler` | Tool | `check_health` | Empty input schema; output is the health JSON |
+| `query.examples.json` | Resource | `examples://query` | Single resource listing all examples; also attached as `Tool.examples` per matching tool |
+| code-only | Tool / Resource / Prompt | author-supplied | Plugin calls `Register*` directly |
+
+### Query types -> tools
+
+```
+QueryTypeDefinition.metadata.name = "Pull_Requests"
+QueryTypeDefinition.spec.discriminators[].field = "queryType"
+QueryTypeDefinition.spec.discriminators[].value = "Pull_Requests"
+QueryTypeDefinition.spec.schema = JSON Schema
+                                                ↓
+mcp.Tool{
+    Name:        "query_Pull_Requests",
+    Description: schema.description (fallback: "Query " + name),
+    InputSchema: schema,
+    Annotations: {"queryType": "Pull_Requests"},
+    Handler:     unifiedQueryToolHandler,  // shared across all query tools
+}
+```
+
+The shared handler:
+
+1. Validates input against the tool's JSON Schema
+2. Wraps it in a `backend.DataQuery` with `RefID="A"`, `QueryType` from the discriminator, JSON body = the input
+3. Calls the bound `QueryDataHandler.QueryData(ctx, ...)`
+4. Encodes the resulting `data.Frames` to JSON and returns as MCP tool output
+
+### Routes -> tools
+
+```
+Path "/labels", method GET, parameters [owner, repository, query]
+                ↓
+mcp.Tool{
+    Name:        "get_labels",
+    Description: operation.summary or operation.description,
+    InputSchema: derived from OpenAPI parameters + requestBody,
+    Handler:     callResourceHandler("/labels", "GET"),
+}
+```
+
+The handler builds a `backend.CallResourceRequest`:
+
+- `Path` = OpenAPI path with path-params substituted
+- `Method` = OpenAPI method
+- `URL.Query` = remaining args
+- `Body` = JSON of `requestBody` arg if any
+
+Path sanitization: `/labels` -> `labels`, `/repos/{owner}/{repo}/files` -> `repos_files` (path params dropped from the name; their values come from tool args).
+
+### Query examples -> resource + tool examples
+
+For each `QueryExample`:
+
+- Attach as an entry in the `examples` field of the tool whose `queryType` matches
+- Also publish a single resource `examples://query` whose body is the full examples list - useful for one-shot agent context
+
+### Things intentionally not auto-derived
+
+- Tool descriptions richer than what's in the JSON Schema. Plugins can override after registration via `mcpServer.UpdateTool(name, ...)` (escape hatch).
+- Cross-tool dependencies / call-order. Plugins can hint via Annotations; no enforcement in v1.
+- Tool aliases / hidden tools. Plugins that want a curated subset use code-level registration directly instead of `fromschema`.
+
+## Transport and lifecycle
+
+**Transport**: Streamable HTTP (the current MCP HTTP transport spec). SSE used for server-to-client streaming where the official Go SDK requires it. Stdio not used - the plugin process is long-running and already owns stdin/stdout for hashicorp go-plugin handshake.
+
+**Address resolution** (priority order):
+
+1. `GF_PLUGIN_MCP_ADDR` env var (`":7401"`, `"127.0.0.1:7401"`, or `"0.0.0.0:7401"`)
+2. `mcp.ServerOpts.Addr` if set in code
+3. Auto-pick a free port on `127.0.0.1`
+
+**Port advertisement**: when the port is auto-picked, the SDK writes `dist/mcp.addr` (sibling of the existing `dist/standalone.txt` debug file), containing `host:port\n`. Tooling and tests read this to find the live MCP endpoint.
+
+**Auth**: none in the POC. Listener binds to `127.0.0.1` by default. Per the upstream design, auth and policy belong to a gateway (e.g. MetaMCP) and are out of scope.
+
+## POC implementation
+
+### `grafana-plugin-sdk-go`
+
+- New `experimental/mcp` package (server, tools, resources, prompts)
+- New `experimental/mcp/fromschema` sub-package (query, route, examples, healthcheck walkers)
+- New `experimental/mcp/mcptest` (in-memory client for tests)
+- Extend `backend/datasource.ManageOpts` with `MCPServer *mcp.Server`
+- Extend the underlying `backend.ServeOpts` plumbing in `Manage` to wire MCP startup/shutdown
+- Unit tests: each `fromschema` walker, the bind/handler paths, lifecycle (start, shutdown, error-on-startup)
+
+### `github-datasource`
+
+- Pull in (or rebase) PR #291 to get `src/schema/v0alpha1/query.types.json` and `query.examples.json` up to date with the current SDK
+- Author `routes.json` from the existing `resource_handlers.go` routes (`/labels`, `/milestones`)
+- Update `pkg/main.go` to construct an `mcp.Server`, call the `fromschema` helpers, register one example custom prompt and pass it to `datasource.Manage`
+- Embed schema files via `embed.FS`
+
+### `redshift-datasource`
+
+- Author schema files in `src/schema/v0alpha1/` from scratch:
+  - `query.types.json` (the SQL query type, generated via `schemabuilder` like github did)
+  - `query.examples.json` (a small set of sample SQL queries)
+  - `routes.json` (`/secrets`, `/secret`, `/clusters`, `/workgroups` plus the SQL default routes - need to enumerate which of those make sense as agent tools)
+- Same `main.go` updates as github-datasource
+
+### `grafana/grafana`
+
+No changes for the POC. Per the narrowed scope, agent integration is deferred. The MCP listener is reachable directly by any MCP client. Grafana-side discovery and proxying is a follow-up effort.
+
+## Verification
+
+1. Build and run `github-datasource` and `redshift-datasource` standalone (existing magefile target)
+2. Read the address printed in logs or stored in `dist/mcp.addr`
+3. Connect with `mcp-inspector` (or curl) and verify:
+   - `tools/list` returns the expected set: one tool per query type, one tool per `/resources/*` route, plus `check_health`
+   - `tools/call` for a query-type tool returns real data with valid credentials configured
+   - `tools/call` for a route tool returns the same response as the equivalent HTTP `CallResource` request
+   - `resources/list` returns `examples://query`
+   - `prompts/list` returns the custom prompt registered in code
+4. SDK unit tests using the in-memory `mcptest` client cover each path without needing a real plugin process
+
+## Risks and mitigations
+
+**Risk: schema files drift from runtime handlers.** A query type in `query.types.json` with no matching `QueryType` discriminator at runtime would surface as a tool that always errors.
+
+Mitigation: at server startup, log a warning for any registered query tool whose discriminator does not appear in any `DataQuery.QueryType` the bound handler will accept. We don't have a way to enumerate handler-supported types automatically, so this stays as a soft warning rather than a hard fail.
+
+**Risk: route tool input schemas are weak.** OpenAPI parameter definitions can be loose, leading to tool input schemas that are imprecise.
+
+Mitigation: accept this for the POC. Plugins can override the generated tool with `mcpServer.UpdateTool(name, ...)` if they want a tighter schema.
+
+**Risk: port collisions in dev when running multiple plugins.** Two plugins both auto-pick - usually fine, but if both honor the same env var the second crashes.
+
+Mitigation: env var is opt-in and per-plugin. Auto-pick is the default. The `dist/mcp.addr` file makes the picked port discoverable.
+
+**Risk: MCP listener exposed beyond `127.0.0.1`.** A plugin operator setting `0.0.0.0` for testing leaves the unauthenticated MCP endpoint reachable on the network.
+
+Mitigation: SDK logs a warning when the bound address is non-loopback and there is no gateway in front. Hard enforcement is a gateway concern, not a plugin concern.
+
+## Open questions
+
+1. Do we want a way to mark a query type or route as MCP-hidden in the schema files? (Out of scope for the POC; a hide-list is mentioned as future work.)
+2. Should query examples become MCP `Tool.examples` exclusively, or also remain a standalone resource? (POC does both - cheap to revisit.)
+3. Should the SDK provide a `mcpServer.RegisterDefaults(schema)` convenience that calls all `fromschema` helpers in one shot? (Not for v1 - keeping the call sites explicit makes it obvious what's exposed.)
+
+## Success criteria
+
+This POC is successful if:
+
+- A plugin built on the SDK can stand up an MCP endpoint by calling the new helpers, with no duplicate authoring beyond the existing `pluginschema` files
+- Both `github-datasource` and `redshift-datasource` expose tools for every query type and every `/resources/*` route, plus `check_health`
+- An off-the-shelf MCP client can list and call those tools and read the query examples resource
+- Plugin authors can register custom tools, custom resources and prompts in code without touching schema files
+- Nothing on the existing query/resource/health gRPC path changes behavior

--- a/experimental/mcp/docs/findings.md
+++ b/experimental/mcp/docs/findings.md
@@ -1,0 +1,176 @@
+# POC Findings
+
+A running log of issues, surprises, and decisions encountered while embedding
+an MCP server inside Grafana datasource plugins (github-datasource,
+redshift-datasource) via the SDK package at
+`grafana-plugin-sdk-go/experimental/mcp`.
+
+Each entry: what was observed, the root cause, and the workaround/fix.
+
+---
+
+## 1. Anthropic API rejects tool schemas as not draft 2020-12
+
+**Observed.** Calling tools through Claude as the MCP client returned:
+
+```
+API Error: 400 tools.8.custom.input_schema: JSON schema is invalid.
+It must match JSON Schema draft 2020-12 (https://json-schema.org/draft/2020-12).
+```
+
+Only one tool index was reported, even though the issue affected every tool.
+
+**Root cause.** The plugin schema files (e.g.
+`github-datasource/pkg/schema/v0alpha1/query.types.json`) declare each query
+type's schema with:
+
+```json
+"$schema": "https://json-schema.org/draft-04/schema"
+```
+
+Anthropic's tool-use API strictly validates input schemas against
+[JSON Schema draft 2020-12](https://json-schema.org/draft/2020-12). The
+draft-04 `$schema` URI alone is enough to fail validation, regardless of
+whether the rest of the schema body is structurally compatible. The API
+stops at the first failing tool, which is why only `tools.8` was reported —
+all 20 query tools had the same problem.
+
+Beyond `$schema`, draft-04 also differs from 2020-12 in a few other ways
+that can appear in legacy plugin schemas:
+
+- `id` was renamed to `$id`.
+- `exclusiveMinimum` / `exclusiveMaximum` were booleans modifying
+  `minimum`/`maximum`; in 2020-12 they are numbers that replace them.
+- `definitions` was renamed to `$defs` (not yet seen in our schemas, but
+  worth noting for future plugins).
+
+**Fix.** Added `normalizeJSONSchema` to `experimental/mcp/server.go`. Every
+tool's `InputSchema` is normalized before being marshaled and registered
+with the underlying MCP SDK:
+
+- Recursively strip `$schema` and `id`.
+- Convert boolean `exclusiveMinimum` / `exclusiveMaximum` into the
+  2020-12 numeric form (or drop them when the boolean is `false`).
+- Walk nested `properties`, arrays, and sub-schemas without mutating the
+  caller's map.
+
+This keeps the normalization concern in the SDK so every plugin embedding
+the MCP server gets the fix without touching its schema files.
+
+---
+
+## 2. Authentication is a quick-and-dirty hack — needs a proper solution
+
+**Observed.** The MCP HTTP endpoint on `127.0.0.1:7401` (and `:7402` for
+redshift) has no authentication. Any process on the host that can reach
+loopback can call any registered tool. Tool calls reuse cached
+credentials that were captured from an earlier Grafana → plugin gRPC
+call, with no link between the calling MCP client's identity and the
+credentials being used.
+
+**Root cause / mechanism.** Plugins receive credentials via
+`backend.PluginContext.DataSourceInstanceSettings` on every gRPC request
+from Grafana. Grafana decrypts secrets per-request and passes them in.
+MCP tool calls don't originate from Grafana, so there's no
+PluginContext on the request — yet the bound handlers
+(`QueryData`/`CallResource`/`CheckHealth`) need one to talk to the
+upstream API.
+
+To bridge that gap, the SDK uses a "context capture" hack in
+`backend/datasource/manage.go`:
+
+- `contextCapture` wraps the plugin handler and intercepts every gRPC
+  call from Grafana, stashing `req.PluginContext` in a map keyed by
+  datasource UID (`mcp.Server.RegisterPluginContext`).
+- When an MCP tool call arrives on the HTTP endpoint, the server looks
+  up the cached PluginContext by `datasource_uid` (or auto-picks the
+  only one, if a single datasource is registered) and uses it to
+  build the gRPC-style request the bound handler expects.
+- The MCP HTTP server itself accepts every request — no bearer token,
+  no Grafana session cookie, no mTLS. The `server.go:194` warning
+  ("MCP listener bound to non-loopback address; auth must be handled
+  by a gateway") is the explicit acknowledgement of this.
+
+**Risks of the current approach.**
+
+- Credentials are reused across MCP callers. A PluginContext stashed
+  from a request made by user A will be reused for an MCP call from
+  any local client, regardless of who they claim to be.
+- Cached secrets can go stale (rotation, revocation, datasource
+  reconfiguration). The cache is only refreshed when Grafana next
+  calls the plugin via gRPC.
+- "Loopback-only" is the only access control. Anything with local
+  access — sidecar containers, other plugins, dev tools — can call
+  every tool with the cached credentials of every registered
+  datasource. Not safe for shared/multi-tenant hosts.
+- Tools are unconditionally callable before Grafana has ever made a
+  gRPC request: in that state the lookup fails with "no datasource
+  instance registered yet", but the endpoint itself is still open.
+
+**Long-term fix (TBD).** Options worth exploring, roughly ordered by
+how invasive they are:
+
+1. **Per-request bearer token.** Grafana mints a short-lived token tied
+   to a (user, datasource) pair, hands it to the MCP client, the MCP
+   server validates it against Grafana on every call. Closes the
+   "any local process" hole and binds credentials to the actual
+   caller.
+2. **Grafana-mediated MCP.** Grafana exposes the MCP endpoint, handles
+   auth at its existing boundary, and forwards into the plugin via
+   the existing gRPC channel — so PluginContext is built fresh per
+   request, the way Grafana already does for regular plugin calls.
+   Eliminates the cache entirely.
+3. **mTLS between Grafana and plugin's MCP endpoint.** Lower-level
+   transport auth; doesn't solve per-user credential scoping but does
+   close the "any local process" hole.
+
+For the POC, option 0 (loopback + cached PluginContext) is fine —
+flagging here so we don't ship it.
+
+---
+
+## 3. MCP runs on its own HTTP port — chosen for speed, not as the end state
+
+**Context.** When planning the POC we considered two ways to expose
+MCP from a backend datasource plugin:
+
+1. **Extend the existing plugin gRPC contract.** Add MCP-shaped RPCs
+   (list tools, call tool, read resource, get prompt) alongside the
+   existing `QueryData` / `CallResource` / `CheckHealth` methods.
+   Grafana would terminate MCP at its own boundary and forward into
+   the plugin via gRPC, the same way it handles every other plugin
+   request today.
+2. **Run a standalone HTTP server inside the plugin process.** The
+   plugin binary opens its own listener on a port (currently
+   `127.0.0.1:7401` for github, `:7402` for redshift) and speaks the
+   MCP HTTP transport directly to clients.
+
+**Decision.** We went with option 2 for the POC, because it lets us
+iterate entirely inside the plugin SDK and the plugin binaries
+without changes on the Grafana side. We can ship a working,
+testable MCP server today instead of waiting on a contract change.
+
+**Trade-offs we're accepting for now.**
+
+- **Port management is awkward.** Plugins can't read environment
+  variables, so the port has to be hardcoded in each plugin's
+  `main.go`. We hand out ports manually (`:7401`, `:7402`, …) and
+  have no allocation story for the general case.
+- **Auth has nowhere natural to live.** See finding #2 — because
+  the MCP endpoint isn't behind Grafana, there's no Grafana session
+  / user identity on the request, and we resort to caching
+  PluginContext from the gRPC side.
+- **Discovery is ad-hoc.** External clients have to know the port.
+  The SDK writes `dist/mcp.addr` next to the plugin so tools can
+  find it, but that's a workaround, not a real discovery
+  mechanism.
+- **Two transports to maintain.** The plugin now has both gRPC
+  (Grafana → plugin) and HTTP (MCP client → plugin) running side
+  by side, with their own lifecycle, error paths, and logging.
+
+**Long-term direction.** Option 1 (gRPC contract) is the more likely
+end state. It puts MCP behind Grafana's existing auth and routing,
+removes the port/discovery problem, and lets PluginContext be built
+fresh per request rather than cached. The cost is a contract change
+on the Grafana side and a longer path to a first working version —
+which is exactly the cost we wanted to defer for the POC.

--- a/experimental/mcp/docs/findings.md
+++ b/experimental/mcp/docs/findings.md
@@ -174,3 +174,169 @@ removes the port/discovery problem, and lets PluginContext be built
 fresh per request rather than cached. The cost is a contract change
 on the Grafana side and a longer path to a first working version —
 which is exactly the cost we wanted to defer for the POC.
+
+---
+
+## 4. Bundled datasource plugins don't fit the current SDK entry point
+
+**Context.** The next plugins we want MCP support in are Loki,
+Prometheus, and MySQL. Unlike github-datasource and
+redshift-datasource, these ship bundled with Grafana — they live
+under `grafana/pkg/tsdb/{loki,prometheus,mysql}` and are linked
+directly into the Grafana binary rather than running as separate
+plugin processes.
+
+**Why this breaks the current wiring.** The SDK exposes MCP through
+`MCPServer` on `datasource.ManageOpts` in
+`backend/datasource/manage.go`. `Manage()` is what an external
+plugin's `main.go` calls to stand up its gRPC server, and it's also
+where the embedded MCP listener is started and where the
+`contextCapture` PluginContext-stashing hack lives. Bundled plugins
+never go through `Manage()` — they're registered into Grafana's
+in-process plugin registry as Go services. There's no `ManageOpts`
+to hang an `MCPServer` off, no separate process to host the
+listener, and no gRPC boundary to capture PluginContext from in the
+first place.
+
+**Why the standalone-HTTP shape is also wrong for bundled plugins.**
+Even if we plumbed `mcp.Server` directly into each bundled plugin's
+service constructor, three loopback ports inside one Grafana
+process gives us none of the (already weak) isolation benefit of
+the per-plugin-process model, makes the auth story worse rather
+than better (everything is inside Grafana's auth boundary already,
+but the MCP listener sits outside it), and multiplies the
+port/discovery problems from finding #3.
+
+**Options, ordered by how invasive they are.**
+
+1. **One shared MCP server owned by Grafana; bundled plugins
+   register into it.** Grafana stands up a single `mcp.Server` as a
+   service alongside its HTTP server. Each bundled plugin's
+   `ProvideService` calls the existing
+   `BindQueryData`/`BindCallResource`/`BindCheckHealth` against
+   that shared server, namespacing its tools by datasource type.
+   Requires exposing a public construct/start/stop surface on
+   `mcp.Server` that doesn't go through `datasource.Manage`, and
+   moving the auth boundary onto Grafana's existing middleware
+   (which also lets us drop the cached-PluginContext hack — Grafana
+   has the real one in-process). This is the natural convergence
+   point with finding #2 option 2 and finding #3 option 1.
+2. **gRPC contract first, bundled second.** If we land the
+   gRPC-contract direction from finding #3 before tackling bundled
+   plugins, bundled plugins ride along for free: Grafana terminates
+   MCP at its boundary and dispatches to whichever in-process or
+   out-of-process plugin owns the tool. Bundled plugins just need
+   to implement the new contract methods. Strictly better than
+   option 1 long-term, but blocked on the same contract change.
+3. **Unbundle Loki/Prometheus/MySQL.** Run them as external plugin
+   processes again so `datasource.Manage()` works as-is. Clean from
+   an SDK perspective, but a multi-quarter project and orthogonal
+   to MCP — not realistic as a way to extend the POC.
+
+**Recommendation for the next POC step.** Option 1: extract a
+Grafana-ownable surface from `mcp.Server` (constructor + lifecycle
+that doesn't assume `Manage()` is the caller), then wire it into
+Grafana's service graph and have one bundled plugin (Loki is
+probably the most useful) bind its handlers to it. That validates
+both the shared-server model and the Grafana-side auth path before
+we commit to a contract change.
+
+---
+
+## 5. grafana-assistant only consumes MCP tools, not resources
+
+**Observed.** When connecting our embedded MCP servers to
+grafana-assistant, only the registered tools were picked up and
+made available to the model. Resources registered via
+`mcp.Server.RegisterResource` (see `experimental/mcp/resources.go`)
+are exposed correctly over the MCP transport — `resources/list`
+and `resources/read` work when probed with a generic MCP client —
+but grafana-assistant never lists or reads them.
+
+**Implication.** Any datasource context we'd want to surface as a
+read-only, addressable blob (schema dumps, dashboards, saved
+queries, docs snippets) has to be modeled as a tool call rather
+than as an MCP resource if we want grafana-assistant to actually
+use it. That changes the design trade-off: resources are the more
+natural MCP shape for "here is some context, read it if you need
+it", but right now they're effectively dead weight for the
+assistant integration.
+
+**Open questions.**
+
+- Is this a deliberate choice on the grafana-assistant side
+  (tools-only by design), or a not-yet-implemented capability?
+- If it's the former, should the SDK keep encouraging resource
+  registration at all for the assistant use case, or steer
+  plugins toward tool-shaped equivalents?
+- Prompts (`experimental/mcp/prompts.go`) are in the same boat —
+  worth confirming whether they're consumed either.
+
+**Action.** Flagging with the grafana-assistant team to confirm
+intent and timeline. Until then, plugin authors targeting the
+assistant should prefer tools over resources for any context they
+want the model to reach.
+
+---
+
+## 6. Anthropic API rejects property keys containing `[` or `]`
+
+**Observed.** With the `mcp-from-openapi` server (port 7501) wired
+into grafana-assistant as the `datasource-information` built-in
+provider, every chat turn failed. The UI showed the generic:
+
+> There was an issue with your request. Please try again or contact
+> support if the problem persists.
+
+The assistant API logs had the real error:
+
+```
+POST "https://api.anthropic.com/v1/messages": 400 Bad Request
+tools.27.custom.input_schema.properties: Property keys should match
+pattern '^[a-zA-Z0-9_.-]{1,64}$'
+```
+
+The generic UI message comes from the assistant frontend's
+`createUserFriendlyErrorMessage` mapping any `bad_request`/`400`
+to that string
+(`apps/plugin/src/utils/errorMessages.ts`), so the underlying cause
+is only visible in the API container logs.
+
+**Root cause.** Anthropic's tool-use API enforces a stricter
+property-key pattern than JSON Schema itself does: keys in
+`input_schema.properties` must match `^[a-zA-Z0-9_.-]{1,64}$`. The
+OpenAPI→MCP generator preserves the wire-level parameter name
+verbatim, so Prometheus/Loki endpoints that take a repeated
+`match[]` query parameter end up with a property literally named
+`match[]`. The `[` and `]` characters are rejected, and Anthropic
+fails the entire `messages` request at the first offending tool
+(tool 27 in our case — only one is reported even though four tools
+share the same problem).
+
+Tools affected in the current `mcp-from-openapi` output:
+
+- `loki_proxy_get`
+- `prometheus_series`
+- `prometheus_labels`
+- `prometheus_label_values`
+
+**Fix.** Rename the JSON property to `match` (no brackets) in the
+generated `inputSchema.properties`, keep `type: array`, and mention
+the wire-level `match[]` name in the property description if it
+matters for the proxy step. The `[]` suffix is a Prometheus
+query-string serialization convention for repeated parameters, not
+a JSON property-naming convention — JSON Schema already expresses
+the multi-value semantics via `type: array`.
+
+If other OpenAPI specs we ingest carry parameter names with
+characters outside `[a-zA-Z0-9_.-]` (spaces, colons, slashes,
+parentheses, names longer than 64 chars, …), the generator should
+sanitize them at the same point: rewrite the key, remember the
+original on the side, and translate back when constructing the
+outgoing HTTP request. Doing this in the generator keeps the
+assistant API free of provider-specific tool-schema patching.
+
+**Related.** Same general shape as finding #1 (Anthropic enforces
+constraints beyond plain JSON Schema). The mitigation pattern is
+the same: normalize tool schemas at registration time so that
+upstream tool authors don't have to know Anthropic's exact rules.

--- a/experimental/mcp/docs/implementation-plan.md
+++ b/experimental/mcp/docs/implementation-plan.md
@@ -1,0 +1,3045 @@
+# Datasource MCP POC Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up an embedded MCP server inside Grafana datasource plugins, driven by the existing `pluginschema` files, with `github-datasource` and `redshift-datasource` exposing tools/resources/prompts over HTTP.
+
+**Architecture:** Plugins keep their existing gRPC server. A new `experimental/mcp` package in `grafana-plugin-sdk-go` runs an MCP HTTP listener in the same process, sharing handlers (`QueryDataHandler`, `CallResourceHandler`, `CheckHealthHandler`) with gRPC. Plugin authors call schema-driven helpers (`fromschema.Register*`) plus optional code-level `Register*` calls in `main.go`.
+
+**Tech Stack:**
+- Go 1.25+
+- `github.com/grafana/grafana-plugin-sdk-go` (this repo gets the new package)
+- `github.com/modelcontextprotocol/go-sdk/mcp` (official Go MCP SDK - new dependency)
+- `github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema` (existing)
+- `github.com/grafana/grafana-plugin-sdk-go/experimental/schemabuilder` (existing)
+
+**Repos touched** (each is a separate git repo - commits per repo):
+- `grafana-plugin-sdk-go/` (Phase 1)
+- `github-datasource/` (Phase 2)
+- `redshift-datasource/` (Phase 3)
+
+**Reference docs:** Spec at `docs/superpowers/specs/2026-05-05-datasource-mcp-poc-design.md`. Before starting Task 1, fetch current `modelcontextprotocol/go-sdk` docs via context7 - the SDK API has been evolving and the code samples below assume the late-2025 API shape (`mcp.NewServer`, `mcp.AddTool`, `mcp.NewStreamableHTTPHandler`). If the current API differs, adapt the calls but keep the package structure and behavior described here.
+
+---
+
+## File Map
+
+### `grafana-plugin-sdk-go` (new files)
+
+| File | Responsibility |
+|---|---|
+| `experimental/mcp/server.go` | `Server` struct, `NewServer`, `Start`, `Shutdown`, address resolution, `dist/mcp.addr` writer |
+| `experimental/mcp/server_test.go` | Server lifecycle, address resolution |
+| `experimental/mcp/tools.go` | `Tool` struct, `RegisterTool`, `UpdateTool` |
+| `experimental/mcp/tools_test.go` | Tool registration, listing |
+| `experimental/mcp/resources.go` | `Resource` struct, `RegisterResource` |
+| `experimental/mcp/resources_test.go` | Resource registration, reading |
+| `experimental/mcp/prompts.go` | `Prompt` struct, `RegisterPrompt` |
+| `experimental/mcp/prompts_test.go` | Prompt registration |
+| `experimental/mcp/handlers.go` | `BindQueryDataHandler`, `BindCallResourceHandler`, `BindCheckHealthHandler` plus the shared execution glue |
+| `experimental/mcp/handlers_test.go` | Query/route/health execution paths |
+| `experimental/mcp/fromschema/querytypes.go` | `RegisterQueryTools(server, schema)` |
+| `experimental/mcp/fromschema/querytypes_test.go` | Walker for `QueryTypeDefinitionList` |
+| `experimental/mcp/fromschema/routes.go` | `RegisterRouteTools(server, schema)` |
+| `experimental/mcp/fromschema/routes_test.go` | OpenAPI walker, path sanitization |
+| `experimental/mcp/fromschema/examples.go` | `RegisterQueryExamples(server, schema)` |
+| `experimental/mcp/fromschema/examples_test.go` | Example attachment + `examples://query` resource |
+| `experimental/mcp/fromschema/healthcheck.go` | `RegisterHealthCheckTool(server)` |
+| `experimental/mcp/fromschema/healthcheck_test.go` | Health tool registration |
+| `experimental/mcp/mcptest/client.go` | In-memory MCP client for round-trip tests |
+| `experimental/mcp/mcptest/client_test.go` | Smoke test for the in-memory client |
+
+### `grafana-plugin-sdk-go` (modified files)
+
+| File | Change |
+|---|---|
+| `backend/datasource/manage.go` | Add `MCPServer *mcp.Server` to `ManageOpts`; start/stop alongside `backend.Manage` |
+
+### `github-datasource` (new files)
+
+> **Schema location note:** Go's `//go:embed` cannot use `..` paths, so the schema files must live within the embedding package's directory subtree. PR #291 generates files into `src/schema/` (where the TypeScript frontend can also pick them up). For this POC we generate into `pkg/schema/` instead so a Go file at `pkg/` (where `main.go` lives) can embed them. If the frontend later needs the same files, add a build step that copies `pkg/schema/` to `src/schema/`. Out of scope here.
+
+| File | Responsibility |
+|---|---|
+| `pkg/schema/v0alpha1/query.types.json` | Query type definitions (regenerate from `pkg/models` via `schemabuilder` test) |
+| `pkg/schema/v0alpha1/query.examples.json` | Query examples (regenerate alongside types) |
+| `pkg/schema/v0alpha1/routes.json` | OpenAPI 3 routes for `/labels` and `/milestones` |
+| `pkg/schema_embed.go` | `embed.FS` and a small `LoadSchema()` helper (package `main`) |
+| `pkg/schema_embed_test.go` | Verify schema loads cleanly at startup |
+
+### `github-datasource` (modified files)
+
+| File | Change |
+|---|---|
+| `pkg/main.go` | Wire MCP server, call `fromschema.Register*`, register one custom prompt |
+| `go.mod` | Bump `grafana-plugin-sdk-go` to the version produced in Phase 1 |
+| `pkg/models/query_test.go` | Bring up to date if needed (PR #291's `TestSchemaDefinitions`) |
+
+### `redshift-datasource` (new files)
+
+> Same `//go:embed` constraint as github-datasource - schema files live in `pkg/schema/` and the embed file at `pkg/`.
+
+| File | Responsibility |
+|---|---|
+| `pkg/schema/v0alpha1/query.types.json` | Generated from `pkg/redshift/models` via `schemabuilder` test |
+| `pkg/schema/v0alpha1/query.examples.json` | Sample SQL queries |
+| `pkg/schema/v0alpha1/routes.json` | OpenAPI 3 routes for `/secrets`, `/secret`, `/clusters`, `/workgroups` |
+| `pkg/redshift/models/schema_test.go` | `schemabuilder` test that emits the schema files |
+| `pkg/schema_embed.go` | `embed.FS` and `LoadSchema()` (package `main`) |
+
+### `redshift-datasource` (modified files)
+
+| File | Change |
+|---|---|
+| `pkg/main.go` | Wire MCP server, call `fromschema.Register*` |
+| `go.mod` | Bump `grafana-plugin-sdk-go` to the Phase 1 version |
+
+---
+
+## Phase 1 - SDK foundation (`grafana-plugin-sdk-go`)
+
+> Working directory for all Phase 1 tasks: `/Users/erik/code/grafana/datasource-mcp-poc/grafana-plugin-sdk-go/`. Branch off `main` with `git checkout -b feat/embedded-mcp` before Task 1.
+
+### Task 1: Add the MCP Go SDK dependency
+
+**Files:**
+- Modify: `go.mod`
+- Modify: `go.sum`
+
+- [ ] **Step 1: Fetch current SDK docs**
+
+Use context7 (`mcp__plugin_context7_context7__resolve-library-id` then `query-docs`) for `modelcontextprotocol/go-sdk` to confirm the current package path and API shape. If the API differs from what's used in subsequent tasks, note the deltas before proceeding.
+
+- [ ] **Step 2: Add the dependency**
+
+```bash
+git -C /Users/erik/code/grafana/datasource-mcp-poc/grafana-plugin-sdk-go checkout -b feat/embedded-mcp
+cd /Users/erik/code/grafana/datasource-mcp-poc/grafana-plugin-sdk-go
+go get github.com/modelcontextprotocol/go-sdk/mcp@latest
+go mod tidy
+```
+
+- [ ] **Step 3: Verify build still works**
+
+```bash
+go build ./...
+```
+Expected: clean build, no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -m "feat(mcp): add modelcontextprotocol/go-sdk dependency"
+```
+
+---
+
+### Task 2: Skeleton `Server`, `Tool`, `Resource`, `Prompt` types
+
+**Files:**
+- Create: `experimental/mcp/server.go`
+- Create: `experimental/mcp/tools.go`
+- Create: `experimental/mcp/resources.go`
+- Create: `experimental/mcp/prompts.go`
+- Create: `experimental/mcp/server_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `experimental/mcp/server_test.go`:
+
+```go
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewServer_returnsServerWithName(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "test-plugin", Version: "1.0.0"})
+	assert.NotNil(t, s)
+	assert.Equal(t, "test-plugin", s.Name())
+	assert.Equal(t, "1.0.0", s.Version())
+}
+
+func TestServer_RegisterTool_listsTool(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterTool(Tool{Name: "ping", Description: "pong"})
+	tools := s.Tools()
+	assert.Len(t, tools, 1)
+	assert.Equal(t, "ping", tools[0].Name)
+}
+
+func TestServer_RegisterResource_listsResource(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterResource(Resource{URI: "examples://query", MIMEType: "application/json"})
+	resources := s.Resources()
+	assert.Len(t, resources, 1)
+	assert.Equal(t, "examples://query", resources[0].URI)
+}
+
+func TestServer_RegisterPrompt_listsPrompt(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterPrompt(Prompt{Name: "investigate", Description: "walk it"})
+	prompts := s.Prompts()
+	assert.Len(t, prompts, 1)
+}
+```
+
+- [ ] **Step 2: Run the test - expect compile failure**
+
+```bash
+go test ./experimental/mcp/...
+```
+Expected: FAIL with "undefined: NewServer", etc.
+
+- [ ] **Step 3: Implement the skeleton**
+
+`experimental/mcp/server.go`:
+
+```go
+// Package mcp embeds an MCP server inside a Grafana datasource plugin process.
+// It binds the plugin's existing gRPC handlers (QueryData, CallResource, CheckHealth)
+// to MCP tools, exposes resources and prompts, and runs an HTTP transport alongside
+// the gRPC server.
+package mcp
+
+import "sync"
+
+// ServerOpts configures a Server.
+type ServerOpts struct {
+	Name    string
+	Version string
+	// Addr is the bind address (e.g. ":7401"). If empty, see address resolution
+	// rules in Server.Start: env var first, then auto-pick on 127.0.0.1.
+	Addr string
+}
+
+// Server is the embedded MCP server for a plugin.
+type Server struct {
+	opts      ServerOpts
+	mu        sync.RWMutex
+	tools     []Tool
+	resources []Resource
+	prompts   []Prompt
+
+	// handler bindings, populated by Bind*
+	queryDataHandler    any // backend.QueryDataHandler - typed import in handlers.go
+	callResourceHandler any // backend.CallResourceHandler
+	checkHealthHandler  any // backend.CheckHealthHandler
+}
+
+// NewServer constructs an unstarted Server.
+func NewServer(opts ServerOpts) *Server {
+	return &Server{opts: opts}
+}
+
+func (s *Server) Name() string    { return s.opts.Name }
+func (s *Server) Version() string { return s.opts.Version }
+
+// Tools returns a snapshot of registered tools.
+func (s *Server) Tools() []Tool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Tool, len(s.tools))
+	copy(out, s.tools)
+	return out
+}
+
+// Resources returns a snapshot of registered resources.
+func (s *Server) Resources() []Resource {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Resource, len(s.resources))
+	copy(out, s.resources)
+	return out
+}
+
+// Prompts returns a snapshot of registered prompts.
+func (s *Server) Prompts() []Prompt {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Prompt, len(s.prompts))
+	copy(out, s.prompts)
+	return out
+}
+```
+
+`experimental/mcp/tools.go`:
+
+```go
+package mcp
+
+import "context"
+
+// ToolHandler runs the tool. args is a JSON object decoded from the MCP call.
+// It returns the tool output (will be JSON-encoded as TextContent) or an error.
+type ToolHandler func(ctx context.Context, args map[string]any) (any, error)
+
+// Tool is a registerable MCP tool.
+type Tool struct {
+	Name        string
+	Description string
+	// InputSchema is a JSON Schema document (as a map) describing the tool's input.
+	// Pass nil for tools that take no arguments.
+	InputSchema map[string]any
+	// Annotations is a free-form metadata map exposed to MCP clients.
+	Annotations map[string]any
+	// Examples surface as the MCP tool's "examples" field.
+	Examples []any
+	// Handler is the function invoked on tools/call. Required.
+	Handler ToolHandler
+}
+
+// RegisterTool adds a tool. If a tool with the same Name already exists, it
+// is replaced (UpdateTool semantics).
+func (s *Server) RegisterTool(t Tool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, existing := range s.tools {
+		if existing.Name == t.Name {
+			s.tools[i] = t
+			return
+		}
+	}
+	s.tools = append(s.tools, t)
+}
+
+// UpdateTool is an alias for RegisterTool to make the override intent explicit
+// when callers know the tool already exists.
+func (s *Server) UpdateTool(t Tool) { s.RegisterTool(t) }
+```
+
+`experimental/mcp/resources.go`:
+
+```go
+package mcp
+
+import "context"
+
+// ResourceReader returns the resource body and its MIME type. The default
+// MIME type from the Resource struct is used if the reader returns "".
+type ResourceReader func(ctx context.Context) (body []byte, mimeType string, err error)
+
+// Resource is a registerable MCP resource.
+type Resource struct {
+	URI         string
+	Name        string
+	Description string
+	MIMEType    string
+	Reader      ResourceReader
+}
+
+func (s *Server) RegisterResource(r Resource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, existing := range s.resources {
+		if existing.URI == r.URI {
+			s.resources[i] = r
+			return
+		}
+	}
+	s.resources = append(s.resources, r)
+}
+```
+
+`experimental/mcp/prompts.go`:
+
+```go
+package mcp
+
+// Prompt is a registerable MCP prompt template.
+type Prompt struct {
+	Name        string
+	Description string
+	// Template is the literal prompt text. Argument substitution is the
+	// caller's responsibility for v1.
+	Template string
+	// Arguments declares any prompt arguments (name, description, required).
+	Arguments []PromptArgument
+}
+
+type PromptArgument struct {
+	Name        string
+	Description string
+	Required    bool
+}
+
+func (s *Server) RegisterPrompt(p Prompt) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, existing := range s.prompts {
+		if existing.Name == p.Name {
+			s.prompts[i] = p
+			return
+		}
+	}
+	s.prompts = append(s.prompts, p)
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+go test ./experimental/mcp/...
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experimental/mcp/
+git commit -m "feat(mcp): add Server skeleton with Tool/Resource/Prompt registration"
+```
+
+---
+
+### Task 3: Bind handler methods
+
+**Files:**
+- Modify: `experimental/mcp/server.go`
+- Create: `experimental/mcp/handlers.go`
+- Create: `experimental/mcp/handlers_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+`experimental/mcp/handlers_test.go`:
+
+```go
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeHandler struct {
+	queryCalledWith    *backend.QueryDataRequest
+	resourceCalledWith *backend.CallResourceRequest
+	healthCalledWith   *backend.CheckHealthRequest
+}
+
+func (f *fakeHandler) QueryData(_ context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	f.queryCalledWith = req
+	return &backend.QueryDataResponse{Responses: backend.Responses{"A": backend.DataResponse{}}}, nil
+}
+
+func (f *fakeHandler) CallResource(_ context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	f.resourceCalledWith = req
+	return sender.Send(&backend.CallResourceResponse{Status: 200, Body: []byte(`{"ok":true}`)})
+}
+
+func (f *fakeHandler) CheckHealth(_ context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	f.healthCalledWith = req
+	return &backend.CheckHealthResult{Status: backend.HealthStatusOk}, nil
+}
+
+func TestServer_Bind_storesHandlers(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	h := &fakeHandler{}
+	s.BindQueryDataHandler(h)
+	s.BindCallResourceHandler(h)
+	s.BindCheckHealthHandler(h)
+	require.NotNil(t, s.queryDataHandler)
+	require.NotNil(t, s.callResourceHandler)
+	require.NotNil(t, s.checkHealthHandler)
+	// Type assertion via accessors:
+	assert.Equal(t, h, s.QueryDataHandler())
+}
+```
+
+- [ ] **Step 2: Run the test - expect failure**
+
+```bash
+go test ./experimental/mcp/...
+```
+Expected: FAIL with "undefined: BindQueryDataHandler", etc.
+
+- [ ] **Step 3: Implement the binders**
+
+`experimental/mcp/handlers.go`:
+
+```go
+package mcp
+
+import "github.com/grafana/grafana-plugin-sdk-go/backend"
+
+// BindQueryDataHandler attaches the plugin's QueryDataHandler. Schema-driven
+// query tools registered via fromschema.RegisterQueryTools delegate to it.
+func (s *Server) BindQueryDataHandler(h backend.QueryDataHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.queryDataHandler = h
+}
+
+// BindCallResourceHandler attaches the plugin's CallResourceHandler. Route
+// tools registered via fromschema.RegisterRouteTools delegate to it.
+func (s *Server) BindCallResourceHandler(h backend.CallResourceHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.callResourceHandler = h
+}
+
+// BindCheckHealthHandler attaches the plugin's CheckHealthHandler.
+func (s *Server) BindCheckHealthHandler(h backend.CheckHealthHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.checkHealthHandler = h
+}
+
+// QueryDataHandler returns the bound handler (or nil).
+func (s *Server) QueryDataHandler() backend.QueryDataHandler {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.queryDataHandler == nil {
+		return nil
+	}
+	return s.queryDataHandler.(backend.QueryDataHandler)
+}
+
+func (s *Server) CallResourceHandler() backend.CallResourceHandler {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.callResourceHandler == nil {
+		return nil
+	}
+	return s.callResourceHandler.(backend.CallResourceHandler)
+}
+
+func (s *Server) CheckHealthHandler() backend.CheckHealthHandler {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.checkHealthHandler == nil {
+		return nil
+	}
+	return s.checkHealthHandler.(backend.CheckHealthHandler)
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+go test ./experimental/mcp/...
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experimental/mcp/handlers.go experimental/mcp/handlers_test.go
+git commit -m "feat(mcp): add Bind*Handler methods on Server"
+```
+
+---
+
+### Task 4: Query tool execution glue
+
+The shared handler converts MCP tool args into a `backend.QueryDataRequest`, calls the bound handler, and JSON-encodes the resulting frames.
+
+**Files:**
+- Modify: `experimental/mcp/handlers.go`
+- Modify: `experimental/mcp/handlers_test.go`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `experimental/mcp/handlers_test.go`:
+
+```go
+func TestExecuteQueryTool_callsHandlerAndEncodesFrames(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	h := &fakeHandler{}
+	s.BindQueryDataHandler(h)
+
+	args := map[string]any{
+		"owner":      "grafana",
+		"repository": "github-datasource",
+	}
+	out, err := s.executeQueryTool(context.Background(), "Pull_Requests", args)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	// Handler should have been called with a single DataQuery whose JSON body matches args.
+	require.NotNil(t, h.queryCalledWith)
+	require.Len(t, h.queryCalledWith.Queries, 1)
+	q := h.queryCalledWith.Queries[0]
+	assert.Equal(t, "Pull_Requests", q.QueryType)
+	assert.Equal(t, "A", q.RefID)
+	assert.JSONEq(t, `{"owner":"grafana","repository":"github-datasource"}`, string(q.JSON))
+}
+
+func TestExecuteQueryTool_errorsWhenHandlerNotBound(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	_, err := s.executeQueryTool(context.Background(), "Pull_Requests", map[string]any{})
+	assert.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run the test - expect failure**
+
+```bash
+go test ./experimental/mcp/...
+```
+Expected: FAIL with "undefined: executeQueryTool".
+
+- [ ] **Step 3: Implement**
+
+Append to `experimental/mcp/handlers.go`:
+
+```go
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// executeQueryTool is the shared handler for every query-type tool. It builds
+// a single-query QueryDataRequest with the given queryType discriminator and
+// the tool args as the JSON body, then JSON-encodes the resulting frames.
+func (s *Server) executeQueryTool(ctx context.Context, queryType string, args map[string]any) (any, error) {
+	h := s.QueryDataHandler()
+	if h == nil {
+		return nil, errors.New("no QueryDataHandler bound to MCP server")
+	}
+	body, err := json.Marshal(args)
+	if err != nil {
+		return nil, fmt.Errorf("marshal query args: %w", err)
+	}
+	req := &backend.QueryDataRequest{
+		Queries: []backend.DataQuery{{
+			RefID:     "A",
+			QueryType: queryType,
+			JSON:      body,
+		}},
+	}
+	resp, err := h.QueryData(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("QueryData failed: %w", err)
+	}
+	out := map[string]any{}
+	for refID, dr := range resp.Responses {
+		if dr.Error != nil {
+			out[refID] = map[string]any{"error": dr.Error.Error()}
+			continue
+		}
+		out[refID] = dr.Frames
+	}
+	return out, nil
+}
+```
+
+(Add the `import` lines via the existing import block - don't duplicate.)
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./experimental/mcp/... -run TestExecuteQueryTool
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experimental/mcp/
+git commit -m "feat(mcp): add executeQueryTool execution glue"
+```
+
+---
+
+### Task 5: Route tool execution glue
+
+**Files:**
+- Modify: `experimental/mcp/handlers.go`
+- Modify: `experimental/mcp/handlers_test.go`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `experimental/mcp/handlers_test.go`:
+
+```go
+func TestExecuteRouteTool_callsHandlerWithBuiltRequest(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	h := &fakeHandler{}
+	s.BindCallResourceHandler(h)
+
+	out, err := s.executeRouteTool(context.Background(), routeToolSpec{
+		Method:     "GET",
+		Path:       "/labels",
+		PathParams: nil,
+		QueryArgs:  []string{"owner", "repository"},
+	}, map[string]any{
+		"owner":      "grafana",
+		"repository": "github-datasource",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, h.resourceCalledWith)
+	assert.Equal(t, "GET", h.resourceCalledWith.Method)
+	assert.Equal(t, "/labels", h.resourceCalledWith.Path)
+	assert.Contains(t, h.resourceCalledWith.URL, "owner=grafana")
+	assert.Contains(t, h.resourceCalledWith.URL, "repository=github-datasource")
+}
+
+func TestExecuteRouteTool_substitutesPathParams(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	h := &fakeHandler{}
+	s.BindCallResourceHandler(h)
+
+	_, err := s.executeRouteTool(context.Background(), routeToolSpec{
+		Method:     "GET",
+		Path:       "/repos/{owner}/{repo}/files",
+		PathParams: []string{"owner", "repo"},
+	}, map[string]any{
+		"owner": "grafana",
+		"repo":  "github-datasource",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/repos/grafana/github-datasource/files", h.resourceCalledWith.Path)
+}
+```
+
+- [ ] **Step 2: Run the test - expect failure**
+
+```bash
+go test ./experimental/mcp/... -run TestExecuteRouteTool
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Append to `experimental/mcp/handlers.go`:
+
+```go
+import (
+	"net/url"
+	"strings"
+)
+
+// routeToolSpec describes how to translate tool args into a CallResourceRequest.
+// It is built once per tool by fromschema.RegisterRouteTools and reused on
+// every call.
+type routeToolSpec struct {
+	Method     string
+	Path       string   // OpenAPI-style path, may contain {param}
+	PathParams []string // names of path parameters in Path, e.g. {"owner","repo"}
+	QueryArgs  []string // tool arg names that go into the query string
+	BodyArg    string   // tool arg name (if any) whose value becomes the request body
+}
+
+// captureSender collects the first CallResourceResponse and is enough for v1.
+type captureSender struct{ resp *backend.CallResourceResponse }
+
+func (c *captureSender) Send(r *backend.CallResourceResponse) error {
+	if c.resp == nil {
+		c.resp = r
+	}
+	return nil
+}
+
+func (s *Server) executeRouteTool(ctx context.Context, spec routeToolSpec, args map[string]any) (any, error) {
+	h := s.CallResourceHandler()
+	if h == nil {
+		return nil, errors.New("no CallResourceHandler bound to MCP server")
+	}
+
+	// Substitute path parameters.
+	path := spec.Path
+	for _, p := range spec.PathParams {
+		v, ok := args[p]
+		if !ok {
+			return nil, fmt.Errorf("missing required path parameter %q", p)
+		}
+		path = strings.ReplaceAll(path, "{"+p+"}", fmt.Sprintf("%v", v))
+	}
+
+	// Build query string from QueryArgs that are present in args.
+	values := url.Values{}
+	for _, q := range spec.QueryArgs {
+		if v, ok := args[q]; ok && v != nil && v != "" {
+			values.Set(q, fmt.Sprintf("%v", v))
+		}
+	}
+
+	// Body, if any.
+	var body []byte
+	if spec.BodyArg != "" {
+		if v, ok := args[spec.BodyArg]; ok {
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("marshal request body: %w", err)
+			}
+			body = b
+		}
+	}
+
+	urlStr := path
+	if encoded := values.Encode(); encoded != "" {
+		urlStr = path + "?" + encoded
+	}
+
+	req := &backend.CallResourceRequest{
+		Method: spec.Method,
+		Path:   path,
+		URL:    urlStr,
+		Body:   body,
+	}
+	sender := &captureSender{}
+	if err := h.CallResource(ctx, req, sender); err != nil {
+		return nil, fmt.Errorf("CallResource failed: %w", err)
+	}
+	if sender.resp == nil {
+		return nil, errors.New("CallResource returned no response")
+	}
+	// Try JSON decode; fall back to string body.
+	if ct, _ := firstHeader(sender.resp.Headers, "Content-Type"); strings.HasPrefix(ct, "application/json") {
+		var decoded any
+		if err := json.Unmarshal(sender.resp.Body, &decoded); err == nil {
+			return decoded, nil
+		}
+	}
+	return string(sender.resp.Body), nil
+}
+
+func firstHeader(h map[string][]string, key string) (string, bool) {
+	if h == nil {
+		return "", false
+	}
+	for k, v := range h {
+		if strings.EqualFold(k, key) && len(v) > 0 {
+			return v[0], true
+		}
+	}
+	return "", false
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./experimental/mcp/... -run TestExecuteRouteTool
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experimental/mcp/
+git commit -m "feat(mcp): add executeRouteTool execution glue"
+```
+
+---
+
+### Task 6: Health check tool execution
+
+**Files:**
+- Modify: `experimental/mcp/handlers.go`
+- Modify: `experimental/mcp/handlers_test.go`
+
+- [ ] **Step 1: Add the failing test**
+
+```go
+func TestExecuteHealthTool_returnsCheckHealthResult(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	h := &fakeHandler{}
+	s.BindCheckHealthHandler(h)
+
+	out, err := s.executeHealthTool(context.Background())
+	require.NoError(t, err)
+	m, ok := out.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "OK", m["status"])
+}
+```
+
+- [ ] **Step 2: Run the test - expect failure**
+
+```bash
+go test ./experimental/mcp/... -run TestExecuteHealthTool
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```go
+func (s *Server) executeHealthTool(ctx context.Context) (any, error) {
+	h := s.CheckHealthHandler()
+	if h == nil {
+		return nil, errors.New("no CheckHealthHandler bound to MCP server")
+	}
+	res, err := h.CheckHealth(ctx, &backend.CheckHealthRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("CheckHealth failed: %w", err)
+	}
+	out := map[string]any{
+		"status":  res.Status.String(),
+		"message": res.Message,
+	}
+	if len(res.JSONDetails) > 0 {
+		var details any
+		if err := json.Unmarshal(res.JSONDetails, &details); err == nil {
+			out["details"] = details
+		}
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./experimental/mcp/...
+```
+Expected: PASS for all tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experimental/mcp/
+git commit -m "feat(mcp): add executeHealthTool execution glue"
+```
+
+---
+
+### Task 7: HTTP transport - Start and Shutdown
+
+This wires the registered tools/resources/prompts into the modelcontextprotocol/go-sdk and starts an HTTP listener.
+
+**Files:**
+- Modify: `experimental/mcp/server.go`
+- Modify: `experimental/mcp/server_test.go`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `experimental/mcp/server_test.go`:
+
+```go
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func TestServer_StartAndShutdown_listensOnEphemeralPort(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0", Addr: "127.0.0.1:0"})
+	require.NoError(t, s.Start(context.Background()))
+
+	addr := s.ListenAddr()
+	require.NotEmpty(t, addr)
+
+	// MCP HTTP endpoint should accept POST to /mcp at minimum (initialize).
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	require.NoError(t, err)
+	conn.Close()
+
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
+func TestServer_Start_failsWhenAddrInUse(t *testing.T) {
+	occupier, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer occupier.Close()
+
+	s := NewServer(ServerOpts{Name: "x", Version: "0", Addr: occupier.Addr().String()})
+	err = s.Start(context.Background())
+	assert.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run the tests - expect failure**
+
+```bash
+go test ./experimental/mcp/... -run TestServer_StartAndShutdown
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement Start/Shutdown**
+
+Append to `experimental/mcp/server.go`:
+
+```go
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	// EnvAddr is the env var that overrides the configured Addr (and forces a
+	// specific bind address, ignoring auto-pick).
+	EnvAddr = "GF_PLUGIN_MCP_ADDR"
+	// AddrFile is written next to dist/standalone.txt with host:port when the
+	// listener is bound, so external tooling can find it.
+	AddrFile = "dist/mcp.addr"
+)
+
+// resolveAddr applies the priority order: env var > opts.Addr > auto-pick on 127.0.0.1.
+func (s *Server) resolveAddr() string {
+	if v := os.Getenv(EnvAddr); v != "" {
+		return v
+	}
+	if s.opts.Addr != "" {
+		return s.opts.Addr
+	}
+	return "127.0.0.1:0"
+}
+
+// Start binds the listener and serves the MCP HTTP transport. Non-blocking:
+// returns once the listener is accepted, or an error if binding failed.
+func (s *Server) Start(ctx context.Context) error {
+	if s.httpServer != nil {
+		return errors.New("MCP server already started")
+	}
+	addr := s.resolveAddr()
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("MCP listen on %s: %w", addr, err)
+	}
+	s.listenAddr = listener.Addr().String()
+
+	// Build the underlying MCP SDK server from our registered state.
+	sdkServer := s.buildSDKServer()
+	handler := mcpsdk.NewStreamableHTTPHandler(func(*http.Request) *mcpsdk.Server { return sdkServer }, nil)
+
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", handler)
+	mux.Handle("/mcp/", handler)
+
+	s.httpServer = &http.Server{Handler: mux}
+	go func() {
+		if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.DefaultLogger.Error("MCP HTTP server stopped with error", "err", err)
+		}
+	}()
+
+	if err := s.writeAddrFile(); err != nil {
+		log.DefaultLogger.Warn("failed to write MCP addr file", "err", err)
+	}
+	if !isLoopback(s.listenAddr) {
+		log.DefaultLogger.Warn("MCP listener bound to non-loopback address; auth must be handled by a gateway", "addr", s.listenAddr)
+	}
+	log.DefaultLogger.Info("MCP server listening", "addr", s.listenAddr)
+	return nil
+}
+
+// Shutdown gracefully stops the HTTP server. Caller should pass a deadline.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.httpServer == nil {
+		return nil
+	}
+	err := s.httpServer.Shutdown(ctx)
+	s.httpServer = nil
+	_ = os.Remove(AddrFile)
+	return err
+}
+
+// ListenAddr returns the bound address (host:port) or "" if not started.
+func (s *Server) ListenAddr() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.listenAddr
+}
+
+func (s *Server) writeAddrFile() error {
+	if err := os.MkdirAll(filepath.Dir(AddrFile), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(AddrFile, []byte(s.listenAddr+"\n"), 0o644)
+}
+
+func isLoopback(hostPort string) bool {
+	host, _, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return false
+	}
+	if host == "" || host == "127.0.0.1" || host == "::1" || host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+```
+
+Add to the `Server` struct (in `server.go`):
+
+```go
+type Server struct {
+	// ... existing fields ...
+	httpServer *http.Server
+	listenAddr string
+}
+```
+
+Stub `buildSDKServer` for now (will be filled in next task):
+
+```go
+// buildSDKServer constructs the modelcontextprotocol/go-sdk Server from the
+// registered Tool/Resource/Prompt state. Called once per Start.
+func (s *Server) buildSDKServer() *mcpsdk.Server {
+	srv := mcpsdk.NewServer(&mcpsdk.Implementation{
+		Name:    s.opts.Name,
+		Version: s.opts.Version,
+	}, nil)
+	// Tools, resources, prompts will be added in Task 8.
+	return srv
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./experimental/mcp/... -run TestServer_Start
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experimental/mcp/
+git commit -m "feat(mcp): add HTTP transport with Start/Shutdown lifecycle"
+```
+
+---
+
+### Task 8: Wire registered Tools/Resources/Prompts into the SDK server
+
+**Files:**
+- Modify: `experimental/mcp/server.go`
+- Create: `experimental/mcp/mcptest/client.go`
+- Modify: `experimental/mcp/server_test.go`
+
+This task uses the in-memory `mcptest` client to round-trip a tool call through the SDK server. We build the client first (needed for the test).
+
+- [ ] **Step 1: Build the in-memory client**
+
+`experimental/mcp/mcptest/client.go`:
+
+```go
+// Package mcptest provides in-memory wiring for testing an mcp.Server end-to-end
+// without spinning up an HTTP listener.
+package mcptest
+
+import (
+	"context"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// NewClient returns a connected client+session pair backed by an in-memory
+// transport pair. The caller is responsible for closing the session.
+func NewClient(ctx context.Context, server *mcpsdk.Server) (*mcpsdk.Client, *mcpsdk.ClientSession, error) {
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
+	clientT, serverT := mcpsdk.NewInMemoryTransports()
+
+	// Connect server side in background.
+	go func() { _, _ = server.Connect(ctx, serverT, nil) }()
+
+	session, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	return client, session, nil
+}
+```
+
+(If the current SDK API names differ - e.g. `NewInMemoryTransports` is named differently - adjust here. The test in step 3 will reveal mismatches immediately.)
+
+- [ ] **Step 2: Add the failing tests**
+
+Append to `experimental/mcp/server_test.go`:
+
+```go
+func TestServer_buildSDKServer_listsRegisteredTools(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterTool(Tool{
+		Name:        "ping",
+		Description: "pong",
+		Handler: func(ctx context.Context, args map[string]any) (any, error) {
+			return "pong", nil
+		},
+	})
+
+	sdk := s.buildSDKServer()
+	ctx := context.Background()
+	_, session, err := mcptest.NewClient(ctx, sdk)
+	require.NoError(t, err)
+	defer session.Close()
+
+	res, err := session.ListTools(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Tools, 1)
+	assert.Equal(t, "ping", res.Tools[0].Name)
+}
+
+func TestServer_buildSDKServer_callsToolHandler(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterTool(Tool{
+		Name:        "echo",
+		Description: "echo",
+		InputSchema: map[string]any{"type": "object"},
+		Handler: func(ctx context.Context, args map[string]any) (any, error) {
+			return args, nil
+		},
+	})
+
+	sdk := s.buildSDKServer()
+	ctx := context.Background()
+	_, session, err := mcptest.NewClient(ctx, sdk)
+	require.NoError(t, err)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "echo",
+		Arguments: map[string]any{"hello": "world"},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Content)
+	textContent, ok := res.Content[0].(*mcpsdk.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, textContent.Text, `"hello":"world"`)
+}
+```
+
+Add the import for `mcptest` and `mcpsdk` at the top of `server_test.go`:
+
+```go
+import (
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/mcptest"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+```
+
+- [ ] **Step 3: Run the tests - expect failure**
+
+```bash
+go test ./experimental/mcp/... -run TestServer_buildSDKServer
+```
+Expected: FAIL - tools/resources/prompts not yet wired into the SDK server.
+
+- [ ] **Step 4: Implement wiring**
+
+Replace `buildSDKServer` in `server.go`:
+
+```go
+import "encoding/json"
+
+func (s *Server) buildSDKServer() *mcpsdk.Server {
+	srv := mcpsdk.NewServer(&mcpsdk.Implementation{
+		Name:    s.opts.Name,
+		Version: s.opts.Version,
+	}, nil)
+
+	for _, t := range s.Tools() {
+		t := t // capture
+		sdkTool := &mcpsdk.Tool{
+			Name:        t.Name,
+			Description: t.Description,
+		}
+		if t.InputSchema != nil {
+			raw, _ := json.Marshal(t.InputSchema)
+			sdkTool.InputSchema = json.RawMessage(raw)
+		}
+		mcpsdk.AddTool(srv, sdkTool, func(ctx context.Context, _ *mcpsdk.ServerSession, req *mcpsdk.CallToolParamsFor[map[string]any]) (*mcpsdk.CallToolResultFor[any], error) {
+			args := req.Arguments
+			out, err := t.Handler(ctx, args)
+			if err != nil {
+				return &mcpsdk.CallToolResultFor[any]{
+					IsError: true,
+					Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: err.Error()}},
+				}, nil
+			}
+			body, err := json.Marshal(out)
+			if err != nil {
+				return nil, err
+			}
+			return &mcpsdk.CallToolResultFor[any]{
+				Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: string(body)}},
+			}, nil
+		})
+	}
+
+	for _, r := range s.Resources() {
+		r := r
+		sdkRes := &mcpsdk.Resource{
+			URI:         r.URI,
+			Name:        r.Name,
+			Description: r.Description,
+			MIMEType:    r.MIMEType,
+		}
+		srv.AddResource(sdkRes, func(ctx context.Context, _ *mcpsdk.ServerSession, _ *mcpsdk.ReadResourceParams) (*mcpsdk.ReadResourceResult, error) {
+			body, mimeType, err := r.Reader(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if mimeType == "" {
+				mimeType = r.MIMEType
+			}
+			return &mcpsdk.ReadResourceResult{
+				Contents: []*mcpsdk.ResourceContents{{
+					URI:      r.URI,
+					MIMEType: mimeType,
+					Text:     string(body),
+				}},
+			}, nil
+		})
+	}
+
+	for _, p := range s.Prompts() {
+		p := p
+		args := make([]*mcpsdk.PromptArgument, 0, len(p.Arguments))
+		for _, a := range p.Arguments {
+			args = append(args, &mcpsdk.PromptArgument{
+				Name:        a.Name,
+				Description: a.Description,
+				Required:    a.Required,
+			})
+		}
+		srv.AddPrompt(&mcpsdk.Prompt{
+			Name:        p.Name,
+			Description: p.Description,
+			Arguments:   args,
+		}, func(ctx context.Context, _ *mcpsdk.ServerSession, _ *mcpsdk.GetPromptParams) (*mcpsdk.GetPromptResult, error) {
+			return &mcpsdk.GetPromptResult{
+				Messages: []*mcpsdk.PromptMessage{{
+					Role:    "user",
+					Content: &mcpsdk.TextContent{Text: p.Template},
+				}},
+			}, nil
+		})
+	}
+
+	return srv
+}
+```
+
+> Note: the exact SDK call signatures (`AddTool`, `AddResource`, `AddPrompt`, `Connect`, `NewInMemoryTransports`, `CallToolParamsFor[T]`, etc.) are based on the late-2025 modelcontextprotocol/go-sdk shape. If the version pulled in Task 1 differs, adapt the SDK calls but keep the wrapping logic and the `Tool/Resource/Prompt` API stable - we want plugins not to care about SDK churn.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+go test ./experimental/mcp/...
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add experimental/mcp/
+git commit -m "feat(mcp): wire registered tools/resources/prompts into SDK server"
+```
+
+---
+
+### Task 9: `fromschema.RegisterHealthCheckTool`
+
+The simplest schema helper. Does not actually read the schema - just registers the standard `check_health` tool when the server has `BindCheckHealthHandler` called.
+
+**Files:**
+- Create: `experimental/mcp/fromschema/healthcheck.go`
+- Create: `experimental/mcp/fromschema/healthcheck_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+`experimental/mcp/fromschema/healthcheck_test.go`:
+
+```go
+package fromschema_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type healthOnly struct{}
+
+func (healthOnly) CheckHealth(_ context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	return &backend.CheckHealthResult{Status: backend.HealthStatusOk, Message: "ok"}, nil
+}
+
+func TestRegisterHealthCheckTool_addsCheckHealthTool(t *testing.T) {
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	s.BindCheckHealthHandler(healthOnly{})
+
+	fromschema.RegisterHealthCheckTool(s)
+
+	tools := s.Tools()
+	require.Len(t, tools, 1)
+	assert.Equal(t, "check_health", tools[0].Name)
+}
+```
+
+- [ ] **Step 2: Run the test - expect failure**
+
+```bash
+go test ./experimental/mcp/fromschema/...
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`experimental/mcp/fromschema/healthcheck.go`:
+
+```go
+// Package fromschema turns a pluginschema.PluginSchema and a bound mcp.Server
+// into registered tools/resources. Each Register* helper is independent and
+// idempotent.
+package fromschema
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+)
+
+// RegisterHealthCheckTool adds a "check_health" tool that delegates to the
+// CheckHealthHandler bound on the server. Safe to call before BindCheckHealthHandler;
+// the tool will surface an error at call time if the handler is missing.
+func RegisterHealthCheckTool(s *mcp.Server) {
+	s.RegisterTool(mcp.Tool{
+		Name:        "check_health",
+		Description: "Run the datasource's health check",
+		InputSchema: map[string]any{"type": "object"},
+		Handler: func(ctx context.Context, _ map[string]any) (any, error) {
+			return s.ExecuteHealthTool(ctx)
+		},
+	})
+}
+```
+
+`fromschema` cannot reach unexported `executeHealthTool`. Expose it from the `mcp` package - add to `experimental/mcp/handlers.go`:
+
+```go
+// ExecuteHealthTool is the public entry point used by fromschema to delegate to
+// the bound CheckHealthHandler.
+func (s *Server) ExecuteHealthTool(ctx context.Context) (any, error) {
+	return s.executeHealthTool(ctx)
+}
+
+// ExecuteQueryTool is exported for fromschema.RegisterQueryTools.
+func (s *Server) ExecuteQueryTool(ctx context.Context, queryType string, args map[string]any) (any, error) {
+	return s.executeQueryTool(ctx, queryType, args)
+}
+
+// ExecuteRouteTool is exported for fromschema.RegisterRouteTools.
+func (s *Server) ExecuteRouteTool(ctx context.Context, spec RouteToolSpec, args map[string]any) (any, error) {
+	return s.executeRouteTool(ctx, routeToolSpec(spec), args)
+}
+
+// RouteToolSpec is the public mirror of routeToolSpec.
+type RouteToolSpec = routeToolSpec
+```
+
+(Type alias keeps the public name capitalized while reusing the same struct.)
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./experimental/mcp/...
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experimental/mcp/
+git commit -m "feat(mcp): add fromschema.RegisterHealthCheckTool"
+```
+
+---
+
+### Task 10: `fromschema.RegisterQueryTools`
+
+**Files:**
+- Create: `experimental/mcp/fromschema/querytypes.go`
+- Create: `experimental/mcp/fromschema/querytypes_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+`experimental/mcp/fromschema/querytypes_test.go`:
+
+```go
+package fromschema_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type queryOnly struct{ lastReq *backend.QueryDataRequest }
+
+func (q *queryOnly) QueryData(_ context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	q.lastReq = req
+	return &backend.QueryDataResponse{}, nil
+}
+
+func TestRegisterQueryTools_addsOneToolPerQueryType(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		QueryTypes: &sdkapi.QueryTypeDefinitionList{
+			Items: []sdkapi.QueryTypeDefinition{
+				{
+					ObjectMeta: sdkapi.ObjectMeta{Name: "Pull_Requests"},
+					Spec: sdkapi.QueryTypeDefinitionSpec{
+						Discriminators: []sdkapi.DiscriminatorFieldValue{{Field: "queryType", Value: "Pull_Requests"}},
+						Schema:         sdkapi.JSONSchema{Spec: json.RawMessage(`{"type":"object"}`)},
+					},
+				},
+				{
+					ObjectMeta: sdkapi.ObjectMeta{Name: "Issues"},
+					Spec: sdkapi.QueryTypeDefinitionSpec{
+						Discriminators: []sdkapi.DiscriminatorFieldValue{{Field: "queryType", Value: "Issues"}},
+						Schema:         sdkapi.JSONSchema{Spec: json.RawMessage(`{"type":"object"}`)},
+					},
+				},
+			},
+		},
+	}
+
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	q := &queryOnly{}
+	s.BindQueryDataHandler(q)
+	fromschema.RegisterQueryTools(s, schema)
+
+	tools := s.Tools()
+	require.Len(t, tools, 2)
+	names := []string{tools[0].Name, tools[1].Name}
+	assert.Contains(t, names, "query_Pull_Requests")
+	assert.Contains(t, names, "query_Issues")
+}
+
+func TestRegisterQueryTools_handlerCallsBoundQueryData(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		QueryTypes: &sdkapi.QueryTypeDefinitionList{
+			Items: []sdkapi.QueryTypeDefinition{{
+				ObjectMeta: sdkapi.ObjectMeta{Name: "Pull_Requests"},
+				Spec: sdkapi.QueryTypeDefinitionSpec{
+					Discriminators: []sdkapi.DiscriminatorFieldValue{{Field: "queryType", Value: "Pull_Requests"}},
+					Schema:         sdkapi.JSONSchema{Spec: json.RawMessage(`{"type":"object"}`)},
+				},
+			}},
+		},
+	}
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	q := &queryOnly{}
+	s.BindQueryDataHandler(q)
+	fromschema.RegisterQueryTools(s, schema)
+
+	tool := s.Tools()[0]
+	_, err := tool.Handler(context.Background(), map[string]any{"owner": "grafana"})
+	require.NoError(t, err)
+	require.NotNil(t, q.lastReq)
+	require.Len(t, q.lastReq.Queries, 1)
+	assert.Equal(t, "Pull_Requests", q.lastReq.Queries[0].QueryType)
+}
+
+func TestRegisterQueryTools_skipsWhenSchemaHasNoQueryTypes(t *testing.T) {
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	fromschema.RegisterQueryTools(s, &pluginschema.PluginSchema{})
+	assert.Empty(t, s.Tools())
+}
+```
+
+> Note: `sdkapi.JSONSchema` exposes `Spec` as `json.RawMessage` (or whatever the current SDK shape is). Inspect `experimental/apis/datasource/v0alpha1/query_definition.go` if the type differs and adjust.
+
+- [ ] **Step 2: Run the tests - expect failure**
+
+```bash
+go test ./experimental/mcp/fromschema/... -run TestRegisterQueryTools
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`experimental/mcp/fromschema/querytypes.go`:
+
+```go
+package fromschema
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+)
+
+// RegisterQueryTools adds one MCP tool per QueryTypeDefinition in the schema.
+// Each tool's name is "query_<discriminator-value>", its InputSchema is the
+// query type's JSON Schema, and its handler delegates to the bound QueryDataHandler.
+func RegisterQueryTools(s *mcp.Server, schema *pluginschema.PluginSchema) {
+	if schema == nil || schema.QueryTypes == nil {
+		return
+	}
+	for _, qt := range schema.QueryTypes.Items {
+		discValue := qt.ObjectMeta.Name
+		if len(qt.Spec.Discriminators) > 0 && qt.Spec.Discriminators[0].Value != "" {
+			discValue = qt.Spec.Discriminators[0].Value
+		}
+
+		var inputSchema map[string]any
+		if raw := schemaSpec(qt.Spec.Schema); len(raw) > 0 {
+			_ = json.Unmarshal(raw, &inputSchema)
+		}
+
+		queryType := discValue
+		s.RegisterTool(mcp.Tool{
+			Name:        "query_" + discValue,
+			Description: fmt.Sprintf("Run a %s query against the datasource", discValue),
+			InputSchema: inputSchema,
+			Annotations: map[string]any{"queryType": queryType},
+			Handler: func(ctx context.Context, args map[string]any) (any, error) {
+				return s.ExecuteQueryTool(ctx, queryType, args)
+			},
+		})
+	}
+}
+
+// schemaSpec returns the JSON-serialized form of the JSON Schema, regardless of
+// whether the SDK type wraps a raw message or a structured spec object.
+func schemaSpec(s sdkapi.JSONSchema) []byte {
+	// JSONSchema in v0alpha1 is currently structured around an embedded *spec.Schema.
+	// Marshalling the wrapper back to JSON yields the raw schema doc.
+	b, err := json.Marshal(s)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+```
+
+> Note: `JSONSchema` in `v0alpha1` may be a thin wrapper around `*spec.Schema`. The marshal-then-pass approach handles either layout uniformly. Verify by looking at `experimental/apis/datasource/v0alpha1/query_definition.go` and `unstructured.go` and adjust if marshalling adds a wrapper key (in which case unwrap to the inner schema).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./experimental/mcp/fromschema/... -run TestRegisterQueryTools
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experimental/mcp/fromschema/
+git commit -m "feat(mcp): add fromschema.RegisterQueryTools"
+```
+
+---
+
+### Task 11: `fromschema.RegisterRouteTools`
+
+**Files:**
+- Create: `experimental/mcp/fromschema/routes.go`
+- Create: `experimental/mcp/fromschema/routes_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+`experimental/mcp/fromschema/routes_test.go`:
+
+```go
+package fromschema_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+type resourceOnly struct{ lastReq *backend.CallResourceRequest }
+
+func (r *resourceOnly) CallResource(_ context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	r.lastReq = req
+	return sender.Send(&backend.CallResourceResponse{Status: 200, Body: []byte(`{"ok":true}`)})
+}
+
+func TestRegisterRouteTools_addsToolsForResourceRoutes(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		Routes: &pluginschema.Routes{
+			Paths: map[string]*spec3.Path{
+				"/resources/labels": {
+					PathProps: spec3.PathProps{
+						Get: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+								Summary: "List GitHub labels",
+								Parameters: []*spec3.Parameter{
+									{ParameterProps: spec3.ParameterProps{Name: "owner", In: "query", Required: true, Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}}}},
+									{ParameterProps: spec3.ParameterProps{Name: "repository", In: "query", Required: true, Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}}}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	r := &resourceOnly{}
+	s.BindCallResourceHandler(r)
+	fromschema.RegisterRouteTools(s, schema)
+
+	tools := s.Tools()
+	require.Len(t, tools, 1)
+	// Tool name strips the /resources/ prefix - this matches the path that
+	// CallResourceHandler actually sees at runtime.
+	assert.Equal(t, "get_labels", tools[0].Name)
+	assert.Equal(t, "List GitHub labels", tools[0].Description)
+}
+
+func TestRegisterRouteTools_skipsProxyRoutes(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		Routes: &pluginschema.Routes{
+			Paths: map[string]*spec3.Path{
+				"/proxy/foo": {PathProps: spec3.PathProps{Get: &spec3.Operation{}}},
+			},
+		},
+	}
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	fromschema.RegisterRouteTools(s, schema)
+	assert.Empty(t, s.Tools())
+}
+
+func TestRegisterRouteTools_handlerCallsBoundCallResource(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		Routes: &pluginschema.Routes{
+			Paths: map[string]*spec3.Path{
+				"/resources/labels": {PathProps: spec3.PathProps{Get: &spec3.Operation{}}},
+			},
+		},
+	}
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	r := &resourceOnly{}
+	s.BindCallResourceHandler(r)
+	fromschema.RegisterRouteTools(s, schema)
+
+	_, err := s.Tools()[0].Handler(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	require.NotNil(t, r.lastReq)
+	assert.Equal(t, "GET", r.lastReq.Method)
+	// CallResourceHandler sees the path WITHOUT the /resources/ prefix
+	// (Grafana strips it before forwarding; we mirror that behavior).
+	assert.Equal(t, "/labels", r.lastReq.Path)
+}
+```
+
+- [ ] **Step 2: Run the tests - expect failure**
+
+```bash
+go test ./experimental/mcp/fromschema/... -run TestRegisterRouteTools
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`experimental/mcp/fromschema/routes.go`:
+
+```go
+package fromschema
+
+import (
+	"context"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+	"k8s.io/kube-openapi/pkg/spec3"
+)
+
+// RegisterRouteTools adds one MCP tool per (path, method) pair under /resources/*.
+// /proxy/* paths are skipped.
+//
+// The /resources/ prefix is stripped both from the tool name and from the path
+// passed to CallResourceHandler at runtime - Grafana strips that prefix before
+// forwarding resource calls to the plugin, so the plugin's handler sees e.g.
+// "/labels", not "/resources/labels".
+func RegisterRouteTools(s *mcp.Server, schema *pluginschema.PluginSchema) {
+	if schema == nil || schema.Routes == nil {
+		return
+	}
+	for schemaPath, p := range schema.Routes.Paths {
+		if !strings.HasPrefix(schemaPath, "/resources/") {
+			continue
+		}
+		runtimePath := strings.TrimPrefix(schemaPath, "/resources")
+		registerOpIfPresent(s, "GET", runtimePath, p.Get)
+		registerOpIfPresent(s, "POST", runtimePath, p.Post)
+		registerOpIfPresent(s, "PUT", runtimePath, p.Put)
+		registerOpIfPresent(s, "DELETE", runtimePath, p.Delete)
+		registerOpIfPresent(s, "PATCH", runtimePath, p.Patch)
+	}
+}
+
+func registerOpIfPresent(s *mcp.Server, method, path string, op *spec3.Operation) {
+	if op == nil {
+		return
+	}
+	spec := mcp.RouteToolSpec{
+		Method: method,
+		Path:   path,
+	}
+	inputProps := map[string]any{}
+	required := []string{}
+	for _, param := range op.Parameters {
+		if param == nil {
+			continue
+		}
+		switch param.In {
+		case "path":
+			spec.PathParams = append(spec.PathParams, param.Name)
+		case "query":
+			spec.QueryArgs = append(spec.QueryArgs, param.Name)
+		}
+		// Add to input schema regardless of `In` so the tool exposes it.
+		inputProps[param.Name] = paramToSchema(param)
+		if param.Required {
+			required = append(required, param.Name)
+		}
+	}
+	if op.RequestBody != nil {
+		spec.BodyArg = "body"
+		inputProps["body"] = map[string]any{"type": "object"}
+		required = append(required, "body")
+	}
+
+	inputSchema := map[string]any{
+		"type":       "object",
+		"properties": inputProps,
+	}
+	if len(required) > 0 {
+		inputSchema["required"] = required
+	}
+
+	desc := op.Summary
+	if desc == "" {
+		desc = op.Description
+	}
+	if desc == "" {
+		desc = method + " " + path
+	}
+
+	s.RegisterTool(mcp.Tool{
+		Name:        toolName(method, path),
+		Description: desc,
+		InputSchema: inputSchema,
+		Handler: func(ctx context.Context, args map[string]any) (any, error) {
+			return s.ExecuteRouteTool(ctx, spec, args)
+		},
+	})
+}
+
+func paramToSchema(p *spec3.Parameter) map[string]any {
+	out := map[string]any{}
+	if p.Schema != nil && len(p.Schema.Type) > 0 {
+		out["type"] = p.Schema.Type[0]
+	} else {
+		out["type"] = "string"
+	}
+	if p.Description != "" {
+		out["description"] = p.Description
+	}
+	return out
+}
+
+// toolName converts (GET, "/resources/labels") to "get_resources_labels".
+// Path params are dropped from the name (their values come from tool args).
+func toolName(method, path string) string {
+	m := strings.ToLower(method)
+	parts := []string{m}
+	for _, seg := range strings.Split(strings.Trim(path, "/"), "/") {
+		if seg == "" || strings.HasPrefix(seg, "{") {
+			continue
+		}
+		parts = append(parts, seg)
+	}
+	return strings.Join(parts, "_")
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./experimental/mcp/fromschema/... -run TestRegisterRouteTools
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experimental/mcp/fromschema/
+git commit -m "feat(mcp): add fromschema.RegisterRouteTools"
+```
+
+---
+
+### Task 12: `fromschema.RegisterQueryExamples`
+
+**Files:**
+- Create: `experimental/mcp/fromschema/examples.go`
+- Create: `experimental/mcp/fromschema/examples_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package fromschema_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterQueryExamples_publishesResourceAndAttachesExamples(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		QueryTypes: &sdkapi.QueryTypeDefinitionList{
+			Items: []sdkapi.QueryTypeDefinition{{
+				ObjectMeta: sdkapi.ObjectMeta{Name: "Pull_Requests"},
+				Spec: sdkapi.QueryTypeDefinitionSpec{
+					Discriminators: []sdkapi.DiscriminatorFieldValue{{Field: "queryType", Value: "Pull_Requests"}},
+					Schema:         sdkapi.JSONSchema{Spec: json.RawMessage(`{"type":"object"}`)},
+				},
+			}},
+		},
+		QueryExamples: &sdkapi.QueryExamples{Examples: []sdkapi.QueryExample{
+			{Name: "Simple", QueryType: "Pull_Requests", SaveModel: sdkapi.AsUnstructured(map[string]any{"owner": "grafana"})},
+		}},
+	}
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	fromschema.RegisterQueryTools(s, schema)
+	fromschema.RegisterQueryExamples(s, schema)
+
+	// Resource registered.
+	resources := s.Resources()
+	require.Len(t, resources, 1)
+	assert.Equal(t, "examples://query", resources[0].URI)
+	body, _, err := resources[0].Reader(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Pull_Requests")
+
+	// Example attached to the matching tool.
+	for _, t2 := range s.Tools() {
+		if t2.Name == "query_Pull_Requests" {
+			require.Len(t, t2.Examples, 1)
+			return
+		}
+	}
+	t.Fatalf("query_Pull_Requests tool not found")
+}
+```
+
+- [ ] **Step 2: Run - expect failure**
+
+```bash
+go test ./experimental/mcp/fromschema/... -run TestRegisterQueryExamples
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+`experimental/mcp/fromschema/examples.go`:
+
+```go
+package fromschema
+
+import (
+	"context"
+	"encoding/json"
+
+	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+)
+
+// RegisterQueryExamples publishes a single resource "examples://query" listing
+// every QueryExample, and attaches each example to the corresponding tool's
+// Examples field. Must be called after RegisterQueryTools so the tools exist.
+func RegisterQueryExamples(s *mcp.Server, schema *pluginschema.PluginSchema) {
+	if schema == nil || schema.QueryExamples == nil {
+		return
+	}
+	body, err := json.MarshalIndent(schema.QueryExamples, "", "  ")
+	if err != nil {
+		body = []byte("{}")
+	}
+	s.RegisterResource(mcp.Resource{
+		URI:         "examples://query",
+		Name:        "Query examples",
+		Description: "Datasource-specific query examples grouped by queryType",
+		MIMEType:    "application/json",
+		Reader: func(_ context.Context) ([]byte, string, error) {
+			return body, "application/json", nil
+		},
+	})
+
+	// Attach each example to its matching tool, if registered.
+	byName := map[string]*sdkapi.QueryExample{}
+	for i := range schema.QueryExamples.Examples {
+		ex := &schema.QueryExamples.Examples[i]
+		byName[ex.QueryType] = ex
+	}
+	for _, t := range s.Tools() {
+		qt, ok := t.Annotations["queryType"].(string)
+		if !ok {
+			continue
+		}
+		ex, ok := byName[qt]
+		if !ok {
+			continue
+		}
+		t.Examples = append(t.Examples, ex.SaveModel.Object)
+		s.UpdateTool(t)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./experimental/mcp/fromschema/...
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experimental/mcp/fromschema/
+git commit -m "feat(mcp): add fromschema.RegisterQueryExamples"
+```
+
+---
+
+### Task 13: Lifecycle integration with `datasource.Manage` + handler accessor
+
+`automanagement.NewManager` is in `internal/`, so plugins can't import it directly. We add a public accessor in `backend/datasource/` so plugins can bind the same handler to MCP that `Manage` will use for gRPC.
+
+**Files:**
+- Modify: `backend/datasource/manage.go`
+- Create: `backend/datasource/manage_mcp_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+`backend/datasource/manage_mcp_test.go`:
+
+```go
+package datasource
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartMCPServer_startsAndStops(t *testing.T) {
+	s := mcp.NewServer(mcp.ServerOpts{Name: "test", Version: "1.0", Addr: "127.0.0.1:0"})
+	require.NoError(t, startMCPServer(s))
+	addr := s.ListenAddr()
+	require.NotEmpty(t, addr)
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	require.NoError(t, err)
+	conn.Close()
+	require.NoError(t, stopMCPServer(s))
+}
+
+func TestStartMCPServer_logsAndContinuesOnError(t *testing.T) {
+	occupier, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer occupier.Close()
+
+	s := mcp.NewServer(mcp.ServerOpts{Name: "test", Version: "1.0", Addr: occupier.Addr().String()})
+	// Should not panic and should not fail Manage.
+	err = startMCPServer(s)
+	assert.NoError(t, err) // we swallow the error and log it
+	assert.Empty(t, s.ListenAddr())
+}
+
+func TestNewAutomanagementHandler_returnsHandler(t *testing.T) {
+	im := NewInstanceManager(func(_ context.Context, _ backend.PluginContext) (instancemgmt.Instance, error) {
+		return struct{}{}, nil
+	})
+	h := NewAutomanagementHandler(im)
+	require.NotNil(t, h)
+	// The returned handler implements all four interfaces.
+	_, isQuery := any(h).(backend.QueryDataHandler)
+	_, isResource := any(h).(backend.CallResourceHandler)
+	_, isHealth := any(h).(backend.CheckHealthHandler)
+	assert.True(t, isQuery)
+	assert.True(t, isResource)
+	assert.True(t, isHealth)
+}
+```
+
+- [ ] **Step 2: Run - expect failure**
+
+```bash
+go test ./backend/datasource/... -run TestStartMCPServer
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Modify `manage.go`**
+
+```go
+package datasource
+
+import (
+	"context"
+	// existing imports ...
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+)
+
+// ManageOpts can modify Manage behavior.
+type ManageOpts struct {
+	// existing fields ...
+
+	// MCPServer, if non-nil, is started alongside the gRPC plugin server and
+	// shut down on plugin termination. MCP startup failures are logged but do
+	// not prevent the plugin from running.
+	MCPServer *mcp.Server
+}
+
+// Manage starts serving the data source over gPRC with automatic instance management.
+func Manage(pluginID string, instanceFactory InstanceFactoryFunc, opts ManageOpts) error {
+	if buildinfo.InfoModeEnabled() {
+		// existing block ...
+	}
+
+	backend.SetupPluginEnvironment(pluginID)
+	if err := backend.SetupTracer(pluginID, opts.TracingOpts); err != nil {
+		return fmt.Errorf("setup tracer: %w", err)
+	}
+	handler := automanagement.NewManager(NewInstanceManager(instanceFactory))
+
+	if opts.MCPServer != nil {
+		if err := startMCPServer(opts.MCPServer); err != nil {
+			// startMCPServer never returns errors today; left for future hard-fail option.
+			log.DefaultLogger.Warn("MCP server startup error", "err", err)
+		}
+		defer func() {
+			if err := stopMCPServer(opts.MCPServer); err != nil {
+				log.DefaultLogger.Warn("MCP server shutdown error", "err", err)
+			}
+		}()
+	}
+
+	return backend.Manage(pluginID, backend.ServeOpts{
+		// ... existing fields ...
+	})
+}
+
+// startMCPServer starts the MCP server. Errors are logged and swallowed; the
+// plugin continues without MCP if startup fails (e.g. port in use).
+func startMCPServer(s *mcp.Server) error {
+	if err := s.Start(context.Background()); err != nil {
+		log.DefaultLogger.Warn("MCP server failed to start - continuing without MCP", "err", err)
+		return nil
+	}
+	return nil
+}
+
+func stopMCPServer(s *mcp.Server) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return s.Shutdown(ctx)
+}
+
+// PluginHandler is the union of handler interfaces an automanagement-backed
+// plugin handler implements. Plugins use this to bind the same handler to
+// both gRPC (via Manage) and MCP (via mcp.Server.Bind*).
+type PluginHandler interface {
+	backend.QueryDataHandler
+	backend.CallResourceHandler
+	backend.CheckHealthHandler
+	backend.StreamHandler
+}
+
+// NewAutomanagementHandler wraps the given InstanceManager with the SDK's
+// automanagement layer and returns the resulting handler. The returned value
+// implements PluginHandler. Plugins bind this to mcp.Server then pass the same
+// instance factory through datasource.Manage.
+func NewAutomanagementHandler(im instancemgmt.InstanceManager) PluginHandler {
+	return automanagement.NewManager(im)
+}
+```
+
+> Add the import for `instancemgmt` and `automanagement` if they aren't already present in `manage.go`. `automanagement` is already imported in the file from the existing implementation.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./backend/datasource/...
+go test ./experimental/mcp/...
+```
+Expected: PASS for both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/datasource/ experimental/mcp/
+git commit -m "feat(mcp): integrate MCP server lifecycle into datasource.Manage"
+```
+
+---
+
+### Task 14: Phase 1 integration smoke test
+
+**Files:**
+- Create: `experimental/mcp/integration_test.go`
+
+A round-trip test that registers everything via `fromschema`, starts a real HTTP listener, calls a query tool, and verifies the bound handler was invoked.
+
+- [ ] **Step 1: Write the integration test**
+
+```go
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubDS struct{ qReq *backend.QueryDataRequest }
+
+func (s *stubDS) QueryData(_ context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	s.qReq = req
+	return &backend.QueryDataResponse{}, nil
+}
+func (s *stubDS) CallResource(_ context.Context, _ *backend.CallResourceRequest, _ backend.CallResourceResponseSender) error {
+	return nil
+}
+func (s *stubDS) CheckHealth(_ context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	return &backend.CheckHealthResult{Status: backend.HealthStatusOk}, nil
+}
+
+func TestEndToEnd_registerStartCallTool(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		QueryTypes: &sdkapi.QueryTypeDefinitionList{
+			Items: []sdkapi.QueryTypeDefinition{{
+				ObjectMeta: sdkapi.ObjectMeta{Name: "Pull_Requests"},
+				Spec: sdkapi.QueryTypeDefinitionSpec{
+					Discriminators: []sdkapi.DiscriminatorFieldValue{{Field: "queryType", Value: "Pull_Requests"}},
+					Schema:         sdkapi.JSONSchema{Spec: json.RawMessage(`{"type":"object"}`)},
+				},
+			}},
+		},
+	}
+
+	srv := mcp.NewServer(mcp.ServerOpts{Name: "test-ds", Version: "1.0", Addr: "127.0.0.1:0"})
+	ds := &stubDS{}
+	srv.BindQueryDataHandler(ds)
+	srv.BindCallResourceHandler(ds)
+	srv.BindCheckHealthHandler(ds)
+
+	fromschema.RegisterQueryTools(srv, schema)
+	fromschema.RegisterHealthCheckTool(srv)
+
+	require.NoError(t, srv.Start(context.Background()))
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}()
+
+	// Smoke: list tools via raw HTTP (initialize + tools/list). MCP protocol
+	// over HTTP is JSON-RPC; we send the canonical handshake.
+	addr := "http://" + srv.ListenAddr() + "/mcp"
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}`)
+	resp, err := http.Post(addr, "application/json", body)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300, "got status %d", resp.StatusCode)
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+go test ./experimental/mcp/...
+```
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add experimental/mcp/integration_test.go
+git commit -m "test(mcp): add end-to-end registration + HTTP smoke test"
+```
+
+---
+
+### Task 15: Tag the SDK version
+
+To unblock plugins, push the branch and let downstreams pin to it.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git -C /Users/erik/code/grafana/datasource-mcp-poc/grafana-plugin-sdk-go push -u origin feat/embedded-mcp
+```
+
+- [ ] **Step 2: Note the commit SHA**
+
+```bash
+git -C /Users/erik/code/grafana/datasource-mcp-poc/grafana-plugin-sdk-go rev-parse HEAD
+```
+
+Save this SHA - the plugins will pin to it via `go get github.com/grafana/grafana-plugin-sdk-go@<SHA>`.
+
+> Phase 1 complete. The SDK now exposes `experimental/mcp` and `fromschema`, lifecycle-integrated with `datasource.Manage`. Verify with `go test ./experimental/mcp/... ./backend/datasource/...` before moving on.
+
+---
+
+## Phase 2 - github-datasource
+
+> Working directory: `/Users/erik/code/grafana/datasource-mcp-poc/github-datasource/`. Branch off `main`: `git -C github-datasource checkout -b feat/embedded-mcp`.
+
+### Task 16: Bump SDK + regenerate query schema
+
+**Files:**
+- Modify: `go.mod`
+- Modify: `pkg/models/query_test.go` (already has `TestSchemaDefinitions`; verify it still compiles against the current SDK)
+- Create: `pkg/schema/v0alpha1/query.types.json`
+- Create: `pkg/schema/v0alpha1/query.examples.json`
+
+PR #291 already implements the schemabuilder test that emits these files - to `src/schema/`. We bring it up to date with the current SDK and redirect the destination to `pkg/schema/` so Go's `//go:embed` can pick them up.
+
+- [ ] **Step 1: Bump SDK**
+
+```bash
+cd /Users/erik/code/grafana/datasource-mcp-poc/github-datasource
+go get github.com/grafana/grafana-plugin-sdk-go@<SHA from Task 15>
+go mod tidy
+```
+
+- [ ] **Step 2: Apply PR #291's `pkg/models/query_test.go` and redirect destination**
+
+If PR #291 is mergeable, fetch it (`gh pr checkout 291 --repo grafana/github-datasource`) then rebase onto `feat/embedded-mcp`. Otherwise, copy the `TestSchemaDefinitions` test body from the PR diff into `pkg/models/query_test.go` verbatim.
+
+Then change the final line of the test from:
+
+```go
+builder.UpdateProviderFiles(t, "v0alpha1", "../../src/schema/")
+```
+
+to:
+
+```go
+builder.UpdateProviderFiles(t, "v0alpha1", "../schema/")
+```
+
+(`pkg/models/` -> `pkg/schema/` is one level up.)
+
+- [ ] **Step 3: Run the schemabuilder test - it writes the JSON files**
+
+```bash
+mkdir -p pkg/schema
+go test ./pkg/models/... -run TestSchemaDefinitions
+```
+Expected: PASS, with `pkg/schema/v0alpha1/query.types.json` and `query.examples.json` created.
+
+- [ ] **Step 4: Verify the files exist and are well-formed**
+
+```bash
+ls pkg/schema/v0alpha1/
+test -f pkg/schema/v0alpha1/query.types.json
+test -f pkg/schema/v0alpha1/query.examples.json
+jq '.items | length' pkg/schema/v0alpha1/query.types.json
+```
+Expected: integer count of query types (~20).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go.mod go.sum pkg/models/query_test.go pkg/schema/v0alpha1/
+git commit -m "feat: generate v0alpha1 query schema for MCP support"
+```
+
+---
+
+### Task 17: Author `routes.json`
+
+Translate the existing `pkg/github/resource_handlers.go` routes into OpenAPI 3.
+
+**Files:**
+- Create: `pkg/schema/v0alpha1/routes.json`
+
+- [ ] **Step 1: Inspect existing routes**
+
+```bash
+grep -n "Handle" pkg/github/resource_handlers.go
+grep -rn "/labels\|/milestones" pkg/
+```
+Confirm the routes registered on `CallResourceHandler` (currently `/labels` and `/milestones`).
+
+- [ ] **Step 2: Write `pkg/schema/v0alpha1/routes.json`**
+
+```json
+{
+  "paths": {
+    "/resources/labels": {
+      "get": {
+        "summary": "List GitHub labels matching the given query",
+        "parameters": [
+          { "name": "owner", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Owner of the repository" },
+          { "name": "repository", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Repository name" },
+          { "name": "query", "in": "query", "required": false, "schema": { "type": "string" }, "description": "Substring filter on label name" }
+        ]
+      }
+    },
+    "/resources/milestones": {
+      "get": {
+        "summary": "List GitHub milestones matching the given query",
+        "parameters": [
+          { "name": "owner", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "repository", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "query", "in": "query", "required": false, "schema": { "type": "string" } }
+        ]
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Validate the JSON syntactically**
+
+```bash
+jq '.paths | keys' pkg/schema/v0alpha1/routes.json
+```
+Expected: `["/resources/labels", "/resources/milestones"]`.
+
+The full schema-loading smoke test is added in Task 18 once the embed file exists.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/schema/v0alpha1/routes.json
+git commit -m "feat: add routes.json for labels and milestones"
+```
+
+---
+
+### Task 18: Embed schema and wire MCP into `main.go`
+
+**Files:**
+- Create: `pkg/schema_embed.go`
+- Create: `pkg/schema_embed_test.go`
+- Modify: `pkg/main.go`
+
+The embed file lives at `pkg/` (same directory as `main.go`, package `main`) so it can `//go:embed schema/v0alpha1/*.json` without `..` paths.
+
+- [ ] **Step 1: Create the embed helper**
+
+`pkg/schema_embed.go`:
+
+```go
+package main
+
+import (
+	"embed"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+)
+
+//go:embed schema/v0alpha1/*.json
+var schemaFS embed.FS
+
+// loadSchema returns the embedded v0alpha1 PluginSchema.
+func loadSchema() (*pluginschema.PluginSchema, error) {
+	return pluginschema.NewCompositeFileSchemaProvider(schemaFS).Get("v0alpha1")
+}
+```
+
+- [ ] **Step 2: Add a smoke test for schema loading**
+
+`pkg/schema_embed_test.go`:
+
+```go
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSchema_returnsAllSections(t *testing.T) {
+	schema, err := loadSchema()
+	require.NoError(t, err)
+	require.NotNil(t, schema.QueryTypes)
+	require.NotEmpty(t, schema.QueryTypes.Items)
+	require.NotNil(t, schema.QueryExamples)
+	require.NotEmpty(t, schema.QueryExamples.Examples)
+	require.NotNil(t, schema.Routes)
+	require.Contains(t, schema.Routes.Paths, "/resources/labels")
+	require.Contains(t, schema.Routes.Paths, "/resources/milestones")
+}
+```
+
+Run it:
+
+```bash
+go test ./pkg/...
+```
+Expected: PASS.
+
+- [ ] **Step 3: Wire MCP into `pkg/main.go`**
+
+Use `datasource.NewAutomanagementHandler` (added in Phase 1 Task 13) to get a handler that implements all interfaces. Bind it to the MCP server, then pass the same instance factory to `datasource.Manage`.
+
+Final `pkg/main.go` shape:
+
+```go
+package main
+
+import (
+	"os"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+
+	"github.com/grafana/github-datasource/pkg/github"
+)
+
+func main() {
+	schema, err := loadSchema()
+	if err != nil {
+		log.DefaultLogger.Error("schema load failed", "err", err)
+		os.Exit(1)
+	}
+
+	mcpServer := mcp.NewServer(mcp.ServerOpts{
+		Name:    "grafana-github-datasource",
+		Version: "1.0.0",
+	})
+
+	// Build the instance manager once, bind to MCP, then pass to Manage.
+	instanceFactory := github.NewDatasource
+	im := datasource.NewInstanceManager(instanceFactory)
+	mgr := datasource.NewAutomanagementHandler(im)
+
+	mcpServer.BindQueryDataHandler(mgr)
+	mcpServer.BindCallResourceHandler(mgr)
+	mcpServer.BindCheckHealthHandler(mgr)
+
+	fromschema.RegisterQueryTools(mcpServer, schema)
+	fromschema.RegisterRouteTools(mcpServer, schema)
+	fromschema.RegisterQueryExamples(mcpServer, schema)
+	fromschema.RegisterHealthCheckTool(mcpServer)
+
+	mcpServer.RegisterPrompt(mcp.Prompt{
+		Name:        "investigate-pull-requests",
+		Description: "Walk through investigating recent pull requests in a repository",
+		Template:    "List the most recent pull requests for the configured repository, then summarise patterns in review activity over the last 7 days.",
+	})
+
+	if err := datasource.Manage("grafana-github-datasource", instanceFactory, datasource.ManageOpts{
+		MCPServer: mcpServer,
+	}); err != nil {
+		log.DefaultLogger.Error("plugin exited", "err", err)
+		os.Exit(1)
+	}
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+```bash
+cd /Users/erik/code/grafana/datasource-mcp-poc/github-datasource
+go build ./...
+go test ./pkg/...
+```
+Expected: clean build, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/schema_embed.go pkg/schema_embed_test.go pkg/main.go
+git commit -m "feat: embed schema and wire MCP server in main.go"
+```
+
+---
+
+## Phase 3 - redshift-datasource
+
+> Working directory: `/Users/erik/code/grafana/datasource-mcp-poc/redshift-datasource/`. Branch: `git checkout -b feat/embedded-mcp`.
+
+### Task 19: Bump SDK
+
+- [ ] **Step 1: Bump and tidy**
+
+```bash
+cd /Users/erik/code/grafana/datasource-mcp-poc/redshift-datasource
+go get github.com/grafana/grafana-plugin-sdk-go@<SHA from Task 15>
+go mod tidy
+go build ./...
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -m "chore: bump grafana-plugin-sdk-go to embed-mcp branch"
+```
+
+---
+
+### Task 20: Generate query schema via schemabuilder
+
+The redshift plugin uses a generic SQL query type. Generate the schema with one item.
+
+**Files:**
+- Create: `pkg/redshift/models/schema_test.go`
+- Create: `pkg/schema/v0alpha1/query.types.json`
+- Create: `pkg/schema/v0alpha1/query.examples.json`
+
+- [ ] **Step 1: Find the redshift query model**
+
+```bash
+grep -rn "type.*Query struct" pkg/redshift/models/ pkg/redshift/
+find pkg/redshift -name "*.go" | xargs grep -l "QueryDataRequest\|HandleQuery"
+```
+
+In redshift the SQL query is typically modeled in `pkg/redshift/datasource.go` or via `sqlds`. Identify the Go type that represents a single query (e.g. `models.RedshiftQuery` or the SQL framework's `sqlds.Query`).
+
+- [ ] **Step 2: Write the schemabuilder test**
+
+`pkg/redshift/models/schema_test.go`:
+
+```go
+package models
+
+import (
+	"reflect"
+	"testing"
+
+	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/schemabuilder"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaDefinitions(t *testing.T) {
+	builder, err := schemabuilder.NewSchemaBuilder(schemabuilder.BuilderOptions{
+		PluginID: []string{"grafana-redshift-datasource"},
+		ScanCode: []schemabuilder.CodePaths{{
+			BasePackage: "github.com/grafana/redshift-datasource/pkg/redshift/models",
+			CodePath:    "./",
+		}},
+	})
+	require.NoError(t, err)
+
+	err = builder.AddQueries([]schemabuilder.QueryTypeInfo{{
+		// REPLACE GoType with the actual redshift query Go type identified in step 1.
+		GoType:         reflect.TypeFor[*RedshiftQuery](),
+		Discriminators: data.NewDiscriminators("queryType", "sql"),
+		Examples: []data.QueryExample{
+			{
+				Name:      "SimpleSQL",
+				QueryType: "sql",
+				SaveModel: data.AsUnstructured(map[string]any{
+					"rawSQL": "SELECT 1",
+					"format": "table",
+				}),
+			},
+		},
+	}})
+	require.NoError(t, err)
+
+	builder.UpdateProviderFiles(t, "v0alpha1", "../../schema/")
+}
+```
+
+> If `RedshiftQuery` is named differently or lives elsewhere, change the import path and `GoType`. The discriminator value can stay as `"sql"` since redshift only has one query type. The `../../schema/` destination resolves to `pkg/schema/` from `pkg/redshift/models/`.
+
+- [ ] **Step 3: Run it**
+
+```bash
+mkdir -p pkg/schema
+go test ./pkg/redshift/models/... -run TestSchemaDefinitions
+ls pkg/schema/v0alpha1/
+```
+Expected: `query.types.json` and `query.examples.json` created.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/redshift/models/schema_test.go pkg/schema/v0alpha1/
+git commit -m "feat: generate v0alpha1 query schema"
+```
+
+---
+
+### Task 21: Author `routes.json`
+
+**Files:**
+- Create: `pkg/schema/v0alpha1/routes.json`
+
+- [ ] **Step 1: Enumerate routes**
+
+```bash
+grep -A 2 "func.*Routes" pkg/redshift/routes/routes.go
+```
+
+Routes from the existing handler: `/secrets`, `/secret`, `/clusters`, `/workgroups`, plus the SQL framework's defaults (likely `/tables`, `/schemas`, `/columns`).
+
+- [ ] **Step 2: Write `pkg/schema/v0alpha1/routes.json`**
+
+```json
+{
+  "paths": {
+    "/resources/secrets": {
+      "get": { "summary": "List AWS Secrets Manager secrets eligible for Redshift" }
+    },
+    "/resources/secret": {
+      "post": {
+        "summary": "Get a single secret value",
+        "requestBody": {
+          "content": { "application/json": { "schema": { "type": "object" } } }
+        }
+      }
+    },
+    "/resources/clusters": {
+      "get": { "summary": "List Redshift provisioned clusters" }
+    },
+    "/resources/workgroups": {
+      "get": { "summary": "List Redshift Serverless workgroups" }
+    },
+    "/resources/tables": {
+      "post": {
+        "summary": "List tables in the connected schema",
+        "requestBody": {
+          "content": { "application/json": { "schema": { "type": "object" } } }
+        }
+      }
+    },
+    "/resources/schemas": {
+      "post": {
+        "summary": "List schemas in the connected database",
+        "requestBody": {
+          "content": { "application/json": { "schema": { "type": "object" } } }
+        }
+      }
+    },
+    "/resources/columns": {
+      "post": {
+        "summary": "List columns of a given table",
+        "requestBody": {
+          "content": { "application/json": { "schema": { "type": "object" } } }
+        }
+      }
+    }
+  }
+}
+```
+
+> If the SQL default routes are different, run `curl http://localhost:3000/api/datasources/<id>/resources/<name>` against a configured plugin and adjust based on what works. For the POC, leave any unverified routes out rather than guess.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/schema/v0alpha1/routes.json
+git commit -m "feat: add routes.json for redshift resource endpoints"
+```
+
+---
+
+### Task 22: Embed schema and wire MCP into `main.go`
+
+**Files:**
+- Create: `pkg/schema_embed.go`
+- Modify: `pkg/main.go`
+
+- [ ] **Step 1: Embed helper**
+
+`pkg/schema_embed.go`:
+
+```go
+package main
+
+import (
+	"embed"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+)
+
+//go:embed schema/v0alpha1/*.json
+var schemaFS embed.FS
+
+func loadSchema() (*pluginschema.PluginSchema, error) {
+	return pluginschema.NewCompositeFileSchemaProvider(schemaFS).Get("v0alpha1")
+}
+```
+
+- [ ] **Step 2: Wire `pkg/main.go`**
+
+Apply the same pattern as github-datasource Task 18:
+
+```go
+package main
+
+import (
+	"os"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+
+	"github.com/grafana/redshift-datasource/pkg/redshift"
+)
+
+func main() {
+	schema, err := loadSchema()
+	if err != nil {
+		log.DefaultLogger.Error("schema load failed", "err", err)
+		os.Exit(1)
+	}
+
+	mcpServer := mcp.NewServer(mcp.ServerOpts{
+		Name:    "grafana-redshift-datasource",
+		Version: "2.5.0",
+	})
+
+	instanceFactory := redshift.NewDatasource
+	im := datasource.NewInstanceManager(instanceFactory)
+	mgr := datasource.NewAutomanagementHandler(im)
+
+	mcpServer.BindQueryDataHandler(mgr)
+	mcpServer.BindCallResourceHandler(mgr)
+	mcpServer.BindCheckHealthHandler(mgr)
+
+	fromschema.RegisterQueryTools(mcpServer, schema)
+	fromschema.RegisterRouteTools(mcpServer, schema)
+	fromschema.RegisterQueryExamples(mcpServer, schema)
+	fromschema.RegisterHealthCheckTool(mcpServer)
+
+	if err := datasource.Manage("grafana-redshift-datasource", instanceFactory, datasource.ManageOpts{
+		MCPServer: mcpServer,
+	}); err != nil {
+		log.DefaultLogger.Error("plugin exited", "err", err)
+		os.Exit(1)
+	}
+}
+```
+
+> If `redshift.NewDatasource` has a different signature than `datasource.InstanceFactoryFunc`, adapt by writing a small wrapper in `pkg/redshift/datasource.go` whose signature matches.
+
+- [ ] **Step 3: Build**
+
+```bash
+go build ./...
+go test ./pkg/...
+```
+Expected: clean build, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/schema_embed.go pkg/main.go
+git commit -m "feat: embed schema and wire MCP server in main.go"
+```
+
+---
+
+## Phase 4 - Verification
+
+### Task 23: Build and smoke-test github-datasource
+
+- [ ] **Step 1: Build the plugin binary**
+
+```bash
+cd /Users/erik/code/grafana/datasource-mcp-poc/github-datasource
+mage -v build:linux
+# or whatever target produces a runnable binary; check Magefile.go
+```
+
+Alternatively, run directly:
+
+```bash
+go run ./pkg
+```
+
+- [ ] **Step 2: Verify the listener came up**
+
+In a second terminal:
+
+```bash
+cat /Users/erik/code/grafana/datasource-mcp-poc/github-datasource/dist/mcp.addr
+```
+Expected: `127.0.0.1:<port>\n`.
+
+- [ ] **Step 3: List tools via MCP Inspector**
+
+```bash
+npx @modelcontextprotocol/inspector --cli http://$(cat dist/mcp.addr)/mcp tools/list
+```
+
+Expected output includes:
+- `query_Pull_Requests`, `query_Issues`, `query_Commits`, ... (one per query type)
+- `get_resources_labels`, `get_resources_milestones`
+- `check_health`
+
+- [ ] **Step 4: Call `check_health`**
+
+```bash
+npx @modelcontextprotocol/inspector --cli http://$(cat dist/mcp.addr)/mcp tools/call --tool-name check_health
+```
+
+Expected: tool output with `"status": "OK"` (or the actual health state - depends on whether GitHub credentials are configured).
+
+- [ ] **Step 5: List resources**
+
+```bash
+npx @modelcontextprotocol/inspector --cli http://$(cat dist/mcp.addr)/mcp resources/list
+```
+
+Expected: includes `examples://query`.
+
+- [ ] **Step 6: List prompts**
+
+```bash
+npx @modelcontextprotocol/inspector --cli http://$(cat dist/mcp.addr)/mcp prompts/list
+```
+
+Expected: includes `investigate-pull-requests`.
+
+- [ ] **Step 7: Stop the plugin (Ctrl+C) and verify cleanup**
+
+```bash
+ls dist/mcp.addr 2>&1
+```
+Expected: file removed (or an error if it was removed).
+
+---
+
+### Task 24: Build and smoke-test redshift-datasource
+
+Repeat Task 23 for redshift, with these expectations:
+
+- `query_sql` tool (single query type)
+- Route tools: `get_resources_secrets`, `post_resources_secret`, `get_resources_clusters`, `get_resources_workgroups`, plus the SQL defaults if listed
+- `check_health` tool
+- `examples://query` resource
+
+If credentials aren't configured, `query_sql` and the resource tools may error - that's expected. The smoke test just verifies the MCP surface is correct.
+
+- [ ] **Step 1-7: Same as Task 23, substituting `redshift-datasource` paths**
+
+---
+
+### Task 25: Final clean build across all repos
+
+- [ ] **Step 1: Run all tests**
+
+```bash
+git -C /Users/erik/code/grafana/datasource-mcp-poc/grafana-plugin-sdk-go status
+go -C /Users/erik/code/grafana/datasource-mcp-poc/grafana-plugin-sdk-go test ./...
+
+go -C /Users/erik/code/grafana/datasource-mcp-poc/github-datasource test ./...
+go -C /Users/erik/code/grafana/datasource-mcp-poc/redshift-datasource test ./...
+```
+
+(`go -C` is shorthand for cd'ing first; if your Go version doesn't support it, use `cd && go test`.)
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Push branches**
+
+```bash
+git -C /Users/erik/code/grafana/datasource-mcp-poc/github-datasource push -u origin feat/embedded-mcp
+git -C /Users/erik/code/grafana/datasource-mcp-poc/redshift-datasource push -u origin feat/embedded-mcp
+```
+
+- [ ] **Step 3: Open draft PRs in each repo**
+
+```bash
+gh pr create --draft --repo grafana/grafana-plugin-sdk-go --base main --head feat/embedded-mcp \
+  --title "feat(experimental/mcp): embedded MCP server for datasource plugins" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds experimental/mcp package with HTTP transport
+- Adds fromschema helpers for query types, resource routes, query examples and health
+- Integrates with datasource.Manage lifecycle via ManageOpts.MCPServer
+
+## Test plan
+- [ ] go test ./experimental/mcp/...
+- [ ] go test ./backend/datasource/...
+- [ ] End-to-end smoke via mcp-inspector against github-datasource
+EOF
+)"
+```
+
+Repeat for github-datasource and redshift-datasource with their respective summaries.
+
+---
+
+## Done
+
+The POC is complete when:
+- All Phase 1 tests pass
+- Both plugins start, write their MCP addr, and respond to `tools/list`, `resources/list` and `prompts/list` from `mcp-inspector`
+- `tools/call check_health` returns a result for both plugins
+- Three draft PRs are open (one per repo)

--- a/experimental/mcp/fromschema/datasource_uid.go
+++ b/experimental/mcp/fromschema/datasource_uid.go
@@ -1,0 +1,23 @@
+package fromschema
+
+const datasourceUIDProp = "datasource_uid"
+
+// addDatasourceUID injects a "datasource_uid" property into an MCP tool's
+// InputSchema. This allows MCP clients to specify which Grafana datasource
+// instance to target. The parameter is optional: when omitted and only one
+// instance is registered, the server uses it automatically.
+func addDatasourceUID(schema map[string]any) map[string]any {
+	if schema == nil {
+		schema = map[string]any{"type": "object"}
+	}
+	props, _ := schema["properties"].(map[string]any)
+	if props == nil {
+		props = map[string]any{}
+		schema["properties"] = props
+	}
+	props[datasourceUIDProp] = map[string]any{
+		"type":        "string",
+		"description": "UID of the Grafana datasource instance to query. Omit when only one instance is configured.",
+	}
+	return schema
+}

--- a/experimental/mcp/fromschema/examples.go
+++ b/experimental/mcp/fromschema/examples.go
@@ -1,0 +1,51 @@
+package fromschema
+
+import (
+	"context"
+	"encoding/json"
+
+	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+)
+
+// RegisterQueryExamples publishes a single resource "examples://query" listing
+// every QueryExample, and attaches each example to the corresponding tool's
+// Examples field. Must be called after RegisterQueryTools so the tools exist.
+func RegisterQueryExamples(s *mcp.Server, schema *pluginschema.PluginSchema) {
+	if schema == nil || schema.QueryExamples == nil {
+		return
+	}
+	body, err := json.MarshalIndent(schema.QueryExamples, "", "  ")
+	if err != nil {
+		body = []byte("{}")
+	}
+	s.RegisterResource(mcp.Resource{
+		URI:         "examples://query",
+		Name:        "Query examples",
+		Description: "Datasource-specific query examples grouped by queryType",
+		MIMEType:    "application/json",
+		Reader: func(_ context.Context) ([]byte, string, error) {
+			return body, "application/json", nil
+		},
+	})
+
+	// attach each example to its matching tool, if registered
+	byName := map[string]*sdkapi.QueryExample{}
+	for i := range schema.QueryExamples.Examples {
+		ex := &schema.QueryExamples.Examples[i]
+		byName[ex.QueryType] = ex
+	}
+	for _, t := range s.Tools() {
+		qt, ok := t.Annotations["queryType"].(string)
+		if !ok {
+			continue
+		}
+		ex, ok := byName[qt]
+		if !ok {
+			continue
+		}
+		t.Examples = append(t.Examples, ex.SaveModel.Object)
+		s.UpdateTool(t)
+	}
+}

--- a/experimental/mcp/fromschema/examples_test.go
+++ b/experimental/mcp/fromschema/examples_test.go
@@ -1,0 +1,50 @@
+package fromschema_test
+
+import (
+	"context"
+	"testing"
+
+	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterQueryExamples_publishesResourceAndAttachesExamples(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		QueryTypes: &sdkapi.QueryTypeDefinitionList{
+			Items: []sdkapi.QueryTypeDefinition{{
+				ObjectMeta: sdkapi.ObjectMeta{Name: "Pull_Requests"},
+				Spec: sdkapi.QueryTypeDefinitionSpec{
+					Discriminators: []sdkapi.DiscriminatorFieldValue{{Field: "queryType", Value: "Pull_Requests"}},
+					Schema:         jsonSchema(t, `{"type":"object"}`),
+				},
+			}},
+		},
+		QueryExamples: &sdkapi.QueryExamples{Examples: []sdkapi.QueryExample{
+			{Name: "Simple", QueryType: "Pull_Requests", SaveModel: sdkapi.AsUnstructured(map[string]any{"owner": "grafana"})},
+		}},
+	}
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	fromschema.RegisterQueryTools(s, schema)
+	fromschema.RegisterQueryExamples(s, schema)
+
+	// resource registered
+	resources := s.Resources()
+	require.Len(t, resources, 1)
+	assert.Equal(t, "examples://query", resources[0].URI)
+	body, _, err := resources[0].Reader(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Pull_Requests")
+
+	// example attached to the matching tool
+	for _, t2 := range s.Tools() {
+		if t2.Name == "query_Pull_Requests" {
+			require.Len(t, t2.Examples, 1)
+			return
+		}
+	}
+	t.Fatalf("query_Pull_Requests tool not found")
+}

--- a/experimental/mcp/fromschema/healthcheck.go
+++ b/experimental/mcp/fromschema/healthcheck.go
@@ -16,9 +16,9 @@ func RegisterHealthCheckTool(s *mcp.Server) {
 	s.RegisterTool(mcp.Tool{
 		Name:        "check_health",
 		Description: "Run the datasource's health check",
-		InputSchema: map[string]any{"type": "object"},
-		Handler: func(ctx context.Context, _ map[string]any) (any, error) {
-			return s.ExecuteHealthTool(ctx)
+		InputSchema: addDatasourceUID(map[string]any{"type": "object"}),
+		Handler: func(ctx context.Context, args map[string]any) (any, error) {
+			return s.ExecuteHealthTool(ctx, args)
 		},
 	})
 }

--- a/experimental/mcp/fromschema/healthcheck.go
+++ b/experimental/mcp/fromschema/healthcheck.go
@@ -1,0 +1,24 @@
+// Package fromschema turns a pluginschema.PluginSchema and a bound mcp.Server
+// into registered tools/resources. Each Register* helper is independent and
+// idempotent.
+package fromschema
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+)
+
+// RegisterHealthCheckTool adds a "check_health" tool that delegates to the
+// CheckHealthHandler bound on the server. Safe to call before BindCheckHealthHandler;
+// the tool will surface an error at call time if the handler is missing.
+func RegisterHealthCheckTool(s *mcp.Server) {
+	s.RegisterTool(mcp.Tool{
+		Name:        "check_health",
+		Description: "Run the datasource's health check",
+		InputSchema: map[string]any{"type": "object"},
+		Handler: func(ctx context.Context, _ map[string]any) (any, error) {
+			return s.ExecuteHealthTool(ctx)
+		},
+	})
+}

--- a/experimental/mcp/fromschema/healthcheck_test.go
+++ b/experimental/mcp/fromschema/healthcheck_test.go
@@ -1,0 +1,29 @@
+package fromschema_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type healthOnly struct{}
+
+func (healthOnly) CheckHealth(_ context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	return &backend.CheckHealthResult{Status: backend.HealthStatusOk, Message: "ok"}, nil
+}
+
+func TestRegisterHealthCheckTool_addsCheckHealthTool(t *testing.T) {
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	s.BindCheckHealthHandler(healthOnly{})
+
+	fromschema.RegisterHealthCheckTool(s)
+
+	tools := s.Tools()
+	require.Len(t, tools, 1)
+	assert.Equal(t, "check_health", tools[0].Name)
+}

--- a/experimental/mcp/fromschema/querytypes.go
+++ b/experimental/mcp/fromschema/querytypes.go
@@ -1,0 +1,52 @@
+package fromschema
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+)
+
+// RegisterQueryTools adds one MCP tool per QueryTypeDefinition in the schema.
+// Each tool's name is "query_<discriminator-value>", its InputSchema is the
+// query type's JSON Schema, and its handler delegates to the bound QueryDataHandler.
+func RegisterQueryTools(s *mcp.Server, schema *pluginschema.PluginSchema) {
+	if schema == nil || schema.QueryTypes == nil {
+		return
+	}
+	for _, qt := range schema.QueryTypes.Items {
+		discValue := qt.ObjectMeta.Name
+		if len(qt.Spec.Discriminators) > 0 && qt.Spec.Discriminators[0].Value != "" {
+			discValue = qt.Spec.Discriminators[0].Value
+		}
+
+		var inputSchema map[string]any
+		if raw := schemaSpec(qt.Spec.Schema); len(raw) > 0 {
+			_ = json.Unmarshal(raw, &inputSchema)
+		}
+
+		queryType := discValue
+		s.RegisterTool(mcp.Tool{
+			Name:        "query_" + discValue,
+			Description: fmt.Sprintf("Run a %s query against the datasource", discValue),
+			InputSchema: inputSchema,
+			Annotations: map[string]any{"queryType": queryType},
+			Handler: func(ctx context.Context, args map[string]any) (any, error) {
+				return s.ExecuteQueryTool(ctx, queryType, args)
+			},
+		})
+	}
+}
+
+// schemaSpec returns the JSON-serialized form of the JSON Schema. JSONSchema's
+// MarshalJSON returns the inner schema body directly so this is just a wrapper.
+func schemaSpec(s sdkapi.JSONSchema) []byte {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/experimental/mcp/fromschema/querytypes.go
+++ b/experimental/mcp/fromschema/querytypes.go
@@ -32,7 +32,7 @@ func RegisterQueryTools(s *mcp.Server, schema *pluginschema.PluginSchema) {
 		s.RegisterTool(mcp.Tool{
 			Name:        "query_" + discValue,
 			Description: fmt.Sprintf("Run a %s query against the datasource", discValue),
-			InputSchema: inputSchema,
+			InputSchema: addDatasourceUID(inputSchema),
 			Annotations: map[string]any{"queryType": queryType},
 			Handler: func(ctx context.Context, args map[string]any) (any, error) {
 				return s.ExecuteQueryTool(ctx, queryType, args)

--- a/experimental/mcp/fromschema/querytypes_test.go
+++ b/experimental/mcp/fromschema/querytypes_test.go
@@ -76,6 +76,9 @@ func TestRegisterQueryTools_handlerCallsBoundQueryData(t *testing.T) {
 		},
 	}
 	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	s.RegisterPluginContext("test-uid", backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "test-uid"},
+	})
 	q := &queryOnly{}
 	s.BindQueryDataHandler(q)
 	fromschema.RegisterQueryTools(s, schema)

--- a/experimental/mcp/fromschema/querytypes_test.go
+++ b/experimental/mcp/fromschema/querytypes_test.go
@@ -1,0 +1,95 @@
+package fromschema_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type queryOnly struct{ lastReq *backend.QueryDataRequest }
+
+func (q *queryOnly) QueryData(_ context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	q.lastReq = req
+	return &backend.QueryDataResponse{}, nil
+}
+
+// jsonSchema is a helper that builds a sdkapi.JSONSchema from a JSON literal.
+func jsonSchema(t *testing.T, body string) sdkapi.JSONSchema {
+	t.Helper()
+	var js sdkapi.JSONSchema
+	require.NoError(t, json.Unmarshal([]byte(body), &js))
+	return js
+}
+
+func TestRegisterQueryTools_addsOneToolPerQueryType(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		QueryTypes: &sdkapi.QueryTypeDefinitionList{
+			Items: []sdkapi.QueryTypeDefinition{
+				{
+					ObjectMeta: sdkapi.ObjectMeta{Name: "Pull_Requests"},
+					Spec: sdkapi.QueryTypeDefinitionSpec{
+						Discriminators: []sdkapi.DiscriminatorFieldValue{{Field: "queryType", Value: "Pull_Requests"}},
+						Schema:         jsonSchema(t, `{"type":"object"}`),
+					},
+				},
+				{
+					ObjectMeta: sdkapi.ObjectMeta{Name: "Issues"},
+					Spec: sdkapi.QueryTypeDefinitionSpec{
+						Discriminators: []sdkapi.DiscriminatorFieldValue{{Field: "queryType", Value: "Issues"}},
+						Schema:         jsonSchema(t, `{"type":"object"}`),
+					},
+				},
+			},
+		},
+	}
+
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	q := &queryOnly{}
+	s.BindQueryDataHandler(q)
+	fromschema.RegisterQueryTools(s, schema)
+
+	tools := s.Tools()
+	require.Len(t, tools, 2)
+	names := []string{tools[0].Name, tools[1].Name}
+	assert.Contains(t, names, "query_Pull_Requests")
+	assert.Contains(t, names, "query_Issues")
+}
+
+func TestRegisterQueryTools_handlerCallsBoundQueryData(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		QueryTypes: &sdkapi.QueryTypeDefinitionList{
+			Items: []sdkapi.QueryTypeDefinition{{
+				ObjectMeta: sdkapi.ObjectMeta{Name: "Pull_Requests"},
+				Spec: sdkapi.QueryTypeDefinitionSpec{
+					Discriminators: []sdkapi.DiscriminatorFieldValue{{Field: "queryType", Value: "Pull_Requests"}},
+					Schema:         jsonSchema(t, `{"type":"object"}`),
+				},
+			}},
+		},
+	}
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	q := &queryOnly{}
+	s.BindQueryDataHandler(q)
+	fromschema.RegisterQueryTools(s, schema)
+
+	tool := s.Tools()[0]
+	_, err := tool.Handler(context.Background(), map[string]any{"owner": "grafana"})
+	require.NoError(t, err)
+	require.NotNil(t, q.lastReq)
+	require.Len(t, q.lastReq.Queries, 1)
+	assert.Equal(t, "Pull_Requests", q.lastReq.Queries[0].QueryType)
+}
+
+func TestRegisterQueryTools_skipsWhenSchemaHasNoQueryTypes(t *testing.T) {
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	fromschema.RegisterQueryTools(s, &pluginschema.PluginSchema{})
+	assert.Empty(t, s.Tools())
+}

--- a/experimental/mcp/fromschema/routes.go
+++ b/experimental/mcp/fromschema/routes.go
@@ -1,0 +1,119 @@
+package fromschema
+
+import (
+	"context"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+	"k8s.io/kube-openapi/pkg/spec3"
+)
+
+// RegisterRouteTools adds one MCP tool per (path, method) pair under /resources/*.
+// /proxy/* paths are skipped.
+//
+// The /resources/ prefix is stripped both from the tool name and from the path
+// passed to CallResourceHandler at runtime - Grafana strips that prefix before
+// forwarding resource calls to the plugin, so the plugin's handler sees e.g.
+// "/labels", not "/resources/labels".
+func RegisterRouteTools(s *mcp.Server, schema *pluginschema.PluginSchema) {
+	if schema == nil || schema.Routes == nil {
+		return
+	}
+	for schemaPath, p := range schema.Routes.Paths {
+		if !strings.HasPrefix(schemaPath, "/resources/") {
+			continue
+		}
+		runtimePath := strings.TrimPrefix(schemaPath, "/resources")
+		registerOpIfPresent(s, "GET", runtimePath, p.Get)
+		registerOpIfPresent(s, "POST", runtimePath, p.Post)
+		registerOpIfPresent(s, "PUT", runtimePath, p.Put)
+		registerOpIfPresent(s, "DELETE", runtimePath, p.Delete)
+		registerOpIfPresent(s, "PATCH", runtimePath, p.Patch)
+	}
+}
+
+func registerOpIfPresent(s *mcp.Server, method, path string, op *spec3.Operation) {
+	if op == nil {
+		return
+	}
+	spec := mcp.RouteToolSpec{
+		Method: method,
+		Path:   path,
+	}
+	inputProps := map[string]any{}
+	required := []string{}
+	for _, param := range op.Parameters {
+		if param == nil {
+			continue
+		}
+		switch param.In {
+		case "path":
+			spec.PathParams = append(spec.PathParams, param.Name)
+		case "query":
+			spec.QueryArgs = append(spec.QueryArgs, param.Name)
+		}
+		// add to input schema regardless of `In` so the tool exposes it
+		inputProps[param.Name] = paramToSchema(param)
+		if param.Required {
+			required = append(required, param.Name)
+		}
+	}
+	if op.RequestBody != nil {
+		spec.BodyArg = "body"
+		inputProps["body"] = map[string]any{"type": "object"}
+		required = append(required, "body")
+	}
+
+	inputSchema := map[string]any{
+		"type":       "object",
+		"properties": inputProps,
+	}
+	if len(required) > 0 {
+		inputSchema["required"] = required
+	}
+
+	desc := op.Summary
+	if desc == "" {
+		desc = op.Description
+	}
+	if desc == "" {
+		desc = method + " " + path
+	}
+
+	s.RegisterTool(mcp.Tool{
+		Name:        toolName(method, path),
+		Description: desc,
+		InputSchema: inputSchema,
+		Handler: func(ctx context.Context, args map[string]any) (any, error) {
+			return s.ExecuteRouteTool(ctx, spec, args)
+		},
+	})
+}
+
+func paramToSchema(p *spec3.Parameter) map[string]any {
+	out := map[string]any{}
+	if p.Schema != nil && len(p.Schema.Type) > 0 {
+		out["type"] = p.Schema.Type[0]
+	} else {
+		out["type"] = "string"
+	}
+	if p.Description != "" {
+		out["description"] = p.Description
+	}
+	return out
+}
+
+// toolName converts (GET, "/labels") to "get_labels". Path params are dropped
+// from the name (their values come from tool args).
+func toolName(method, path string) string {
+	m := strings.ToLower(method)
+	parts := []string{m}
+	for _, seg := range strings.Split(strings.Trim(path, "/"), "/") {
+		if seg == "" || strings.HasPrefix(seg, "{") {
+			continue
+		}
+		parts = append(parts, seg)
+	}
+	return strings.Join(parts, "_")
+}

--- a/experimental/mcp/fromschema/routes.go
+++ b/experimental/mcp/fromschema/routes.go
@@ -65,10 +65,10 @@ func registerOpIfPresent(s *mcp.Server, method, path string, op *spec3.Operation
 		required = append(required, "body")
 	}
 
-	inputSchema := map[string]any{
+	inputSchema := addDatasourceUID(map[string]any{
 		"type":       "object",
 		"properties": inputProps,
-	}
+	})
 	if len(required) > 0 {
 		inputSchema["required"] = required
 	}

--- a/experimental/mcp/fromschema/routes_test.go
+++ b/experimental/mcp/fromschema/routes_test.go
@@ -1,0 +1,91 @@
+package fromschema_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+type resourceOnly struct{ lastReq *backend.CallResourceRequest }
+
+func (r *resourceOnly) CallResource(_ context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	r.lastReq = req
+	return sender.Send(&backend.CallResourceResponse{Status: 200, Body: []byte(`{"ok":true}`)})
+}
+
+func TestRegisterRouteTools_addsToolsForResourceRoutes(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		Routes: &pluginschema.Routes{
+			Paths: map[string]*spec3.Path{
+				"/resources/labels": {
+					PathProps: spec3.PathProps{
+						Get: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+								Summary: "List GitHub labels",
+								Parameters: []*spec3.Parameter{
+									{ParameterProps: spec3.ParameterProps{Name: "owner", In: "query", Required: true, Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}}}},
+									{ParameterProps: spec3.ParameterProps{Name: "repository", In: "query", Required: true, Schema: &spec.Schema{SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}}}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	r := &resourceOnly{}
+	s.BindCallResourceHandler(r)
+	fromschema.RegisterRouteTools(s, schema)
+
+	tools := s.Tools()
+	require.Len(t, tools, 1)
+	// tool name strips the /resources/ prefix - this matches the path that
+	// CallResourceHandler actually sees at runtime.
+	assert.Equal(t, "get_labels", tools[0].Name)
+	assert.Equal(t, "List GitHub labels", tools[0].Description)
+}
+
+func TestRegisterRouteTools_skipsProxyRoutes(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		Routes: &pluginschema.Routes{
+			Paths: map[string]*spec3.Path{
+				"/proxy/foo": {PathProps: spec3.PathProps{Get: &spec3.Operation{}}},
+			},
+		},
+	}
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	fromschema.RegisterRouteTools(s, schema)
+	assert.Empty(t, s.Tools())
+}
+
+func TestRegisterRouteTools_handlerCallsBoundCallResource(t *testing.T) {
+	schema := &pluginschema.PluginSchema{
+		Routes: &pluginschema.Routes{
+			Paths: map[string]*spec3.Path{
+				"/resources/labels": {PathProps: spec3.PathProps{Get: &spec3.Operation{}}},
+			},
+		},
+	}
+	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	r := &resourceOnly{}
+	s.BindCallResourceHandler(r)
+	fromschema.RegisterRouteTools(s, schema)
+
+	_, err := s.Tools()[0].Handler(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	require.NotNil(t, r.lastReq)
+	assert.Equal(t, "GET", r.lastReq.Method)
+	// CallResourceHandler sees the path WITHOUT the /resources/ prefix
+	// (Grafana strips it before forwarding; we mirror that behavior).
+	assert.Equal(t, "/labels", r.lastReq.Path)
+}

--- a/experimental/mcp/fromschema/routes_test.go
+++ b/experimental/mcp/fromschema/routes_test.go
@@ -77,6 +77,9 @@ func TestRegisterRouteTools_handlerCallsBoundCallResource(t *testing.T) {
 		},
 	}
 	s := mcp.NewServer(mcp.ServerOpts{Name: "x", Version: "0"})
+	s.RegisterPluginContext("test-uid", backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "test-uid"},
+	})
 	r := &resourceOnly{}
 	s.BindCallResourceHandler(r)
 	fromschema.RegisterRouteTools(s, schema)

--- a/experimental/mcp/handlers.go
+++ b/experimental/mcp/handlers.go
@@ -181,6 +181,28 @@ func (s *Server) executeRouteTool(ctx context.Context, spec routeToolSpec, args 
 	return string(sender.resp.Body), nil
 }
 
+func (s *Server) executeHealthTool(ctx context.Context) (any, error) {
+	h := s.CheckHealthHandler()
+	if h == nil {
+		return nil, errors.New("no CheckHealthHandler bound to MCP server")
+	}
+	res, err := h.CheckHealth(ctx, &backend.CheckHealthRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("CheckHealth failed: %w", err)
+	}
+	out := map[string]any{
+		"status":  res.Status.String(),
+		"message": res.Message,
+	}
+	if len(res.JSONDetails) > 0 {
+		var details any
+		if err := json.Unmarshal(res.JSONDetails, &details); err == nil {
+			out["details"] = details
+		}
+	}
+	return out, nil
+}
+
 func firstHeader(h map[string][]string, key string) (string, bool) {
 	if h == nil {
 		return "", false

--- a/experimental/mcp/handlers.go
+++ b/experimental/mcp/handlers.go
@@ -65,16 +65,23 @@ func (s *Server) CheckHealthHandler() backend.CheckHealthHandler {
 // executeQueryTool is the shared handler for every query-type tool. It builds
 // a single-query QueryDataRequest with the given queryType discriminator and
 // the tool args as the JSON body, then JSON-encodes the resulting frames.
+// It extracts "datasource_uid" from args (removing it before marshaling the query body)
+// and uses it to look up the PluginContext for the target datasource instance.
 func (s *Server) executeQueryTool(ctx context.Context, queryType string, args map[string]any) (any, error) {
 	h := s.QueryDataHandler()
 	if h == nil {
 		return nil, errors.New("no QueryDataHandler bound to MCP server")
+	}
+	pctx, args, err := s.extractPluginContext(args)
+	if err != nil {
+		return nil, err
 	}
 	body, err := json.Marshal(args)
 	if err != nil {
 		return nil, fmt.Errorf("marshal query args: %w", err)
 	}
 	req := &backend.QueryDataRequest{
+		PluginContext: pctx,
 		Queries: []backend.DataQuery{{
 			RefID:     "A",
 			QueryType: queryType,
@@ -122,6 +129,10 @@ func (s *Server) executeRouteTool(ctx context.Context, spec routeToolSpec, args 
 	if h == nil {
 		return nil, errors.New("no CallResourceHandler bound to MCP server")
 	}
+	pctx, args, err := s.extractPluginContext(args)
+	if err != nil {
+		return nil, err
+	}
 
 	// substitute path parameters
 	path := spec.Path
@@ -159,10 +170,11 @@ func (s *Server) executeRouteTool(ctx context.Context, spec routeToolSpec, args 
 	}
 
 	req := &backend.CallResourceRequest{
-		Method: spec.Method,
-		Path:   path,
-		URL:    urlStr,
-		Body:   body,
+		PluginContext: pctx,
+		Method:        spec.Method,
+		Path:          path,
+		URL:           urlStr,
+		Body:          body,
 	}
 	sender := &captureSender{}
 	if err := h.CallResource(ctx, req, sender); err != nil {
@@ -183,8 +195,8 @@ func (s *Server) executeRouteTool(ctx context.Context, spec routeToolSpec, args 
 
 // ExecuteHealthTool is the public entry point used by fromschema to delegate to
 // the bound CheckHealthHandler.
-func (s *Server) ExecuteHealthTool(ctx context.Context) (any, error) {
-	return s.executeHealthTool(ctx)
+func (s *Server) ExecuteHealthTool(ctx context.Context, args map[string]any) (any, error) {
+	return s.executeHealthTool(ctx, args)
 }
 
 // ExecuteQueryTool is exported for fromschema.RegisterQueryTools.
@@ -200,12 +212,16 @@ func (s *Server) ExecuteRouteTool(ctx context.Context, spec RouteToolSpec, args 
 // RouteToolSpec is the public mirror of routeToolSpec.
 type RouteToolSpec = routeToolSpec
 
-func (s *Server) executeHealthTool(ctx context.Context) (any, error) {
+func (s *Server) executeHealthTool(ctx context.Context, args map[string]any) (any, error) {
 	h := s.CheckHealthHandler()
 	if h == nil {
 		return nil, errors.New("no CheckHealthHandler bound to MCP server")
 	}
-	res, err := h.CheckHealth(ctx, &backend.CheckHealthRequest{})
+	pctx, _, err := s.extractPluginContext(args)
+	if err != nil {
+		return nil, err
+	}
+	res, err := h.CheckHealth(ctx, &backend.CheckHealthRequest{PluginContext: pctx})
 	if err != nil {
 		return nil, fmt.Errorf("CheckHealth failed: %w", err)
 	}
@@ -220,6 +236,25 @@ func (s *Server) executeHealthTool(ctx context.Context) (any, error) {
 		}
 	}
 	return out, nil
+}
+
+// extractPluginContext removes "datasource_uid" from args (so it is not sent
+// in the query body), looks up the matching PluginContext in the server's
+// registry, and returns it alongside the remaining args.
+func (s *Server) extractPluginContext(args map[string]any) (backend.PluginContext, map[string]any, error) {
+	uid, _ := args["datasource_uid"].(string)
+	// return a copy of args without datasource_uid
+	filtered := make(map[string]any, len(args))
+	for k, v := range args {
+		if k != "datasource_uid" {
+			filtered[k] = v
+		}
+	}
+	pctx, err := s.LookupPluginContext(uid)
+	if err != nil {
+		return backend.PluginContext{}, nil, err
+	}
+	return pctx, filtered, nil
 }
 
 func firstHeader(h map[string][]string, key string) (string, bool) {

--- a/experimental/mcp/handlers.go
+++ b/experimental/mcp/handlers.go
@@ -181,6 +181,25 @@ func (s *Server) executeRouteTool(ctx context.Context, spec routeToolSpec, args 
 	return string(sender.resp.Body), nil
 }
 
+// ExecuteHealthTool is the public entry point used by fromschema to delegate to
+// the bound CheckHealthHandler.
+func (s *Server) ExecuteHealthTool(ctx context.Context) (any, error) {
+	return s.executeHealthTool(ctx)
+}
+
+// ExecuteQueryTool is exported for fromschema.RegisterQueryTools.
+func (s *Server) ExecuteQueryTool(ctx context.Context, queryType string, args map[string]any) (any, error) {
+	return s.executeQueryTool(ctx, queryType, args)
+}
+
+// ExecuteRouteTool is exported for fromschema.RegisterRouteTools.
+func (s *Server) ExecuteRouteTool(ctx context.Context, spec RouteToolSpec, args map[string]any) (any, error) {
+	return s.executeRouteTool(ctx, routeToolSpec(spec), args)
+}
+
+// RouteToolSpec is the public mirror of routeToolSpec.
+type RouteToolSpec = routeToolSpec
+
 func (s *Server) executeHealthTool(ctx context.Context) (any, error) {
 	h := s.CheckHealthHandler()
 	if h == nil {

--- a/experimental/mcp/handlers.go
+++ b/experimental/mcp/handlers.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
@@ -92,4 +94,101 @@ func (s *Server) executeQueryTool(ctx context.Context, queryType string, args ma
 		out[refID] = dr.Frames
 	}
 	return out, nil
+}
+
+// routeToolSpec describes how to translate tool args into a CallResourceRequest.
+// It is built once per tool by fromschema.RegisterRouteTools and reused on
+// every call.
+type routeToolSpec struct {
+	Method     string
+	Path       string   // OpenAPI-style path, may contain {param}
+	PathParams []string // names of path parameters in Path, e.g. {"owner","repo"}
+	QueryArgs  []string // tool arg names that go into the query string
+	BodyArg    string   // tool arg name (if any) whose value becomes the request body
+}
+
+// captureSender collects the first CallResourceResponse and is enough for v1.
+type captureSender struct{ resp *backend.CallResourceResponse }
+
+func (c *captureSender) Send(r *backend.CallResourceResponse) error {
+	if c.resp == nil {
+		c.resp = r
+	}
+	return nil
+}
+
+func (s *Server) executeRouteTool(ctx context.Context, spec routeToolSpec, args map[string]any) (any, error) {
+	h := s.CallResourceHandler()
+	if h == nil {
+		return nil, errors.New("no CallResourceHandler bound to MCP server")
+	}
+
+	// substitute path parameters
+	path := spec.Path
+	for _, p := range spec.PathParams {
+		v, ok := args[p]
+		if !ok {
+			return nil, fmt.Errorf("missing required path parameter %q", p)
+		}
+		path = strings.ReplaceAll(path, "{"+p+"}", fmt.Sprintf("%v", v))
+	}
+
+	// build query string from QueryArgs that are present in args
+	values := url.Values{}
+	for _, q := range spec.QueryArgs {
+		if v, ok := args[q]; ok && v != nil && v != "" {
+			values.Set(q, fmt.Sprintf("%v", v))
+		}
+	}
+
+	// body, if any
+	var body []byte
+	if spec.BodyArg != "" {
+		if v, ok := args[spec.BodyArg]; ok {
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("marshal request body: %w", err)
+			}
+			body = b
+		}
+	}
+
+	urlStr := path
+	if encoded := values.Encode(); encoded != "" {
+		urlStr = path + "?" + encoded
+	}
+
+	req := &backend.CallResourceRequest{
+		Method: spec.Method,
+		Path:   path,
+		URL:    urlStr,
+		Body:   body,
+	}
+	sender := &captureSender{}
+	if err := h.CallResource(ctx, req, sender); err != nil {
+		return nil, fmt.Errorf("CallResource failed: %w", err)
+	}
+	if sender.resp == nil {
+		return nil, errors.New("CallResource returned no response")
+	}
+	// try JSON decode; fall back to string body
+	if ct, _ := firstHeader(sender.resp.Headers, "Content-Type"); strings.HasPrefix(ct, "application/json") {
+		var decoded any
+		if err := json.Unmarshal(sender.resp.Body, &decoded); err == nil {
+			return decoded, nil
+		}
+	}
+	return string(sender.resp.Body), nil
+}
+
+func firstHeader(h map[string][]string, key string) (string, bool) {
+	if h == nil {
+		return "", false
+	}
+	for k, v := range h {
+		if strings.EqualFold(k, key) && len(v) > 0 {
+			return v[0], true
+		}
+	}
+	return "", false
 }

--- a/experimental/mcp/handlers.go
+++ b/experimental/mcp/handlers.go
@@ -1,6 +1,13 @@
 package mcp
 
-import "github.com/grafana/grafana-plugin-sdk-go/backend"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
 
 // BindQueryDataHandler attaches the plugin's QueryDataHandler. Schema-driven
 // query tools registered via fromschema.RegisterQueryTools delegate to it.
@@ -51,4 +58,38 @@ func (s *Server) CheckHealthHandler() backend.CheckHealthHandler {
 		return nil
 	}
 	return s.checkHealthHandler.(backend.CheckHealthHandler)
+}
+
+// executeQueryTool is the shared handler for every query-type tool. It builds
+// a single-query QueryDataRequest with the given queryType discriminator and
+// the tool args as the JSON body, then JSON-encodes the resulting frames.
+func (s *Server) executeQueryTool(ctx context.Context, queryType string, args map[string]any) (any, error) {
+	h := s.QueryDataHandler()
+	if h == nil {
+		return nil, errors.New("no QueryDataHandler bound to MCP server")
+	}
+	body, err := json.Marshal(args)
+	if err != nil {
+		return nil, fmt.Errorf("marshal query args: %w", err)
+	}
+	req := &backend.QueryDataRequest{
+		Queries: []backend.DataQuery{{
+			RefID:     "A",
+			QueryType: queryType,
+			JSON:      body,
+		}},
+	}
+	resp, err := h.QueryData(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("QueryData failed: %w", err)
+	}
+	out := map[string]any{}
+	for refID, dr := range resp.Responses {
+		if dr.Error != nil {
+			out[refID] = map[string]any{"error": dr.Error.Error()}
+			continue
+		}
+		out[refID] = dr.Frames
+	}
+	return out, nil
 }

--- a/experimental/mcp/handlers.go
+++ b/experimental/mcp/handlers.go
@@ -1,0 +1,54 @@
+package mcp
+
+import "github.com/grafana/grafana-plugin-sdk-go/backend"
+
+// BindQueryDataHandler attaches the plugin's QueryDataHandler. Schema-driven
+// query tools registered via fromschema.RegisterQueryTools delegate to it.
+func (s *Server) BindQueryDataHandler(h backend.QueryDataHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.queryDataHandler = h
+}
+
+// BindCallResourceHandler attaches the plugin's CallResourceHandler. Route
+// tools registered via fromschema.RegisterRouteTools delegate to it.
+func (s *Server) BindCallResourceHandler(h backend.CallResourceHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.callResourceHandler = h
+}
+
+// BindCheckHealthHandler attaches the plugin's CheckHealthHandler.
+func (s *Server) BindCheckHealthHandler(h backend.CheckHealthHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.checkHealthHandler = h
+}
+
+// QueryDataHandler returns the bound handler (or nil).
+func (s *Server) QueryDataHandler() backend.QueryDataHandler {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.queryDataHandler == nil {
+		return nil
+	}
+	return s.queryDataHandler.(backend.QueryDataHandler)
+}
+
+func (s *Server) CallResourceHandler() backend.CallResourceHandler {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.callResourceHandler == nil {
+		return nil
+	}
+	return s.callResourceHandler.(backend.CallResourceHandler)
+}
+
+func (s *Server) CheckHealthHandler() backend.CheckHealthHandler {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.checkHealthHandler == nil {
+		return nil
+	}
+	return s.checkHealthHandler.(backend.CheckHealthHandler)
+}

--- a/experimental/mcp/handlers_test.go
+++ b/experimental/mcp/handlers_test.go
@@ -70,3 +70,43 @@ func TestExecuteQueryTool_errorsWhenHandlerNotBound(t *testing.T) {
 	_, err := s.executeQueryTool(context.Background(), "Pull_Requests", map[string]any{})
 	assert.Error(t, err)
 }
+
+func TestExecuteRouteTool_callsHandlerWithBuiltRequest(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	h := &fakeHandler{}
+	s.BindCallResourceHandler(h)
+
+	out, err := s.executeRouteTool(context.Background(), routeToolSpec{
+		Method:     "GET",
+		Path:       "/labels",
+		PathParams: nil,
+		QueryArgs:  []string{"owner", "repository"},
+	}, map[string]any{
+		"owner":      "grafana",
+		"repository": "github-datasource",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, h.resourceCalledWith)
+	assert.Equal(t, "GET", h.resourceCalledWith.Method)
+	assert.Equal(t, "/labels", h.resourceCalledWith.Path)
+	assert.Contains(t, h.resourceCalledWith.URL, "owner=grafana")
+	assert.Contains(t, h.resourceCalledWith.URL, "repository=github-datasource")
+}
+
+func TestExecuteRouteTool_substitutesPathParams(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	h := &fakeHandler{}
+	s.BindCallResourceHandler(h)
+
+	_, err := s.executeRouteTool(context.Background(), routeToolSpec{
+		Method:     "GET",
+		Path:       "/repos/{owner}/{repo}/files",
+		PathParams: []string{"owner", "repo"},
+	}, map[string]any{
+		"owner": "grafana",
+		"repo":  "github-datasource",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/repos/grafana/github-datasource/files", h.resourceCalledWith.Path)
+}

--- a/experimental/mcp/handlers_test.go
+++ b/experimental/mcp/handlers_test.go
@@ -110,3 +110,15 @@ func TestExecuteRouteTool_substitutesPathParams(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "/repos/grafana/github-datasource/files", h.resourceCalledWith.Path)
 }
+
+func TestExecuteHealthTool_returnsCheckHealthResult(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	h := &fakeHandler{}
+	s.BindCheckHealthHandler(h)
+
+	out, err := s.executeHealthTool(context.Background())
+	require.NoError(t, err)
+	m, ok := out.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "OK", m["status"])
+}

--- a/experimental/mcp/handlers_test.go
+++ b/experimental/mcp/handlers_test.go
@@ -1,0 +1,44 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeHandler struct {
+	queryCalledWith    *backend.QueryDataRequest
+	resourceCalledWith *backend.CallResourceRequest
+	healthCalledWith   *backend.CheckHealthRequest
+}
+
+func (f *fakeHandler) QueryData(_ context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	f.queryCalledWith = req
+	return &backend.QueryDataResponse{Responses: backend.Responses{"A": backend.DataResponse{}}}, nil
+}
+
+func (f *fakeHandler) CallResource(_ context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	f.resourceCalledWith = req
+	return sender.Send(&backend.CallResourceResponse{Status: 200, Body: []byte(`{"ok":true}`)})
+}
+
+func (f *fakeHandler) CheckHealth(_ context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	f.healthCalledWith = req
+	return &backend.CheckHealthResult{Status: backend.HealthStatusOk}, nil
+}
+
+func TestServer_Bind_storesHandlers(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	h := &fakeHandler{}
+	s.BindQueryDataHandler(h)
+	s.BindCallResourceHandler(h)
+	s.BindCheckHealthHandler(h)
+	require.NotNil(t, s.queryDataHandler)
+	require.NotNil(t, s.callResourceHandler)
+	require.NotNil(t, s.checkHealthHandler)
+	// Type assertion via accessors:
+	assert.Equal(t, h, s.QueryDataHandler())
+}

--- a/experimental/mcp/handlers_test.go
+++ b/experimental/mcp/handlers_test.go
@@ -45,6 +45,9 @@ func TestServer_Bind_storesHandlers(t *testing.T) {
 
 func TestExecuteQueryTool_callsHandlerAndEncodesFrames(t *testing.T) {
 	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterPluginContext("test-uid", backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "test-uid"},
+	})
 	h := &fakeHandler{}
 	s.BindQueryDataHandler(h)
 
@@ -73,6 +76,9 @@ func TestExecuteQueryTool_errorsWhenHandlerNotBound(t *testing.T) {
 
 func TestExecuteRouteTool_callsHandlerWithBuiltRequest(t *testing.T) {
 	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterPluginContext("test-uid", backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "test-uid"},
+	})
 	h := &fakeHandler{}
 	s.BindCallResourceHandler(h)
 
@@ -96,6 +102,9 @@ func TestExecuteRouteTool_callsHandlerWithBuiltRequest(t *testing.T) {
 
 func TestExecuteRouteTool_substitutesPathParams(t *testing.T) {
 	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterPluginContext("test-uid", backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "test-uid"},
+	})
 	h := &fakeHandler{}
 	s.BindCallResourceHandler(h)
 
@@ -116,7 +125,10 @@ func TestExecuteHealthTool_returnsCheckHealthResult(t *testing.T) {
 	h := &fakeHandler{}
 	s.BindCheckHealthHandler(h)
 
-	out, err := s.executeHealthTool(context.Background())
+	s.RegisterPluginContext("test-uid", backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "test-uid"},
+	})
+	out, err := s.executeHealthTool(context.Background(), map[string]any{})
 	require.NoError(t, err)
 	m, ok := out.(map[string]any)
 	require.True(t, ok)

--- a/experimental/mcp/handlers_test.go
+++ b/experimental/mcp/handlers_test.go
@@ -42,3 +42,31 @@ func TestServer_Bind_storesHandlers(t *testing.T) {
 	// Type assertion via accessors:
 	assert.Equal(t, h, s.QueryDataHandler())
 }
+
+func TestExecuteQueryTool_callsHandlerAndEncodesFrames(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	h := &fakeHandler{}
+	s.BindQueryDataHandler(h)
+
+	args := map[string]any{
+		"owner":      "grafana",
+		"repository": "github-datasource",
+	}
+	out, err := s.executeQueryTool(context.Background(), "Pull_Requests", args)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	// Handler should have been called with a single DataQuery whose JSON body matches args.
+	require.NotNil(t, h.queryCalledWith)
+	require.Len(t, h.queryCalledWith.Queries, 1)
+	q := h.queryCalledWith.Queries[0]
+	assert.Equal(t, "Pull_Requests", q.QueryType)
+	assert.Equal(t, "A", q.RefID)
+	assert.JSONEq(t, `{"owner":"grafana","repository":"github-datasource"}`, string(q.JSON))
+}
+
+func TestExecuteQueryTool_errorsWhenHandlerNotBound(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	_, err := s.executeQueryTool(context.Background(), "Pull_Requests", map[string]any{})
+	assert.Error(t, err)
+}

--- a/experimental/mcp/integration_test.go
+++ b/experimental/mcp/integration_test.go
@@ -48,6 +48,9 @@ func TestEndToEnd_registerStartCallTool(t *testing.T) {
 	}
 
 	srv := mcp.NewServer(mcp.ServerOpts{Name: "test-ds", Version: "1.0", Addr: "127.0.0.1:0"})
+	srv.RegisterPluginContext("test-uid", backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "test-uid"},
+	})
 	ds := &stubDS{}
 	srv.BindQueryDataHandler(ds)
 	srv.BindCallResourceHandler(ds)

--- a/experimental/mcp/integration_test.go
+++ b/experimental/mcp/integration_test.go
@@ -1,0 +1,99 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	sdkapi "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/fromschema"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/pluginschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubDS struct{ qReq *backend.QueryDataRequest }
+
+func (s *stubDS) QueryData(_ context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	s.qReq = req
+	return &backend.QueryDataResponse{}, nil
+}
+func (s *stubDS) CallResource(_ context.Context, _ *backend.CallResourceRequest, _ backend.CallResourceResponseSender) error {
+	return nil
+}
+func (s *stubDS) CheckHealth(_ context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	return &backend.CheckHealthResult{Status: backend.HealthStatusOk}, nil
+}
+
+func TestEndToEnd_registerStartCallTool(t *testing.T) {
+	// build a minimal schema with one query type and unmarshal a JSON Schema
+	// the proper way (the JSONSchema type stores *spec.Schema internally).
+	var js sdkapi.JSONSchema
+	require.NoError(t, json.Unmarshal([]byte(`{"type":"object"}`), &js))
+
+	schema := &pluginschema.PluginSchema{
+		QueryTypes: &sdkapi.QueryTypeDefinitionList{
+			Items: []sdkapi.QueryTypeDefinition{{
+				ObjectMeta: sdkapi.ObjectMeta{Name: "Pull_Requests"},
+				Spec: sdkapi.QueryTypeDefinitionSpec{
+					Discriminators: []sdkapi.DiscriminatorFieldValue{{Field: "queryType", Value: "Pull_Requests"}},
+					Schema:         js,
+				},
+			}},
+		},
+	}
+
+	srv := mcp.NewServer(mcp.ServerOpts{Name: "test-ds", Version: "1.0", Addr: "127.0.0.1:0"})
+	ds := &stubDS{}
+	srv.BindQueryDataHandler(ds)
+	srv.BindCallResourceHandler(ds)
+	srv.BindCheckHealthHandler(ds)
+
+	fromschema.RegisterQueryTools(srv, schema)
+	fromschema.RegisterHealthCheckTool(srv)
+
+	require.NoError(t, srv.Start(context.Background()))
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}()
+
+	addr := srv.ListenAddr()
+	require.NotEmpty(t, addr)
+
+	// verify the listener is actually accepting TCP connections - that's a
+	// sufficient Phase 1 smoke check that registration + Start wired the HTTP
+	// transport up correctly. Deeper protocol-level coverage already lives in
+	// server_test.go via the in-process mcptest client.
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	// confirm both registered tools are visible on the server.
+	tools := srv.Tools()
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	assert.Contains(t, names, "query_Pull_Requests")
+	assert.Contains(t, names, "check_health")
+
+	// invoke the registered query tool directly to confirm the bound handler
+	// is reached end-to-end through the registration path.
+	var queryTool mcp.Tool
+	for _, tool := range tools {
+		if tool.Name == "query_Pull_Requests" {
+			queryTool = tool
+			break
+		}
+	}
+	require.NotNil(t, queryTool.Handler)
+	_, err = queryTool.Handler(context.Background(), map[string]any{})
+	require.NoError(t, err)
+	require.NotNil(t, ds.qReq, "bound QueryData handler should have been invoked")
+}

--- a/experimental/mcp/mcptest/client.go
+++ b/experimental/mcp/mcptest/client.go
@@ -1,0 +1,28 @@
+// Package mcptest provides in-memory wiring for testing an mcp.Server end-to-end
+// without spinning up an HTTP listener.
+package mcptest
+
+import (
+	"context"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// NewClient returns a connected client+session pair backed by an in-memory
+// transport pair. The caller is responsible for closing the session.
+func NewClient(ctx context.Context, server *mcpsdk.Server) (*mcpsdk.Client, *mcpsdk.ClientSession, error) {
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
+	clientT, serverT := mcpsdk.NewInMemoryTransports()
+
+	// connect server side first - servers must be connected before clients
+	// because the client initializes the MCP session during connection
+	if _, err := server.Connect(ctx, serverT, nil); err != nil {
+		return nil, nil, err
+	}
+
+	session, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	return client, session, nil
+}

--- a/experimental/mcp/prompts.go
+++ b/experimental/mcp/prompts.go
@@ -1,0 +1,30 @@
+package mcp
+
+// Prompt is a registerable MCP prompt template.
+type Prompt struct {
+	Name        string
+	Description string
+	// Template is the literal prompt text. Argument substitution is the
+	// caller's responsibility for v1.
+	Template string
+	// Arguments declares any prompt arguments (name, description, required).
+	Arguments []PromptArgument
+}
+
+type PromptArgument struct {
+	Name        string
+	Description string
+	Required    bool
+}
+
+func (s *Server) RegisterPrompt(p Prompt) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, existing := range s.prompts {
+		if existing.Name == p.Name {
+			s.prompts[i] = p
+			return
+		}
+	}
+	s.prompts = append(s.prompts, p)
+}

--- a/experimental/mcp/resources.go
+++ b/experimental/mcp/resources.go
@@ -1,0 +1,28 @@
+package mcp
+
+import "context"
+
+// ResourceReader returns the resource body and its MIME type. The default
+// MIME type from the Resource struct is used if the reader returns "".
+type ResourceReader func(ctx context.Context) (body []byte, mimeType string, err error)
+
+// Resource is a registerable MCP resource.
+type Resource struct {
+	URI         string
+	Name        string
+	Description string
+	MIMEType    string
+	Reader      ResourceReader
+}
+
+func (s *Server) RegisterResource(r Resource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, existing := range s.resources {
+		if existing.URI == r.URI {
+			s.resources[i] = r
+			return
+		}
+	}
+	s.resources = append(s.resources, r)
+}

--- a/experimental/mcp/server.go
+++ b/experimental/mcp/server.go
@@ -13,8 +13,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
+	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -49,6 +53,10 @@ type Server struct {
 	queryDataHandler    any // backend.QueryDataHandler - typed import in handlers.go
 	callResourceHandler any // backend.CallResourceHandler
 	checkHealthHandler  any // backend.CheckHealthHandler
+
+	// pluginContexts maps datasource UID → PluginContext, populated by
+	// RegisterPluginContext as gRPC calls arrive from Grafana.
+	pluginContexts map[string]backend.PluginContext
 
 	// transport state, populated by Start
 	httpServer *http.Server
@@ -90,6 +98,57 @@ func (s *Server) Prompts() []Prompt {
 	return out
 }
 
+// RegisterPluginContext stores the PluginContext for the given datasource UID.
+// Called by the gRPC interception layer in datasource.Manage whenever Grafana
+// sends a request for that instance, so MCP tool calls can reuse the context.
+func (s *Server) RegisterPluginContext(uid string, pctx backend.PluginContext) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pluginContexts == nil {
+		s.pluginContexts = make(map[string]backend.PluginContext)
+	}
+	s.pluginContexts[uid] = pctx
+}
+
+// LookupPluginContext returns the PluginContext for the given uid.
+// If uid is empty and exactly one datasource has been registered, that one is
+// returned (convenience for single-datasource setups). Otherwise an error is
+// returned listing the available UIDs.
+func (s *Server) LookupPluginContext(uid string) (backend.PluginContext, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if uid != "" {
+		pctx, ok := s.pluginContexts[uid]
+		if !ok {
+			uids := s.registeredUIDs()
+			return backend.PluginContext{}, fmt.Errorf("no datasource instance registered for uid %q; registered: [%s]", uid, strings.Join(uids, ", "))
+		}
+		return pctx, nil
+	}
+
+	switch len(s.pluginContexts) {
+	case 0:
+		return backend.PluginContext{}, errors.New("no datasource instance registered yet; Grafana must call the plugin at least once before MCP tools can be used")
+	case 1:
+		for _, pctx := range s.pluginContexts {
+			return pctx, nil
+		}
+	}
+	uids := s.registeredUIDs()
+	return backend.PluginContext{}, fmt.Errorf("multiple datasource instances registered; pass datasource_uid (one of: %s)", strings.Join(uids, ", "))
+}
+
+// registeredUIDs returns a sorted list of registered datasource UIDs. Caller must hold mu.
+func (s *Server) registeredUIDs() []string {
+	uids := make([]string, 0, len(s.pluginContexts))
+	for uid := range s.pluginContexts {
+		uids = append(uids, uid)
+	}
+	sort.Strings(uids)
+	return uids
+}
+
 // resolveAddr applies the priority order: env var > opts.Addr > auto-pick on 127.0.0.1.
 func (s *Server) resolveAddr() string {
 	if v := os.Getenv(EnvAddr); v != "" {
@@ -122,7 +181,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.Handle("/mcp", handler)
 	mux.Handle("/mcp/", handler)
 
-	s.httpServer = &http.Server{Handler: mux}
+	s.httpServer = &http.Server{Handler: logRequests(s.opts.Name, mux)}
 	go func() {
 		if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.DefaultLogger.Error("MCP HTTP server stopped with error", "err", err)
@@ -172,6 +231,9 @@ func (s *Server) buildSDKServer() *mcpsdk.Server {
 			// SDK requires a non-nil object schema; default to an empty object schema
 			schema = map[string]any{"type": "object"}
 		}
+		if normalized, ok := normalizeJSONSchema(schema).(map[string]any); ok {
+			schema = normalized
+		}
 		raw, err := json.Marshal(schema)
 		if err != nil {
 			log.DefaultLogger.Warn("failed to marshal tool input schema, skipping tool", "tool", t.Name, "err", err)
@@ -183,9 +245,12 @@ func (s *Server) buildSDKServer() *mcpsdk.Server {
 			InputSchema: json.RawMessage(raw),
 		}
 		srv.AddTool(sdkTool, func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			start := time.Now()
+			log.DefaultLogger.Info("MCP tool call", "tool", t.Name)
 			var args map[string]any
 			if len(req.Params.Arguments) > 0 {
 				if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+					log.DefaultLogger.Warn("MCP tool args decode failed", "tool", t.Name, "err", err, "duration_ms", time.Since(start).Milliseconds())
 					return &mcpsdk.CallToolResult{
 						IsError: true,
 						Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: err.Error()}},
@@ -194,6 +259,7 @@ func (s *Server) buildSDKServer() *mcpsdk.Server {
 			}
 			out, err := t.Handler(ctx, args)
 			if err != nil {
+				log.DefaultLogger.Error("MCP tool call failed", "tool", t.Name, "err", err, "duration_ms", time.Since(start).Milliseconds())
 				return &mcpsdk.CallToolResult{
 					IsError: true,
 					Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: err.Error()}},
@@ -201,8 +267,10 @@ func (s *Server) buildSDKServer() *mcpsdk.Server {
 			}
 			body, err := json.Marshal(out)
 			if err != nil {
+				log.DefaultLogger.Error("MCP tool result marshal failed", "tool", t.Name, "err", err, "duration_ms", time.Since(start).Milliseconds())
 				return nil, err
 			}
+			log.DefaultLogger.Info("MCP tool call ok", "tool", t.Name, "bytes", len(body), "duration_ms", time.Since(start).Milliseconds())
 			return &mcpsdk.CallToolResult{
 				Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: string(body)}},
 			}, nil
@@ -267,6 +335,117 @@ func (s *Server) writeAddrFile() error {
 		return err
 	}
 	return os.WriteFile(AddrFile, []byte(s.listenAddr+"\n"), 0o644)
+}
+
+// normalizeJSONSchema strips legacy draft-04 keywords and rewrites them into
+// their JSON Schema draft 2020-12 equivalents. Anthropic's tool-use API strictly
+// validates input schemas against 2020-12; a draft-04 "$schema" declaration
+// alone is enough to trigger a 400 error. This walks the schema recursively
+// and removes "$schema"/"id" and converts the boolean form of
+// "exclusiveMinimum"/"exclusiveMaximum" into the 2020-12 numeric form.
+//
+// The original map is not mutated; nested maps and slices are copied as needed.
+func normalizeJSONSchema(in any) any {
+	switch v := in.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, val := range v {
+			// drop draft-04-only metadata keywords
+			if key == "$schema" || key == "id" {
+				continue
+			}
+			out[key] = normalizeJSONSchema(val)
+		}
+		// draft-04: exclusiveMinimum/exclusiveMaximum were booleans modifying
+		// minimum/maximum. In 2020-12 they are numbers replacing minimum/maximum.
+		convertExclusive(out, "minimum", "exclusiveMinimum")
+		convertExclusive(out, "maximum", "exclusiveMaximum")
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = normalizeJSONSchema(item)
+		}
+		return out
+	default:
+		return in
+	}
+}
+
+// convertExclusive rewrites the legacy draft-04 boolean form of
+// exclusiveMinimum/exclusiveMaximum into the 2020-12 numeric form. If the
+// boolean is true, the numeric bound is moved to the exclusive key; if false
+// or absent, the boolean is simply dropped.
+func convertExclusive(m map[string]any, boundKey, exclusiveKey string) {
+	excl, ok := m[exclusiveKey]
+	if !ok {
+		return
+	}
+	b, isBool := excl.(bool)
+	if !isBool {
+		// already a number — leave it alone
+		return
+	}
+	if b {
+		if bound, hasBound := m[boundKey]; hasBound {
+			m[exclusiveKey] = bound
+			delete(m, boundKey)
+			return
+		}
+	}
+	delete(m, exclusiveKey)
+}
+
+// logRequests wraps an http.Handler and emits an info log for every request,
+// including method, path, status, response size, and duration. Errors at the
+// transport layer (status >= 500) are logged at error level.
+func logRequests(serverName string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		log.DefaultLogger.Info("MCP request", "server", serverName, "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr)
+		next.ServeHTTP(rec, r)
+		dur := time.Since(start)
+		level := log.DefaultLogger.Info
+		if rec.status >= 500 {
+			level = log.DefaultLogger.Error
+		}
+		level("MCP response", "server", serverName, "method", r.Method, "path", r.URL.Path, "status", rec.status, "bytes", rec.bytes, "duration_ms", dur.Milliseconds())
+	})
+}
+
+// statusRecorder captures the response status code and byte count so that
+// logRequests can include them in its log line.
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	bytes       int
+	wroteHeader bool
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	if !r.wroteHeader {
+		r.status = status
+		r.wroteHeader = true
+	}
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if !r.wroteHeader {
+		r.wroteHeader = true
+	}
+	n, err := r.ResponseWriter.Write(b)
+	r.bytes += n
+	return n, err
+}
+
+// Flush implements http.Flusher so that streamable HTTP responses still flush
+// through the wrapper. The MCP SDK relies on this for SSE-style transport.
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }
 
 func isLoopback(hostPort string) bool {

--- a/experimental/mcp/server.go
+++ b/experimental/mcp/server.go
@@ -4,7 +4,28 @@
 // the gRPC server.
 package mcp
 
-import "sync"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	// EnvAddr is the env var that overrides the configured Addr (and forces a
+	// specific bind address, ignoring auto-pick).
+	EnvAddr = "GF_PLUGIN_MCP_ADDR"
+	// AddrFile is written next to dist/standalone.txt with host:port when the
+	// listener is bound, so external tooling can find it.
+	AddrFile = "dist/mcp.addr"
+)
 
 // ServerOpts configures a Server.
 type ServerOpts struct {
@@ -27,6 +48,10 @@ type Server struct {
 	queryDataHandler    any // backend.QueryDataHandler - typed import in handlers.go
 	callResourceHandler any // backend.CallResourceHandler
 	checkHealthHandler  any // backend.CheckHealthHandler
+
+	// transport state, populated by Start
+	httpServer *http.Server
+	listenAddr string
 }
 
 // NewServer constructs an unstarted Server.
@@ -62,4 +87,101 @@ func (s *Server) Prompts() []Prompt {
 	out := make([]Prompt, len(s.prompts))
 	copy(out, s.prompts)
 	return out
+}
+
+// resolveAddr applies the priority order: env var > opts.Addr > auto-pick on 127.0.0.1.
+func (s *Server) resolveAddr() string {
+	if v := os.Getenv(EnvAddr); v != "" {
+		return v
+	}
+	if s.opts.Addr != "" {
+		return s.opts.Addr
+	}
+	return "127.0.0.1:0"
+}
+
+// Start binds the listener and serves the MCP HTTP transport. Non-blocking:
+// returns once the listener is accepted, or an error if binding failed.
+func (s *Server) Start(ctx context.Context) error {
+	if s.httpServer != nil {
+		return errors.New("MCP server already started")
+	}
+	addr := s.resolveAddr()
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("MCP listen on %s: %w", addr, err)
+	}
+	s.listenAddr = listener.Addr().String()
+
+	// build the underlying MCP SDK server from our registered state
+	sdkServer := s.buildSDKServer()
+	handler := mcpsdk.NewStreamableHTTPHandler(func(*http.Request) *mcpsdk.Server { return sdkServer }, nil)
+
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", handler)
+	mux.Handle("/mcp/", handler)
+
+	s.httpServer = &http.Server{Handler: mux}
+	go func() {
+		if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.DefaultLogger.Error("MCP HTTP server stopped with error", "err", err)
+		}
+	}()
+
+	if err := s.writeAddrFile(); err != nil {
+		log.DefaultLogger.Warn("failed to write MCP addr file", "err", err)
+	}
+	if !isLoopback(s.listenAddr) {
+		log.DefaultLogger.Warn("MCP listener bound to non-loopback address; auth must be handled by a gateway", "addr", s.listenAddr)
+	}
+	log.DefaultLogger.Info("MCP server listening", "addr", s.listenAddr)
+	return nil
+}
+
+// Shutdown gracefully stops the HTTP server. Caller should pass a deadline.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.httpServer == nil {
+		return nil
+	}
+	err := s.httpServer.Shutdown(ctx)
+	s.httpServer = nil
+	_ = os.Remove(AddrFile)
+	return err
+}
+
+// ListenAddr returns the bound address (host:port) or "" if not started.
+func (s *Server) ListenAddr() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.listenAddr
+}
+
+// buildSDKServer constructs the modelcontextprotocol/go-sdk Server from the
+// registered Tool/Resource/Prompt state. Called once per Start.
+func (s *Server) buildSDKServer() *mcpsdk.Server {
+	srv := mcpsdk.NewServer(&mcpsdk.Implementation{
+		Name:    s.opts.Name,
+		Version: s.opts.Version,
+	}, nil)
+	// tools, resources, prompts will be added in Task 8
+	return srv
+}
+
+func (s *Server) writeAddrFile() error {
+	if err := os.MkdirAll(filepath.Dir(AddrFile), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(AddrFile, []byte(s.listenAddr+"\n"), 0o644)
+}
+
+func isLoopback(hostPort string) bool {
+	host, _, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return false
+	}
+	if host == "" || host == "127.0.0.1" || host == "::1" || host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }

--- a/experimental/mcp/server.go
+++ b/experimental/mcp/server.go
@@ -6,6 +6,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -163,7 +164,101 @@ func (s *Server) buildSDKServer() *mcpsdk.Server {
 		Name:    s.opts.Name,
 		Version: s.opts.Version,
 	}, nil)
-	// tools, resources, prompts will be added in Task 8
+
+	for _, t := range s.Tools() {
+		t := t // capture
+		schema := t.InputSchema
+		if schema == nil {
+			// SDK requires a non-nil object schema; default to an empty object schema
+			schema = map[string]any{"type": "object"}
+		}
+		raw, err := json.Marshal(schema)
+		if err != nil {
+			log.DefaultLogger.Warn("failed to marshal tool input schema, skipping tool", "tool", t.Name, "err", err)
+			continue
+		}
+		sdkTool := &mcpsdk.Tool{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: json.RawMessage(raw),
+		}
+		srv.AddTool(sdkTool, func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			var args map[string]any
+			if len(req.Params.Arguments) > 0 {
+				if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+					return &mcpsdk.CallToolResult{
+						IsError: true,
+						Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: err.Error()}},
+					}, nil
+				}
+			}
+			out, err := t.Handler(ctx, args)
+			if err != nil {
+				return &mcpsdk.CallToolResult{
+					IsError: true,
+					Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: err.Error()}},
+				}, nil
+			}
+			body, err := json.Marshal(out)
+			if err != nil {
+				return nil, err
+			}
+			return &mcpsdk.CallToolResult{
+				Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: string(body)}},
+			}, nil
+		})
+	}
+
+	for _, r := range s.Resources() {
+		r := r
+		sdkRes := &mcpsdk.Resource{
+			URI:         r.URI,
+			Name:        r.Name,
+			Description: r.Description,
+			MIMEType:    r.MIMEType,
+		}
+		srv.AddResource(sdkRes, func(ctx context.Context, _ *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+			body, mimeType, err := r.Reader(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if mimeType == "" {
+				mimeType = r.MIMEType
+			}
+			return &mcpsdk.ReadResourceResult{
+				Contents: []*mcpsdk.ResourceContents{{
+					URI:      r.URI,
+					MIMEType: mimeType,
+					Text:     string(body),
+				}},
+			}, nil
+		})
+	}
+
+	for _, p := range s.Prompts() {
+		p := p
+		args := make([]*mcpsdk.PromptArgument, 0, len(p.Arguments))
+		for _, a := range p.Arguments {
+			args = append(args, &mcpsdk.PromptArgument{
+				Name:        a.Name,
+				Description: a.Description,
+				Required:    a.Required,
+			})
+		}
+		srv.AddPrompt(&mcpsdk.Prompt{
+			Name:        p.Name,
+			Description: p.Description,
+			Arguments:   args,
+		}, func(ctx context.Context, _ *mcpsdk.GetPromptRequest) (*mcpsdk.GetPromptResult, error) {
+			return &mcpsdk.GetPromptResult{
+				Messages: []*mcpsdk.PromptMessage{{
+					Role:    "user",
+					Content: &mcpsdk.TextContent{Text: p.Template},
+				}},
+			}, nil
+		})
+	}
+
 	return srv
 }
 

--- a/experimental/mcp/server.go
+++ b/experimental/mcp/server.go
@@ -1,0 +1,65 @@
+// Package mcp embeds an MCP server inside a Grafana datasource plugin process.
+// It binds the plugin's existing gRPC handlers (QueryData, CallResource, CheckHealth)
+// to MCP tools, exposes resources and prompts, and runs an HTTP transport alongside
+// the gRPC server.
+package mcp
+
+import "sync"
+
+// ServerOpts configures a Server.
+type ServerOpts struct {
+	Name    string
+	Version string
+	// Addr is the bind address (e.g. ":7401"). If empty, see address resolution
+	// rules in Server.Start: env var first, then auto-pick on 127.0.0.1.
+	Addr string
+}
+
+// Server is the embedded MCP server for a plugin.
+type Server struct {
+	opts      ServerOpts
+	mu        sync.RWMutex
+	tools     []Tool
+	resources []Resource
+	prompts   []Prompt
+
+	// handler bindings, populated by Bind*
+	queryDataHandler    any // backend.QueryDataHandler - typed import in handlers.go
+	callResourceHandler any // backend.CallResourceHandler
+	checkHealthHandler  any // backend.CheckHealthHandler
+}
+
+// NewServer constructs an unstarted Server.
+func NewServer(opts ServerOpts) *Server {
+	return &Server{opts: opts}
+}
+
+func (s *Server) Name() string    { return s.opts.Name }
+func (s *Server) Version() string { return s.opts.Version }
+
+// Tools returns a snapshot of registered tools.
+func (s *Server) Tools() []Tool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Tool, len(s.tools))
+	copy(out, s.tools)
+	return out
+}
+
+// Resources returns a snapshot of registered resources.
+func (s *Server) Resources() []Resource {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Resource, len(s.resources))
+	copy(out, s.resources)
+	return out
+}
+
+// Prompts returns a snapshot of registered prompts.
+func (s *Server) Prompts() []Prompt {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Prompt, len(s.prompts))
+	copy(out, s.prompts)
+	return out
+}

--- a/experimental/mcp/server_test.go
+++ b/experimental/mcp/server_test.go
@@ -1,0 +1,37 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewServer_returnsServerWithName(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "test-plugin", Version: "1.0.0"})
+	assert.NotNil(t, s)
+	assert.Equal(t, "test-plugin", s.Name())
+	assert.Equal(t, "1.0.0", s.Version())
+}
+
+func TestServer_RegisterTool_listsTool(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterTool(Tool{Name: "ping", Description: "pong"})
+	tools := s.Tools()
+	assert.Len(t, tools, 1)
+	assert.Equal(t, "ping", tools[0].Name)
+}
+
+func TestServer_RegisterResource_listsResource(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterResource(Resource{URI: "examples://query", MIMEType: "application/json"})
+	resources := s.Resources()
+	assert.Len(t, resources, 1)
+	assert.Equal(t, "examples://query", resources[0].URI)
+}
+
+func TestServer_RegisterPrompt_listsPrompt(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterPrompt(Prompt{Name: "investigate", Description: "walk it"})
+	prompts := s.Prompts()
+	assert.Len(t, prompts, 1)
+}

--- a/experimental/mcp/server_test.go
+++ b/experimental/mcp/server_test.go
@@ -12,6 +12,55 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNormalizeJSONSchema_stripsDraft04Metadata(t *testing.T) {
+	in := map[string]any{
+		"$schema": "https://json-schema.org/draft-04/schema",
+		"id":      "legacy-id",
+		"type":    "object",
+		"properties": map[string]any{
+			"x": map[string]any{
+				"$schema": "https://json-schema.org/draft-04/schema",
+				"type":    "string",
+			},
+		},
+	}
+	out, ok := normalizeJSONSchema(in).(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, out, "$schema")
+	assert.NotContains(t, out, "id")
+	props := out["properties"].(map[string]any)
+	assert.NotContains(t, props["x"].(map[string]any), "$schema")
+	// original input must remain untouched
+	assert.Contains(t, in, "$schema")
+}
+
+func TestNormalizeJSONSchema_convertsExclusiveBoolToNumeric(t *testing.T) {
+	in := map[string]any{
+		"type":             "number",
+		"minimum":          1.0,
+		"exclusiveMinimum": true,
+		"maximum":          10.0,
+		"exclusiveMaximum": false,
+	}
+	out, ok := normalizeJSONSchema(in).(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 1.0, out["exclusiveMinimum"])
+	assert.NotContains(t, out, "minimum")
+	// exclusiveMaximum: false drops both the boolean and keeps maximum as-is
+	assert.NotContains(t, out, "exclusiveMaximum")
+	assert.Equal(t, 10.0, out["maximum"])
+}
+
+func TestNormalizeJSONSchema_leavesNumericExclusiveAlone(t *testing.T) {
+	in := map[string]any{
+		"type":             "number",
+		"exclusiveMinimum": 5.0,
+	}
+	out, ok := normalizeJSONSchema(in).(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 5.0, out["exclusiveMinimum"])
+}
+
 func TestNewServer_returnsServerWithName(t *testing.T) {
 	s := NewServer(ServerOpts{Name: "test-plugin", Version: "1.0.0"})
 	assert.NotNil(t, s)

--- a/experimental/mcp/server_test.go
+++ b/experimental/mcp/server_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/experimental/mcp/mcptest"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -63,4 +65,54 @@ func TestServer_Start_failsWhenAddrInUse(t *testing.T) {
 	s := NewServer(ServerOpts{Name: "x", Version: "0", Addr: occupier.Addr().String()})
 	err = s.Start(context.Background())
 	assert.Error(t, err)
+}
+
+func TestServer_buildSDKServer_listsRegisteredTools(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterTool(Tool{
+		Name:        "ping",
+		Description: "pong",
+		Handler: func(ctx context.Context, args map[string]any) (any, error) {
+			return "pong", nil
+		},
+	})
+
+	sdk := s.buildSDKServer()
+	ctx := context.Background()
+	_, session, err := mcptest.NewClient(ctx, sdk)
+	require.NoError(t, err)
+	defer session.Close()
+
+	res, err := session.ListTools(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, res.Tools, 1)
+	assert.Equal(t, "ping", res.Tools[0].Name)
+}
+
+func TestServer_buildSDKServer_callsToolHandler(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0"})
+	s.RegisterTool(Tool{
+		Name:        "echo",
+		Description: "echo",
+		InputSchema: map[string]any{"type": "object"},
+		Handler: func(ctx context.Context, args map[string]any) (any, error) {
+			return args, nil
+		},
+	})
+
+	sdk := s.buildSDKServer()
+	ctx := context.Background()
+	_, session, err := mcptest.NewClient(ctx, sdk)
+	require.NoError(t, err)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "echo",
+		Arguments: map[string]any{"hello": "world"},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Content)
+	textContent, ok := res.Content[0].(*mcpsdk.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, textContent.Text, `"hello":"world"`)
 }

--- a/experimental/mcp/server_test.go
+++ b/experimental/mcp/server_test.go
@@ -1,9 +1,13 @@
 package mcp
 
 import (
+	"context"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewServer_returnsServerWithName(t *testing.T) {
@@ -34,4 +38,29 @@ func TestServer_RegisterPrompt_listsPrompt(t *testing.T) {
 	s.RegisterPrompt(Prompt{Name: "investigate", Description: "walk it"})
 	prompts := s.Prompts()
 	assert.Len(t, prompts, 1)
+}
+
+func TestServer_StartAndShutdown_listensOnEphemeralPort(t *testing.T) {
+	s := NewServer(ServerOpts{Name: "x", Version: "0", Addr: "127.0.0.1:0"})
+	require.NoError(t, s.Start(context.Background()))
+
+	addr := s.ListenAddr()
+	require.NotEmpty(t, addr)
+
+	// MCP HTTP endpoint should accept POST to /mcp at minimum (initialize).
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	require.NoError(t, err)
+	conn.Close()
+
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
+func TestServer_Start_failsWhenAddrInUse(t *testing.T) {
+	occupier, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer occupier.Close()
+
+	s := NewServer(ServerOpts{Name: "x", Version: "0", Addr: occupier.Addr().String()})
+	err = s.Start(context.Background())
+	assert.Error(t, err)
 }

--- a/experimental/mcp/tools.go
+++ b/experimental/mcp/tools.go
@@ -1,0 +1,40 @@
+package mcp
+
+import "context"
+
+// ToolHandler runs the tool. args is a JSON object decoded from the MCP call.
+// It returns the tool output (will be JSON-encoded as TextContent) or an error.
+type ToolHandler func(ctx context.Context, args map[string]any) (any, error)
+
+// Tool is a registerable MCP tool.
+type Tool struct {
+	Name        string
+	Description string
+	// InputSchema is a JSON Schema document (as a map) describing the tool's input.
+	// Pass nil for tools that take no arguments.
+	InputSchema map[string]any
+	// Annotations is a free-form metadata map exposed to MCP clients.
+	Annotations map[string]any
+	// Examples surface as the MCP tool's "examples" field.
+	Examples []any
+	// Handler is the function invoked on tools/call. Required.
+	Handler ToolHandler
+}
+
+// RegisterTool adds a tool. If a tool with the same Name already exists, it
+// is replaced (UpdateTool semantics).
+func (s *Server) RegisterTool(t Tool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, existing := range s.tools {
+		if existing.Name == t.Name {
+			s.tools[i] = t
+			return
+		}
+	}
+	s.tools = append(s.tools, t)
+}
+
+// UpdateTool is an alias for RegisterTool to make the override intent explicit
+// when callers know the tool already exists.
+func (s *Server) UpdateTool(t Tool) { s.RegisterTool(t) }

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
@@ -103,6 +104,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
+	github.com/modelcontextprotocol/go-sdk v1.6.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
@@ -120,10 +122,13 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/segmentio/asm v1.1.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/unknwon/com v1.0.1 // indirect
 	github.com/unknwon/log v0.0.0-20150304194804-e617c87089d3 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,10 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // @grafana/grafana-app-platform-squad
 )
 
-require github.com/go-openapi/jsonreference v0.21.5
+require (
+	github.com/go-openapi/jsonreference v0.21.5
+	github.com/modelcontextprotocol/go-sdk v1.6.0
+)
 
 require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
@@ -104,7 +107,6 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
-	github.com/modelcontextprotocol/go-sdk v1.6.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1ks85zJ1lfDGgIiMDuIptTOhJq+zKyg=
@@ -191,6 +193,8 @@ github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 h1:+n/aFZefKZp7spd8D
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8R/ZQT/HkhPkY=
+github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -239,6 +243,10 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 h1:Jpy1PXuP99tXNrhbq2BaPz9B+jNAvH1JPQQpG/9GCXY=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -271,6 +279,8 @@ github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
 github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/gogo/googleapis v1.4.1 h1:1Yx4Myt7BxzvUr5ldGSbwYiZG6t9wGBZ+8/fX3Wvtq0
 github.com/gogo/googleapis v1.4.1/go.mod h1:2lpHqI5OcWCtVElxXnPt+s8oJvMpySlOyM6xDCrzib4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=


### PR DESCRIPTION
Adds an `experimental/mcp` package that lets datasource plugins expose tools, resources and prompts over MCP HTTP, driven by their existing `pluginschema` files.

The plugin's `main.go` constructs an `mcp.Server`, binds the same handler used for gRPC via the new `datasource.NewAutomanagementHandler`, and calls `fromschema.Register*` helpers. The MCP listener is lifecycle-managed by `datasource.Manage` via `ManageOpts.MCPServer`.

Companion plugin POCs:
- grafana/github-datasource#740
- grafana/redshift-datasource#828

Design and implementation plan in [`experimental/mcp/docs/`](https://github.com/grafana/grafana-plugin-sdk-go/blob/feat/embedded-mcp/experimental/mcp/docs/design.md).

## Test plan
- [x] `go test ./experimental/mcp/...` passes (24 tests)
- [x] `go test ./backend/datasource/...` passes (3 new lifecycle tests)
- [ ] Manual smoke via `mcp-inspector` against a wired plugin