### PR TITLE
chore(deps): group non-major Go module updates to reduce renovate PR volume

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "schedule": ["before 6am on the first day of the week"],
   "packageRules": [
     {
+      "groupName": "All Go module dependencies",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch", "digest"]
+    },
+    {
       "groupName": "Upstream packages",
       "matchPackageNames": ["golang.org/x/**"]
     },


### PR DESCRIPTION
Renovate opens an individual PR for every loose Go module bump here (pyroscope-go, otel-profiling-go, the go directive, and similar), which adds up in the In Review column.

This adds an "All Go module dependencies" catch-all that folds minor/patch/digest gomod updates into one weekly PR. It sits ahead of the existing per-ecosystem groups (Upstream, OpenTelemetry, gRPC, Prometheus, HashiCorp, Kubernetes, go-openapi), so those still get their own grouped PRs and major bumps still land individually.