### PR TITLE
fix(sqlutil): restore column type propagation to ConvertWithColumn

### DIFF
--- a/data/sqlutil/scanrow.go
+++ b/data/sqlutil/scanrow.go
@@ -91,6 +91,8 @@ func MakeScanRow(colTypes []*sql.ColumnType, colNames []string, converters ...Co
 
 		for _, v := range converters {
 			if converterMatches(v, colType.DatabaseTypeName(), colName) {
+				// v is a copy, so this does not mutate the caller's converter
+				v.colType = *colType
 				rc.append(colName, scanType(v, colType.ScanType()), v)
 				break
 			}

--- a/data/sqlutil/sql_test.go
+++ b/data/sqlutil/sql_test.go
@@ -654,6 +654,38 @@ func TestFrameFromRowsWithInputTypeMatcher(t *testing.T) {
 	require.Equal(t, expected, frame)
 }
 
+func TestFrameFromRowsConvertWithColumnReceivesColumnType(t *testing.T) {
+	var seenTypeNames []string
+	converter := sqlutil.Converter{
+		Name:          "String",
+		InputScanType: reflect.TypeOf(""),
+		InputTypeName: "TEST_TYPE",
+		FrameConverter: sqlutil.FrameConverter{
+			FieldType: data.FieldTypeString,
+			ConvertWithColumn: func(in interface{}, col sql.ColumnType) (interface{}, error) {
+				seenTypeNames = append(seenTypeNames, col.DatabaseTypeName())
+				return *(in.(*string)), nil
+			},
+		},
+	}
+
+	rows := makeSingleResultSetWithTypeNames( //nolint:rowserrcheck
+		[]string{"a"},
+		[]string{"TEST_TYPE"},
+		[]interface{}{"x"},
+		[]interface{}{"y"},
+	)
+
+	frame, err := sqlutil.FrameFromRows(rows, 100, converter)
+	require.NoError(t, err)
+	require.Equal(t, &data.Frame{
+		Fields: []*data.Field{
+			data.NewField("a", nil, []string{"x", "y"}),
+		},
+	}, frame)
+	require.Equal(t, []string{"TEST_TYPE", "TEST_TYPE"}, seenTypeNames)
+}
+
 func TestFrameFromRows_MultipleTimes(t *testing.T) {
 	ptr := func(s string) *string {
 		return &s


### PR DESCRIPTION
## Summary

`Converter.colType` is documented as "set during scan" but the assignment was dropped in the 6e33248 refactor (February 2023), so `FrameConverter.ConvertWithColumn` has been receiving a zero `sql.ColumnType` ever since. This reinstates the assignment in `MakeScanRow` on the matched converter copy and adds a regression test asserting `ConvertWithColumn` sees the column's real `DatabaseTypeName`.

## Note for reviewers

This is behaviour-affecting for any existing `ConvertWithColumn` user: they go from always receiving a zero `sql.ColumnType` to receiving the actual column type. That matches the documented contract and the hook is unusable without it, so this is almost certainly a fix rather than a break, but it seemed worth isolating in its own PR for review.

Stacked on #1592 (the regression test reuses the `makeSingleResultSetWithTypeNames` fake-driver helper added there). Will be retargeted to `main` and rebased once #1592 merges.
