### PR TITLE
chore(renovate): disable dependency dashboard and add package groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
     },
     {
       "groupName": "gRPC packages",
-      "matchPackageNames": ["google.golang.org/grpc", "google.golang.org/protobuf", "google.golang.org/genproto/**"]
+      "matchPackageNames": ["google.golang.org/grpc", "google.golang.org/protobuf", "google.golang.org/genproto/**", "github.com/grpc-ecosystem/**"]
     },
     {
       "groupName": "Prometheus packages",
@@ -25,10 +25,6 @@
     {
       "groupName": "HashiCorp packages",
       "matchPackageNames": ["github.com/hashicorp/**"]
-    },
-    {
-      "groupName": "grpc-ecosystem packages",
-      "matchPackageNames": ["github.com/grpc-ecosystem/**"]
     },
     {
       "groupName": "Kubernetes packages",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "dependencyDashboard": false,
   "schedule": ["before 6am on the first day of the week"],
   "packageRules": [
     {
@@ -8,6 +9,30 @@
     {
       "groupName": "OpenTelemetry packages",
       "matchPackageNames": ["go.opentelemetry.io/**"]
+    },
+    {
+      "groupName": "go-openapi packages",
+      "matchPackageNames": ["github.com/go-openapi/**"]
+    },
+    {
+      "groupName": "gRPC packages",
+      "matchPackageNames": ["google.golang.org/grpc", "google.golang.org/protobuf", "google.golang.org/genproto/**"]
+    },
+    {
+      "groupName": "Prometheus packages",
+      "matchPackageNames": ["github.com/prometheus/**"]
+    },
+    {
+      "groupName": "HashiCorp packages",
+      "matchPackageNames": ["github.com/hashicorp/**"]
+    },
+    {
+      "groupName": "grpc-ecosystem packages",
+      "matchPackageNames": ["github.com/grpc-ecosystem/**"]
+    },
+    {
+      "groupName": "Kubernetes packages",
+      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"]
     }
   ],
   "github-actions": { "enabled": true, "groupName": "GitHub Actions" },


### PR DESCRIPTION
Disables the Renovate dependency dashboard issue, and adds a few more package groups to cut down on PR noise.

New groups, all multi-package families that tend to release together:
- `github.com/go-openapi/**` (loads, spec, strfmt, swag, validate)
- `google.golang.org/**` (grpc, protobuf, genproto) plus `github.com/grpc-ecosystem/**` — version-coupled, best bumped together
- `github.com/prometheus/**`
- `github.com/hashicorp/**`
- `k8s.io/**` + `sigs.k8s.io/**`