### PR TITLE
chore: migrate codeowners to @grafana/grafana-catalog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone opens a pull request.
-* @grafana/plugins-platform-backend
+* @grafana/grafana-catalog
 /backend/gtime @grafana/oss-big-tent @grafana/observability-logs @grafana/partner-datasources
 /data/ @grafana/grafana-datasources-core-services
 /experimental/apis/datasource @grafana/grafana-datasources-core-services


### PR DESCRIPTION
## Summary

Migrate ownership from the three retiring plugins-platform handles to a single new handle `@grafana/grafana-catalog`:

- `@grafana/plugins-platform` → `@grafana/grafana-catalog`
- `@grafana/plugins-platform-frontend` → `@grafana/grafana-catalog`
- `@grafana/plugins-platform-backend` → `@grafana/grafana-catalog`

Tracking issue: grafana/grafana-catalog-team#870

## Test plan
- [ ] CI passes
- [ ] CODEOWNERS validation succeeds