### PR TITLE
Set user agent on all HTTP requests

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -47,25 +47,12 @@ func WithGrafanaConfig(ctx context.Context, cfg *config.GrafanaCfg) context.Cont
 	return config.WithGrafanaConfig(ctx, cfg)
 }
 
-type userAgentKey struct{}
-
-// UserAgentFromContext returns user agent from context.
+// Deprecated: use useragent.FromContext instead.
 func UserAgentFromContext(ctx context.Context) *useragent.UserAgent {
-	v := ctx.Value(userAgentKey{})
-	if v == nil {
-		return useragent.Empty()
-	}
-
-	ua := v.(*useragent.UserAgent)
-	if ua == nil {
-		return useragent.Empty()
-	}
-
-	return ua
+	return useragent.FromContext(ctx)
 }
 
-// WithUserAgent injects supplied user agent into context.
+// Deprecated: use useragent.WithUserAgent instead.
 func WithUserAgent(ctx context.Context, ua *useragent.UserAgent) context.Context {
-	ctx = context.WithValue(ctx, userAgentKey{}, ua)
-	return ctx
+	return useragent.WithUserAgent(ctx, ua)
 }

--- a/backend/config_test.go
+++ b/backend/config_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/useragent"
 	"github.com/grafana/grafana-plugin-sdk-go/config"
 	"github.com/grafana/grafana-plugin-sdk-go/experimental/featuretoggles"
 )
@@ -211,25 +210,6 @@ func TestAppURL(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "http://localhost-env:3000", v)
 	})
