### PR TITLE
feat(sqlutil): add InputTypeMatcher for function-based converter matching

### DIFF
--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -148,6 +148,17 @@ type Converter struct {
 	// InputColumnName is the case-sensitive name that must match the column that this converter matches
 	InputColumnName string
 
+	// InputTypeMatcher is an optional function that reports whether this converter applies to the
+	// column's database type name, as reported by sql.ColumnType.DatabaseTypeName (which may be
+	// empty for some drivers). It is consulted in addition to InputTypeName, InputTypeRegex and
+	// InputColumnName; the converter is selected if any of them match, and the first matching
+	// converter in the supplied slice wins. Use it for parameterized or nested types (e.g.
+	// ClickHouse "SimpleAggregateFunction(max, Float64)") where enumerating every permutation
+	// with InputTypeRegex is impractical. It is invoked once per column per result set, never per
+	// row, and is ignored by the Dynamic converter path. The database driver must be able to scan
+	// the wrapped type into this converter's InputScanType.
+	InputTypeMatcher func(dbType string) bool
+
 	// FrameConverter defines how to convert the scanned value into a value that can be put into a dataframe
 	FrameConverter FrameConverter
 

--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -140,7 +140,8 @@ func (r *RowConverter) NewScannableRow() []any {
 
 func converterMatches(v Converter, dbType string, colName string) bool {
 	return (v.InputColumnName == colName && v.InputColumnName != "") ||
-		v.InputTypeName == dbType || (v.InputTypeRegex != nil && v.InputTypeRegex.MatchString(dbType))
+		v.InputTypeName == dbType || (v.InputTypeRegex != nil && v.InputTypeRegex.MatchString(dbType)) ||
+		(v.InputTypeMatcher != nil && v.InputTypeMatcher(dbType))
 }
 
 func columnType(colType *sql.ColumnType) *sql.ColumnType {

--- a/data/sqlutil/scanrow_internal_test.go
+++ b/data/sqlutil/scanrow_internal_test.go
@@ -1,0 +1,160 @@
+package sqlutil
+
+import (
+	"database/sql"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// unwrapWrapperTypes recursively unwraps ClickHouse-style wrapper types, e.g.
+// "SimpleAggregateFunction(max, Float64)" -> "Float64",
+// "LowCardinality(String)" -> "String", including nested combinations such as
+// "SimpleAggregateFunction(anyLast, LowCardinality(Float64))" -> "Float64".
+func unwrapWrapperTypes(dbType string) string {
+	for {
+		switch {
+		case strings.HasPrefix(dbType, "LowCardinality(") && strings.HasSuffix(dbType, ")"):
+			dbType = dbType[len("LowCardinality(") : len(dbType)-1]
+		case strings.HasPrefix(dbType, "SimpleAggregateFunction(") && strings.HasSuffix(dbType, ")"):
+			inner := dbType[len("SimpleAggregateFunction(") : len(dbType)-1]
+			depth := 0
+			cut := -1
+			for i, ch := range inner {
+				switch {
+				case ch == '(':
+					depth++
+				case ch == ')':
+					depth--
+				case ch == ',' && depth == 0:
+					cut = i
+				}
+				if cut >= 0 {
+					break
+				}
+			}
+			if cut < 0 {
+				return dbType
+			}
+			dbType = strings.TrimSpace(inner[cut+1:])
+		default:
+			return dbType
+		}
+	}
+}
+
+func TestConverterMatchesWithInputTypeMatcher(t *testing.T) {
+	float64Converter := Converter{
+		Name: "Float64",
+		// An unset InputTypeName exact-matches an empty DatabaseTypeName, which
+		// would short-circuit the empty-type-name case before the matcher runs,
+		// so pin it to a value that never matches.
+		InputTypeName: "sentinel-never-matches",
+		InputTypeMatcher: func(dbType string) bool {
+			return unwrapWrapperTypes(dbType) == "Float64"
+		},
+	}
+
+	tests := []struct {
+		dbType string
+		want   bool
+	}{
+		{"Float64", true},
+		{"SimpleAggregateFunction(max, Float64)", true},
+		{"LowCardinality(Float64)", true},
+		{"SimpleAggregateFunction(anyLast, LowCardinality(Float64))", true},
+		{"Float32", false},
+		{"Map(String, Float64)", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		name := tt.dbType
+		if name == "" {
+			name = "empty type name"
+		}
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.want, converterMatches(float64Converter, tt.dbType, "col"))
+		})
+	}
+}
+
+func TestConverterMatchesExistingPredicatesWithMatcher(t *testing.T) {
+	tests := []struct {
+		name    string
+		conv    Converter
+		dbType  string
+		colName string
+		want    bool
+	}{
+		{
+			name: "nil matcher and no other predicate does not match",
+			conv: Converter{},
+			// zero-value predicates must not match arbitrary types
+			dbType: "Float64", colName: "col", want: false,
+		},
+		{
+			name:   "type name still matches with nil matcher",
+			conv:   Converter{InputTypeName: "Float64"},
+			dbType: "Float64", colName: "col", want: true,
+		},
+		{
+			name:   "regex still matches with nil matcher",
+			conv:   Converter{InputTypeRegex: regexp.MustCompile(`^Float`)},
+			dbType: "Float64", colName: "col", want: true,
+		},
+		{
+			name:   "column name still matches with nil matcher",
+			conv:   Converter{InputColumnName: "col"},
+			dbType: "Float64", colName: "col", want: true,
+		},
+		{
+			name: "matcher matches when other predicates do not",
+			conv: Converter{
+				InputTypeName:    "Other",
+				InputTypeMatcher: func(string) bool { return true },
+			},
+			dbType: "Float64", colName: "col", want: true,
+		},
+		{
+			name: "non-matching matcher does not prevent a type name match",
+			conv: Converter{
+				InputTypeName:    "Float64",
+				InputTypeMatcher: func(string) bool { return false },
+			},
+			dbType: "Float64", colName: "col", want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, converterMatches(tt.conv, tt.dbType, tt.colName))
+		})
+	}
+}
+
+func TestMakeScanRowMatcherPrecedence(t *testing.T) {
+	matcherConverter := Converter{
+		Name:             "matcher",
+		InputScanType:    reflect.TypeOf(""),
+		InputTypeMatcher: func(string) bool { return true },
+	}
+	regexConverter := Converter{
+		Name:           "regex",
+		InputScanType:  reflect.TypeOf(""),
+		InputTypeRegex: regexp.MustCompile(`.*`),
+	}
+
+	// The first matching converter in slice order wins, regardless of which
+	// mechanism (matcher or regex) it matched with.
+	rc, err := MakeScanRow([]*sql.ColumnType{nil}, []string{"a"}, matcherConverter, regexConverter)
+	require.NoError(t, err)
+	require.Len(t, rc.Converters, 1)
+	require.Equal(t, "matcher", rc.Converters[0].Name)
+
+	rc, err = MakeScanRow([]*sql.ColumnType{nil}, []string{"a"}, regexConverter, matcherConverter)
+	require.NoError(t, err)
+	require.Len(t, rc.Converters, 1)
+	require.Equal(t, "regex", rc.Converters[0].Name)
+}

--- a/data/sqlutil/sql_test.go
+++ b/data/sqlutil/sql_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 
@@ -35,9 +36,10 @@ func (*baseRows) Close() error {
 type singleResultSet struct {
 	baseRows
 
-	rows       [][]interface{}
-	currentRow int
-	scanTypes  []reflect.Type
+	rows        [][]interface{}
+	currentRow  int
+	scanTypes   []reflect.Type
+	dbTypeNames []string
 }
 
 func (rows *singleResultSet) Next(dest []driver.Value) error {
@@ -57,6 +59,13 @@ func (rows *singleResultSet) ColumnTypeScanType(index int) reflect.Type {
 		return reflect.TypeFor[any]()
 	}
 	return rows.scanTypes[index]
+}
+
+func (rows *singleResultSet) ColumnTypeDatabaseTypeName(index int) string {
+	if index >= len(rows.dbTypeNames) {
+		return ""
+	}
+	return rows.dbTypeNames[index]
 }
 
 type multipleResultSets struct {
@@ -170,6 +179,24 @@ func makeSingleResultSetWithScanTypes(
 			rows:       data,
 			currentRow: -1,
 			scanTypes:  scanTypes,
+		},
+	}).Query("")
+	return rows
+}
+
+func makeSingleResultSetWithTypeNames(
+	columnNames []string,
+	dbTypeNames []string,
+	data ...[]interface{},
+) *sql.Rows {
+	rows, _ := sql.OpenDB(&fakeDB{
+		rows: &singleResultSet{
+			baseRows: baseRows{
+				columnNames: columnNames,
+			},
+			rows:        data,
+			currentRow:  -1,
+			dbTypeNames: dbTypeNames,
 		},
 	}).Query("")
 	return rows
@@ -541,6 +568,90 @@ func TestFrameFromRows(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFrameFromRowsWithInputTypeMatcher(t *testing.T) {
+	// unwrap recursively strips ClickHouse-style wrapper types so a single
+	// converter per base type can match every wrapped permutation.
+	var unwrap func(dbType string) string
+	unwrap = func(dbType string) string {
+		const saf = "SimpleAggregateFunction("
+		const lc = "LowCardinality("
+		switch {
+		case strings.HasPrefix(dbType, lc) && strings.HasSuffix(dbType, ")"):
+			return unwrap(dbType[len(lc) : len(dbType)-1])
+		case strings.HasPrefix(dbType, saf) && strings.HasSuffix(dbType, ")"):
+			inner := dbType[len(saf) : len(dbType)-1]
+			depth := 0
+			for i, ch := range inner {
+				switch {
+				case ch == '(':
+					depth++
+				case ch == ')':
+					depth--
+				case ch == ',' && depth == 0:
+					return unwrap(strings.TrimSpace(inner[i+1:]))
+				}
+			}
+			return dbType
+		default:
+			return dbType
+		}
+	}
+	matcherFor := func(baseType string) func(string) bool {
+		return func(dbType string) bool {
+			return unwrap(dbType) == baseType
+		}
+	}
+
+	converters := []sqlutil.Converter{
+		{
+			Name:             "Float64",
+			InputScanType:    reflect.TypeOf(float64(0)),
+			InputTypeMatcher: matcherFor("Float64"),
+			FrameConverter: sqlutil.FrameConverter{
+				FieldType: data.FieldTypeFloat64,
+				ConverterFunc: func(in interface{}) (interface{}, error) {
+					return *(in.(*float64)), nil
+				},
+			},
+		},
+		{
+			Name:             "String",
+			InputScanType:    reflect.TypeOf(""),
+			InputTypeMatcher: matcherFor("String"),
+			FrameConverter: sqlutil.FrameConverter{
+				FieldType: data.FieldTypeString,
+				ConverterFunc: func(in interface{}) (interface{}, error) {
+					return *(in.(*string)), nil
+				},
+			},
+		},
+	}
+
+	rows := makeSingleResultSetWithTypeNames( //nolint:rowserrcheck
+		[]string{"saf", "nested", "lc", "plain"},
+		[]string{
+			"SimpleAggregateFunction(max, Float64)",
+			"SimpleAggregateFunction(anyLast, LowCardinality(Float64))",
+			"LowCardinality(String)",
+			"Float64",
+		},
+		[]interface{}{1.5, 2.5, "a", 3.5},
+		[]interface{}{4.5, 5.5, "b", 6.5},
+	)
+
+	frame, err := sqlutil.FrameFromRows(rows, 100, converters...)
+	require.NoError(t, err)
+	expected := &data.Frame{
+		Fields: []*data.Field{
+			data.NewField("saf", nil, []float64{1.5, 4.5}),
+			data.NewField("nested", nil, []float64{2.5, 5.5}),
+			data.NewField("lc", nil, []string{"a", "b"}),
+			data.NewField("plain", nil, []float64{3.5, 6.5}),
+		},
+	}
+	require.Equal(t, expected, frame)
 }
 
 func TestFrameFromRows_MultipleTimes(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds an optional `InputTypeMatcher func(dbType string) bool` field to `sqlutil.Converter`, consulted in `converterMatches` alongside the existing `InputTypeName`, `InputTypeRegex` and `InputColumnName` fields.

Implements the SDK side of grafana/sqlds#156.

## Problem

Converter matching is purely declarative, so parameterised or nested column types can only be handled by enumerating permutations. ClickHouse is the canonical case: grafana/clickhouse-datasource#1928 needed around 30 generated regex patterns to cover `SimpleAggregateFunction` inner types, and nested combinations such as `SimpleAggregateFunction(anyLast, LowCardinality(Float64))` still fall through to a JSON catch-all because no enumeration covers them.

## Change

A driver can now attach one matcher per base converter that recursively unwraps wrapper types and compares the base type, so a single `Float64` converter covers `Float64`, `SimpleAggregateFunction(max, Float64)`, `LowCardinality(Float64)` and any nested combination.

- The matcher is OR'd as the last clause of `converterMatches`, so behaviour for converters without a matcher is byte-for-byte identical, and the nil zero value keeps this fully backward compatible
- First matching converter in slice order still wins, the same ordering discipline regex converters already require
- Matching runs once per column per result set in `MakeScanRow`, never per row, so there is no per-row cost
- The `Dynamic` converter path is unaffected (it infers types from scanned values and diverts before `MakeScanRow`)

## Tests

- White-box table tests for `converterMatches` with a recursive ClickHouse-style unwrap matcher, including nested wrappers, non-matches, the empty type name, interplay with the existing predicates and `MakeScanRow` slice-order precedence
- An end-to-end `FrameFromRows` test where one matcher-equipped converter per base type handles four differently wrapped columns, using a new `makeSingleResultSetWithTypeNames` fake-driver helper (the existing fakes did not implement `ColumnTypeDatabaseTypeName`)

One pre-existing quirk surfaced while writing the tests, left unchanged here: an unset `InputTypeName` exact-matches an empty `DatabaseTypeName`, since both are `""`.

## Alternatives considered

A resolver hook (`func(sql.ColumnType) *Converter`) passed to `FrameFromRows` would be more powerful but needs a new entry point and is harder to test, since `sql.ColumnType` cannot be fabricated outside `database/sql`. The matcher field is the minimal surface and does not block adding a resolver later.