-}
-
-func TestUserAgentFromContext(t *testing.T) {
-	ua, err := useragent.New("10.0.0", "test", "test")
-	require.NoError(t, err)
-
-	ctx := WithUserAgent(context.Background(), ua)
-	result := UserAgentFromContext(ctx)
-
-	require.Equal(t, "10.0.0", result.GrafanaVersion())
-	require.Equal(t, "Grafana/10.0.0 (test; test)", result.String())
-}
-
-func TestUserAgentFromContext_NoUserAgent(t *testing.T) {
-	ctx := context.Background()
-
-	result := UserAgentFromContext(ctx)
-	require.Equal(t, "0.0.0", result.GrafanaVersion())
-	require.Equal(t, "Grafana/0.0.0 (unknown; unknown)", result.String())
 }
 
 func TestUserFacingDefaultError(t *testing.T) {

--- a/backend/handler_middleware.go
+++ b/backend/handler_middleware.go
@@ -3,6 +3,8 @@ package backend
 import (
 	"context"
 	"errors"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/useragent"
 )
 
 var (
@@ -49,7 +51,7 @@ func (h *MiddlewareHandler) setupContext(ctx context.Context, pluginCtx PluginCo
 	ctx = WithPluginContext(ctx, pluginCtx)
 	ctx = WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
 	ctx = WithUser(ctx, pluginCtx.User)
-	ctx = WithUserAgent(ctx, pluginCtx.UserAgent)
+	ctx = useragent.WithUserAgent(ctx, pluginCtx.UserAgent)
 	return ctx
 }
 

--- a/backend/httpclient/http_client.go
+++ b/backend/httpclient/http_client.go
@@ -233,6 +233,7 @@ func DefaultMiddlewares() []Middleware {
 		DataSourceMetricsMiddleware(),
 		BasicAuthenticationMiddleware(),
 		CustomHeadersMiddleware(),
+		UserAgentMiddleware(),
 		ContextualMiddleware(),
 		ErrorSourceMiddleware(),
 		ResponseLimitMiddleware(0),

--- a/backend/httpclient/http_client_test.go
+++ b/backend/httpclient/http_client_test.go
@@ -70,14 +70,15 @@ func TestNewClient(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, client)
 
-		require.Len(t, usedMiddlewares, 7)
+		require.Len(t, usedMiddlewares, 8)
 		require.Equal(t, TracingMiddlewareName, usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 		require.Equal(t, DataSourceMetricsMiddlewareName, usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 		require.Equal(t, BasicAuthenticationMiddlewareName, usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 		require.Equal(t, CustomHeadersMiddlewareName, usedMiddlewares[3].(MiddlewareName).MiddlewareName())
-		require.Equal(t, ContextualMiddlewareName, usedMiddlewares[4].(MiddlewareName).MiddlewareName())
-		require.Equal(t, ErrorSourceMiddlewareName, usedMiddlewares[5].(MiddlewareName).MiddlewareName())
-		require.Equal(t, ResponseLimitMiddlewareName, usedMiddlewares[6].(MiddlewareName).MiddlewareName())
+		require.Equal(t, UserAgentMiddlewareName, usedMiddlewares[4].(MiddlewareName).MiddlewareName())
+		require.Equal(t, ContextualMiddlewareName, usedMiddlewares[5].(MiddlewareName).MiddlewareName())
+		require.Equal(t, ErrorSourceMiddlewareName, usedMiddlewares[6].(MiddlewareName).MiddlewareName())
+		require.Equal(t, ResponseLimitMiddlewareName, usedMiddlewares[7].(MiddlewareName).MiddlewareName())
 	})
 
 	t.Run("New() with opts middleware should return expected http.Client", func(t *testing.T) {

--- a/backend/httpclient/provider_test.go
+++ b/backend/httpclient/provider_test.go
@@ -25,14 +25,15 @@ func TestProvider(t *testing.T) {
 			client, err := ctx.provider.New()
 			require.NoError(t, err)
 			require.NotNil(t, client)
-			require.Len(t, ctx.usedMiddlewares, 7)
+			require.Len(t, ctx.usedMiddlewares, 8)
 			require.Equal(t, TracingMiddlewareName, ctx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 			require.Equal(t, DataSourceMetricsMiddlewareName, ctx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 			require.Equal(t, BasicAuthenticationMiddlewareName, ctx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 			require.Equal(t, CustomHeadersMiddlewareName, ctx.usedMiddlewares[3].(MiddlewareName).MiddlewareName())
-			require.Equal(t, ContextualMiddlewareName, ctx.usedMiddlewares[4].(MiddlewareName).MiddlewareName())
-			require.Equal(t, ErrorSourceMiddlewareName, ctx.usedMiddlewares[5].(MiddlewareName).MiddlewareName())
-			require.Equal(t, ResponseLimitMiddlewareName, ctx.usedMiddlewares[6].(MiddlewareName).MiddlewareName())
+			require.Equal(t, UserAgentMiddlewareName, ctx.usedMiddlewares[4].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ContextualMiddlewareName, ctx.usedMiddlewares[5].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ErrorSourceMiddlewareName, ctx.usedMiddlewares[6].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ResponseLimitMiddlewareName, ctx.usedMiddlewares[7].(MiddlewareName).MiddlewareName())
 		})
 
 		t.Run("Transport should use default middlewares", func(t *testing.T) {
@@ -40,14 +41,15 @@ func TestProvider(t *testing.T) {
 			transport, err := ctx.provider.GetTransport()
 			require.NoError(t, err)
 			require.NotNil(t, transport)
-			require.Len(t, ctx.usedMiddlewares, 7)
+			require.Len(t, ctx.usedMiddlewares, 8)
 			require.Equal(t, TracingMiddlewareName, ctx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 			require.Equal(t, DataSourceMetricsMiddlewareName, ctx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 			require.Equal(t, BasicAuthenticationMiddlewareName, ctx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
 			require.Equal(t, CustomHeadersMiddlewareName, ctx.usedMiddlewares[3].(MiddlewareName).MiddlewareName())
-			require.Equal(t, ContextualMiddlewareName, ctx.usedMiddlewares[4].(MiddlewareName).MiddlewareName())
-			require.Equal(t, ErrorSourceMiddlewareName, ctx.usedMiddlewares[5].(MiddlewareName).MiddlewareName())
-			require.Equal(t, ResponseLimitMiddlewareName, ctx.usedMiddlewares[6].(MiddlewareName).MiddlewareName())
+			require.Equal(t, UserAgentMiddlewareName, ctx.usedMiddlewares[4].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ContextualMiddlewareName, ctx.usedMiddlewares[5].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ErrorSourceMiddlewareName, ctx.usedMiddlewares[6].(MiddlewareName).MiddlewareName())
+			require.Equal(t, ResponseLimitMiddlewareName, ctx.usedMiddlewares[7].(MiddlewareName).MiddlewareName())
 		})
 
 		t.Run("New() with options and no middleware should return expected http client and transport", func(t *testing.T) {
@@ -88,7 +90,7 @@ func TestProvider(t *testing.T) {
 			require.Equal(t, DefaultTimeoutOptions.Timeout, client.Timeout)
 
 			t.Run("Should use configured middlewares and implement MiddlewareName", func(t *testing.T) {
-				require.Len(t, pCtx.usedMiddlewares, 10)
+				require.Len(t, pCtx.usedMiddlewares, 11)
 				require.Equal(t, "mw1", pCtx.usedMiddlewares[0].(MiddlewareName).MiddlewareName())
 				require.Equal(t, "mw2", pCtx.usedMiddlewares[1].(MiddlewareName).MiddlewareName())
 				require.Equal(t, "mw3", pCtx.usedMiddlewares[2].(MiddlewareName).MiddlewareName())
@@ -96,9 +98,10 @@ func TestProvider(t *testing.T) {
 				require.Equal(t, DataSourceMetricsMiddlewareName, pCtx.usedMiddlewares[4].(MiddlewareName).MiddlewareName())
 				require.Equal(t, BasicAuthenticationMiddlewareName, pCtx.usedMiddlewares[5].(MiddlewareName).MiddlewareName())
 				require.Equal(t, CustomHeadersMiddlewareName, pCtx.usedMiddlewares[6].(MiddlewareName).MiddlewareName())
-				require.Equal(t, ContextualMiddlewareName, pCtx.usedMiddlewares[7].(MiddlewareName).MiddlewareName())
-				require.Equal(t, ErrorSourceMiddlewareName, pCtx.usedMiddlewares[8].(MiddlewareName).MiddlewareName())
-				require.Equal(t, ResponseLimitMiddlewareName, pCtx.usedMiddlewares[9].(MiddlewareName).MiddlewareName())
+				require.Equal(t, UserAgentMiddlewareName, pCtx.usedMiddlewares[7].(MiddlewareName).MiddlewareName())
+				require.Equal(t, ContextualMiddlewareName, pCtx.usedMiddlewares[8].(MiddlewareName).MiddlewareName())
+				require.Equal(t, ErrorSourceMiddlewareName, pCtx.usedMiddlewares[9].(MiddlewareName).MiddlewareName())
+				require.Equal(t, ResponseLimitMiddlewareName, pCtx.usedMiddlewares[10].(MiddlewareName).MiddlewareName())
 			})
 
 			t.Run("When roundtrip should call expected middlewares", func(t *testing.T) {

--- a/backend/httpclient/user_agent_middleware.go
+++ b/backend/httpclient/user_agent_middleware.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/useragent"
 	"github.com/grafana/grafana-plugin-sdk-go/build/buildinfo"
 )
 
@@ -25,16 +26,18 @@ func UserAgentMiddleware() Middleware {
 }
 
 func newUserAgentMiddleware(pluginID string, version string, haveVersionInfo bool) Middleware {
-	userAgent := fmt.Sprintf("%s/%s (Grafana plugin)", pluginID, version)
+	userAgentSuffix := fmt.Sprintf(" %s/%s (Grafana plugin)", pluginID, version)
 
 	return NamedMiddlewareFunc(UserAgentMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
-		if !haveVersionInfo {
-			return next
-		}
-
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if !haveVersionInfo {
+				return next.RoundTrip(req)
+			}
+
+			baseUserAgent := useragent.FromContext(req.Context()).String()
+
 			if len(req.Header.Values("User-Agent")) == 0 {
-				req.Header.Set("User-Agent", userAgent)
+				req.Header.Set("User-Agent", baseUserAgent+userAgentSuffix)
 			}
 
 			return next.RoundTrip(req)

--- a/backend/httpclient/user_agent_middleware.go
+++ b/backend/httpclient/user_agent_middleware.go
@@ -15,23 +15,26 @@ func UserAgentMiddleware() Middleware {
 	info, err := buildinfo.GetBuildInfo.GetInfo()
 
 	if err != nil {
-		log.DefaultLogger.Error("failed to get plugin build info", "error", err)
+		log.DefaultLogger.Debug("failed to get plugin build info, HTTP requests will not have a user agent set", "error", err)
 
-		info = buildinfo.Info{
-			PluginID: "unknown-grafana-plugin",
-			Version:  "unknown",
-		}
+		return newUserAgentMiddleware("", "", false)
 	}
 
-	return newUserAgentMiddleware(info.PluginID, info.Version)
+	return newUserAgentMiddleware(info.PluginID, info.Version, true)
 }
 
-func newUserAgentMiddleware(pluginID string, version string) Middleware {
+func newUserAgentMiddleware(pluginID string, version string, haveVersionInfo bool) Middleware {
 	userAgent := pluginID + "/" + version
 
 	return NamedMiddlewareFunc(UserAgentMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
+		if !haveVersionInfo {
+			return next
+		}
+
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			req.Header.Set("User-Agent", userAgent)
+			if len(req.Header.Values("User-Agent")) == 0 {
+				req.Header.Set("User-Agent", userAgent)
+			}
 
 			return next.RoundTrip(req)
 		})

--- a/backend/httpclient/user_agent_middleware.go
+++ b/backend/httpclient/user_agent_middleware.go
@@ -1,6 +1,7 @@
 package httpclient
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -24,7 +25,7 @@ func UserAgentMiddleware() Middleware {
 }
 
 func newUserAgentMiddleware(pluginID string, version string, haveVersionInfo bool) Middleware {
-	userAgent := pluginID + "/" + version
+	userAgent := fmt.Sprintf("%s/%s (Grafana plugin)", pluginID, version)
 
 	return NamedMiddlewareFunc(UserAgentMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
 		if !haveVersionInfo {

--- a/backend/httpclient/user_agent_middleware.go
+++ b/backend/httpclient/user_agent_middleware.go
@@ -1,0 +1,39 @@
+package httpclient
+
+import (
+	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/build/buildinfo"
+)
+
+// UserAgentMiddlewareName is the middleware name used by UserAgentMiddleware.
+const UserAgentMiddlewareName = "UserAgent"
+
+// UserAgentMiddleware sets a user agent header on the outgoing request.
+func UserAgentMiddleware() Middleware {
+	info, err := buildinfo.GetBuildInfo.GetInfo()
+
+	if err != nil {
+		log.DefaultLogger.Error("failed to get plugin build info", "error", err)
+
+		info = buildinfo.Info{
+			PluginID: "unknown-grafana-plugin",
+			Version:  "unknown",
+		}
+	}
+
+	return newUserAgentMiddleware(info.PluginID, info.Version)
+}
+
+func newUserAgentMiddleware(pluginID string, version string) Middleware {
+	userAgent := pluginID + "/" + version
+
+	return NamedMiddlewareFunc(UserAgentMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
+		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			req.Header.Set("User-Agent", userAgent)
+
+			return next.RoundTrip(req)
+		})
+	})
+}

--- a/backend/httpclient/user_agent_middleware.go
+++ b/backend/httpclient/user_agent_middleware.go
@@ -26,7 +26,7 @@ func UserAgentMiddleware() Middleware {
 }
 
 func newUserAgentMiddleware(pluginID string, version string, haveVersionInfo bool) Middleware {
-	userAgentSuffix := fmt.Sprintf(" %s/%s (Grafana plugin)", pluginID, version)
+	userAgentSuffix := fmt.Sprintf(" %s/%s", pluginID, version)
 
 	return NamedMiddlewareFunc(UserAgentMiddlewareName, func(opts Options, next http.RoundTripper) http.RoundTripper {
 		return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/backend/httpclient/user_agent_middleware_test.go
+++ b/backend/httpclient/user_agent_middleware_test.go
@@ -46,7 +46,7 @@ func TestUserAgentMiddleware(t *testing.T) {
 		headers := http.Header{}
 		finalHeaders := runTestCase(t, headers)
 		expectedHeaders := http.Header{
-			"User-Agent": []string{"Grafana/4.5.6 (SomeOS; x64) test-plugin/1.2.3 (Grafana plugin)"},
+			"User-Agent": []string{"Grafana/4.5.6 (SomeOS; x64) test-plugin/1.2.3"},
 		}
 
 		require.Equal(t, expectedHeaders, finalHeaders)
@@ -58,7 +58,7 @@ func TestUserAgentMiddleware(t *testing.T) {
 		}
 		finalHeaders := runTestCase(t, headers)
 		expectedHeaders := http.Header{
-			"User-Agent": []string{"Grafana/4.5.6 (SomeOS; x64) test-plugin/1.2.3 (Grafana plugin)"},
+			"User-Agent": []string{"Grafana/4.5.6 (SomeOS; x64) test-plugin/1.2.3"},
 			"X-Foo":      []string{"bar"},
 		}
 

--- a/backend/httpclient/user_agent_middleware_test.go
+++ b/backend/httpclient/user_agent_middleware_test.go
@@ -9,6 +9,8 @@ import (
 
 func TestUserAgentMiddleware(t *testing.T) {
 	runTestCase := func(t *testing.T, requestHeaders http.Header) http.Header {
+		t.Helper()
+
 		ctx := &testContext{}
 		finalRoundTripper := ctx.createRoundTripper("final")
 		userAgent := newUserAgentMiddleware("test-plugin", "1.2.3", true)

--- a/backend/httpclient/user_agent_middleware_test.go
+++ b/backend/httpclient/user_agent_middleware_test.go
@@ -8,25 +8,66 @@ import (
 )
 
 func TestUserAgentMiddleware(t *testing.T) {
-	ctx := &testContext{}
-	finalRoundTripper := ctx.createRoundTripper("final")
-	userAgent := newUserAgentMiddleware("test-plugin", "1.2.3")
-	rt := userAgent.CreateMiddleware(Options{}, finalRoundTripper)
-	require.NotNil(t, rt)
-	middlewareName, ok := userAgent.(MiddlewareName)
-	require.True(t, ok)
-	require.Equal(t, UserAgentMiddlewareName, middlewareName.MiddlewareName())
+	runTestCase := func(t *testing.T, requestHeaders http.Header) http.Header {
+		ctx := &testContext{}
+		finalRoundTripper := ctx.createRoundTripper("final")
+		userAgent := newUserAgentMiddleware("test-plugin", "1.2.3", true)
+		rt := userAgent.CreateMiddleware(Options{}, finalRoundTripper)
+		require.NotNil(t, rt)
+		middlewareName, ok := userAgent.(MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, UserAgentMiddlewareName, middlewareName.MiddlewareName())
 
-	req, err := http.NewRequest(http.MethodGet, "http://", nil)
-	require.NoError(t, err)
-	res, err := rt.RoundTrip(req)
-	require.NoError(t, err)
-	require.NotNil(t, res)
-	if res.Body != nil {
-		require.NoError(t, res.Body.Close())
+		req, err := http.NewRequest(http.MethodGet, "http://", nil)
+		require.NoError(t, err)
+		req.Header = requestHeaders
+
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		if res.Body != nil {
+			require.NoError(t, res.Body.Close())
+		}
+		require.Len(t, ctx.callChain, 1)
+		require.ElementsMatch(t, []string{"final"}, ctx.callChain)
+
+		return req.Header
 	}
-	require.Len(t, ctx.callChain, 1)
-	require.ElementsMatch(t, []string{"final"}, ctx.callChain)
 
-	require.Equal(t, []string{"test-plugin/1.2.3"}, req.Header.Values("User-Agent"))
+	t.Run("when no headers are present on the request", func(t *testing.T) {
+		headers := http.Header{}
+		finalHeaders := runTestCase(t, headers)
+		expectedHeaders := http.Header{
+			"User-Agent": []string{"test-plugin/1.2.3"},
+		}
+
+		require.Equal(t, expectedHeaders, finalHeaders)
+	})
+
+	t.Run("when other headers are present on the request, but no User-Agent", func(t *testing.T) {
+		headers := http.Header{
+			"X-Foo": []string{"bar"},
+		}
+		finalHeaders := runTestCase(t, headers)
+		expectedHeaders := http.Header{
+			"User-Agent": []string{"test-plugin/1.2.3"},
+			"X-Foo":      []string{"bar"},
+		}
+
+		require.Equal(t, expectedHeaders, finalHeaders)
+	})
+
+	t.Run("when a User-Agent header is already present", func(t *testing.T) {
+		headers := http.Header{
+			"User-Agent": []string{"foo"},
+			"X-Foo":      []string{"bar"},
+		}
+		finalHeaders := runTestCase(t, headers)
+		expectedHeaders := http.Header{
+			"User-Agent": []string{"foo"},
+			"X-Foo":      []string{"bar"},
+		}
+
+		require.Equal(t, expectedHeaders, finalHeaders)
+	})
 }

--- a/backend/httpclient/user_agent_middleware_test.go
+++ b/backend/httpclient/user_agent_middleware_test.go
@@ -1,0 +1,32 @@
+package httpclient
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserAgentMiddleware(t *testing.T) {
+	ctx := &testContext{}
+	finalRoundTripper := ctx.createRoundTripper("final")
+	userAgent := newUserAgentMiddleware("test-plugin", "1.2.3")
+	rt := userAgent.CreateMiddleware(Options{}, finalRoundTripper)
+	require.NotNil(t, rt)
+	middlewareName, ok := userAgent.(MiddlewareName)
+	require.True(t, ok)
+	require.Equal(t, UserAgentMiddlewareName, middlewareName.MiddlewareName())
+
+	req, err := http.NewRequest(http.MethodGet, "http://", nil)
+	require.NoError(t, err)
+	res, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	if res.Body != nil {
+		require.NoError(t, res.Body.Close())
+	}
+	require.Len(t, ctx.callChain, 1)
+	require.ElementsMatch(t, []string{"final"}, ctx.callChain)
+
+	require.Equal(t, []string{"test-plugin/1.2.3"}, req.Header.Values("User-Agent"))
+}

--- a/backend/httpclient/user_agent_middleware_test.go
+++ b/backend/httpclient/user_agent_middleware_test.go
@@ -1,18 +1,21 @@
 package httpclient
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/useragent"
 )
 
 func TestUserAgentMiddleware(t *testing.T) {
 	runTestCase := func(t *testing.T, requestHeaders http.Header) http.Header {
 		t.Helper()
 
-		ctx := &testContext{}
-		finalRoundTripper := ctx.createRoundTripper("final")
+		testCtx := &testContext{}
+		finalRoundTripper := testCtx.createRoundTripper("final")
 		userAgent := newUserAgentMiddleware("test-plugin", "1.2.3", true)
 		rt := userAgent.CreateMiddleware(Options{}, finalRoundTripper)
 		require.NotNil(t, rt)
@@ -20,7 +23,10 @@ func TestUserAgentMiddleware(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, UserAgentMiddlewareName, middlewareName.MiddlewareName())
 
-		req, err := http.NewRequest(http.MethodGet, "http://", nil)
+		ua, err := useragent.New("4.5.6", "SomeOS", "x64")
+		require.NoError(t, err)
+		ctx := useragent.WithUserAgent(context.Background(), ua)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://", nil)
 		require.NoError(t, err)
 		req.Header = requestHeaders
 
@@ -30,8 +36,8 @@ func TestUserAgentMiddleware(t *testing.T) {
 		if res.Body != nil {
 			require.NoError(t, res.Body.Close())
 		}
-		require.Len(t, ctx.callChain, 1)
-		require.ElementsMatch(t, []string{"final"}, ctx.callChain)
+		require.Len(t, testCtx.callChain, 1)
+		require.ElementsMatch(t, []string{"final"}, testCtx.callChain)
 
 		return req.Header
 	}
@@ -40,7 +46,7 @@ func TestUserAgentMiddleware(t *testing.T) {
 		headers := http.Header{}
 		finalHeaders := runTestCase(t, headers)
 		expectedHeaders := http.Header{
-			"User-Agent": []string{"test-plugin/1.2.3 (Grafana plugin)"},
+			"User-Agent": []string{"Grafana/4.5.6 (SomeOS; x64) test-plugin/1.2.3 (Grafana plugin)"},
 		}
 
 		require.Equal(t, expectedHeaders, finalHeaders)
@@ -52,7 +58,7 @@ func TestUserAgentMiddleware(t *testing.T) {
 		}
 		finalHeaders := runTestCase(t, headers)
 		expectedHeaders := http.Header{
-			"User-Agent": []string{"test-plugin/1.2.3 (Grafana plugin)"},
+			"User-Agent": []string{"Grafana/4.5.6 (SomeOS; x64) test-plugin/1.2.3 (Grafana plugin)"},
 			"X-Foo":      []string{"bar"},
 		}
 

--- a/backend/httpclient/user_agent_middleware_test.go
+++ b/backend/httpclient/user_agent_middleware_test.go
@@ -40,7 +40,7 @@ func TestUserAgentMiddleware(t *testing.T) {
 		headers := http.Header{}
 		finalHeaders := runTestCase(t, headers)
 		expectedHeaders := http.Header{
-			"User-Agent": []string{"test-plugin/1.2.3"},
+			"User-Agent": []string{"test-plugin/1.2.3 (Grafana plugin)"},
 		}
 
 		require.Equal(t, expectedHeaders, finalHeaders)
@@ -52,7 +52,7 @@ func TestUserAgentMiddleware(t *testing.T) {
 		}
 		finalHeaders := runTestCase(t, headers)
 		expectedHeaders := http.Header{
-			"User-Agent": []string{"test-plugin/1.2.3"},
+			"User-Agent": []string{"test-plugin/1.2.3 (Grafana plugin)"},
 			"X-Foo":      []string{"bar"},
 		}
 

--- a/backend/useragent/user_agent.go
+++ b/backend/useragent/user_agent.go
@@ -1,6 +1,7 @@
 package useragent
 
 import (
+	"context"
 	"errors"
 	"regexp"
 )
@@ -60,4 +61,27 @@ func (ua *UserAgent) GrafanaVersion() string {
 
 func (ua *UserAgent) String() string {
 	return "Grafana/" + ua.grafanaVersion + " (" + ua.os + "; " + ua.arch + ")"
+}
+
+type userAgentKey struct{}
+
+// FromContext returns user agent from context.
+func FromContext(ctx context.Context) *UserAgent {
+	v := ctx.Value(userAgentKey{})
+	if v == nil {
+		return Empty()
+	}
+
+	ua := v.(*UserAgent)
+	if ua == nil {
+		return Empty()
+	}
+
+	return ua
+}
+
+// WithUserAgent injects supplied user agent into context.
+func WithUserAgent(ctx context.Context, ua *UserAgent) context.Context {
+	ctx = context.WithValue(ctx, userAgentKey{}, ua)
+	return ctx
 }

--- a/backend/useragent/user_agent_test.go
+++ b/backend/useragent/user_agent_test.go
@@ -1,6 +1,7 @@
 package useragent
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -130,4 +131,23 @@ func TestEmpty(t *testing.T) {
 	}
 	res := Empty()
 	require.Equal(t, expected, res)
+}
+
+func TestUserAgentFromContext(t *testing.T) {
+	ua, err := New("10.0.0", "test", "test")
+	require.NoError(t, err)
+
+	ctx := WithUserAgent(context.Background(), ua)
+	result := FromContext(ctx)
+
+	require.Equal(t, "10.0.0", result.GrafanaVersion())
+	require.Equal(t, "Grafana/10.0.0 (test; test)", result.String())
+}
+
+func TestUserAgentFromContext_NoUserAgent(t *testing.T) {
+	ctx := context.Background()
+
+	result := FromContext(ctx)
+	require.Equal(t, "0.0.0", result.GrafanaVersion())
+	require.Equal(t, "Grafana/0.0.0 (unknown; unknown)", result.String())
 }

--- a/build/buildinfo/info.go
+++ b/build/buildinfo/info.go
@@ -49,7 +49,7 @@ func (f GetterFunc) GetInfo() (Info, error) {
 var GetBuildInfo = GetterFunc(func() (Info, error) {
 	v := Info{}
 	if buildInfoJSON == "" {
-		return v, fmt.Errorf("build info was now set when this was compiled")
+		return v, fmt.Errorf("build info was not set when this was compiled")
 	}
 	err := json.Unmarshal([]byte(buildInfoJSON), &v)
 	return v, err


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new default middleware that sets a `User-Agent` header on all outgoing HTTP requests.

The format is `<plugin ID>/<plugin version>`, eg. `test-plugin/1.2.3`.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-plugin-sdk-go/issues/1601

**Special notes for your reviewer**:

I haven't done much with Grafana plugins before, so very open to feedback on anything - for example, does the format of the user agent make sense? 