### PR TITLE
backend: add a capture seam for datasources that do not speak HTTP

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 # these will be requested for review when someone opens a pull request.
 * @grafana/grafana-catalog
 /backend/gtime @grafana/data-sources-plugins @grafana/observability-logs
+/backend/harcapture @grafana/data-sources-plugins
+/backend/querycapture @grafana/data-sources-plugins
 /data/ @grafana/grafana-datasources-core-services
 /data/sqlutil @grafana/data-sources-plugins
 /experimental/apis/datasource @grafana/grafana-datasources-core-services

--- a/backend/har_capture_middleware.go
+++ b/backend/har_capture_middleware.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/harcapture"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/querycapture"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
@@ -86,6 +87,15 @@ func (h *harCaptureHandler) QueryData(ctx context.Context, req *QueryDataRequest
 		})
 	})
 	ctx = httpclient.WithContextualMiddleware(ctx, captureMW)
+
+	// Activate non-HTTP capture on the same context and into the same buffer. A datasource that speaks
+	// its own protocol over a database/sql driver has no http.RoundTripper to wrap, so the middleware
+	// above never sees it; the recorder is the seam such a plugin reports through (see package
+	// querycapture). Sharing the buffer is what keeps SQL and HTTP evidence in one document instead of
+	// racing for the reserved refID -- which matters for the plugins whose driver is itself HTTP-backed
+	// (ClickHouse, BigQuery, Athena), since those produce both kinds at once. A plugin with no capture
+	// point never reads the recorder back, so this is inert for every plugin that predates the seam.
+	ctx = querycapture.WithRecorder(ctx, harcapture.NewRecorder(buf))
 
 	resp, err := h.BaseHandler.QueryData(ctx, req)
 

--- a/backend/har_capture_middleware_test.go
+++ b/backend/har_capture_middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/handlertest"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/querycapture"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
@@ -317,4 +319,75 @@ func makeHTTPCall(ctx context.Context, t *testing.T, method, url string, body io
 	if err == nil && resp != nil && resp.Body != nil {
 		_ = resp.Body.Close()
 	}
+}
+
+// TestHARCaptureMiddleware_withHeader_capturesNonHTTPQuery covers the datasource kind the HTTP
+// middleware cannot see at all: one that speaks its own protocol over a database/sql driver and makes
+// no HTTP call. Such a plugin reports through the querycapture.Recorder the middleware installs, and
+// its statements must reach Grafana in the same __har__ frame as HTTP traffic would.
+func TestHARCaptureMiddleware_withHeader_capturesNonHTTPQuery(t *testing.T) {
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(backend.NewHARCaptureMiddlewareForTest()))
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		// Stands in for sqlds' DBQuery.Run: capture is on, so report the statement that was executed.
+		rec, ok := querycapture.RecorderFromContext(ctx)
+		require.True(t, ok, "capture is on, so a recorder must be installed on the query context")
+		rec.Record(querycapture.Interaction{
+			Kind:           querycapture.KindSQLQuery,
+			StartedAt:      time.Now(),
+			Duration:       3 * time.Millisecond,
+			DatasourceUID:  "P1234",
+			DatasourceType: "grafana-clickhouse-datasource",
+			RefID:          "A",
+			Statement:      "SELECT host, avg(value) FROM metrics GROUP BY host",
+			FrameCount:     1,
+			RowCount:       2,
+		})
+		return &backend.QueryDataResponse{Responses: backend.Responses{"A": backend.DataResponse{}}}, nil
+	}
+
+	resp, err := cdt.MiddlewareHandler.QueryData(context.Background(), &backend.QueryDataRequest{
+		Headers:       map[string]string{"X-Grafana-HAR-Capture": "true"},
+		PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{UID: "P1234"}},
+	})
+	require.NoError(t, err)
+
+	// The plugin's own response is untouched ...
+	_, hasA := resp.Responses["A"]
+	assert.True(t, hasA)
+
+	// ... and the recorded statement rides back in the reserved capture frame.
+	harResp, ok := resp.Responses["__har__P1234"]
+	require.True(t, ok, "expected a capture frame for a plugin that made no HTTP call but recorded SQL")
+	require.Len(t, harResp.Frames, 1)
+	custom, ok := harResp.Frames[0].Meta.Custom.(map[string]interface{})
+	require.True(t, ok)
+	harStr, ok := custom["har"].(string)
+	require.True(t, ok)
+
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(harStr), &doc))
+	entries := doc["log"].(map[string]interface{})["entries"].([]interface{})
+	require.Len(t, entries, 1)
+	entry := entries[0].(map[string]interface{})
+	request := entry["request"].(map[string]interface{})
+	assert.Equal(t, "QUERY", request["method"])
+	assert.Equal(t, "SELECT host, avg(value) FROM metrics GROUP BY host",
+		request["postData"].(map[string]interface{})["text"])
+	assert.Equal(t, "sql.query", entry["_query"].(map[string]interface{})["kind"])
+}
+
+// TestHARCaptureMiddleware_noHeader_noRecorder is the off-by-default half of the contract: with no
+// capture header there must be no recorder on the context, so a plugin's capture point stays a
+// pass-through and cannot leak statements into a response nobody asked to capture.
+func TestHARCaptureMiddleware_noHeader_noRecorder(t *testing.T) {
+	cdt := handlertest.NewHandlerMiddlewareTest(t, handlertest.WithMiddlewares(backend.NewHARCaptureMiddlewareForTest()))
+	var recorderPresent bool
+	cdt.TestHandler.QueryDataFunc = func(ctx context.Context, _ *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		_, recorderPresent = querycapture.RecorderFromContext(ctx)
+		return &backend.QueryDataResponse{Responses: backend.Responses{}}, nil
+	}
+
+	_, err := cdt.MiddlewareHandler.QueryData(context.Background(), &backend.QueryDataRequest{})
+	require.NoError(t, err)
+	assert.False(t, recorderPresent)
 }

--- a/backend/harcapture/bodyrestore_test.go
+++ b/backend/harcapture/bodyrestore_test.go
@@ -194,7 +194,7 @@ func TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize(t *testing.T) {
 }
 
 // TestSDKHARCaptureBuffer_totalSizeCap asserts that once the cumulative retained body budget is
-// exceeded, later entries keep their metadata/sizes but drop the body text.
+// exhausted, later entries keep their metadata/sizes but drop the body text.
 func TestSDKHARCaptureBuffer_totalSizeCap(t *testing.T) {
 	buf := NewBuffer()
 	big := strings.Repeat("a", maxCapturedBodyBytes) // one per-body-capped chunk each
@@ -220,13 +220,49 @@ func TestSDKHARCaptureBuffer_totalSizeCap(t *testing.T) {
 			keptTrueSize = true
 		}
 	}
-	if total > maxCapturedTotalBytes+2*maxCapturedBodyBytes {
-		t.Errorf("retained body text %d exceeds the cap budget", total)
+	if total > maxCapturedTotalBytes {
+		t.Errorf("retained body text %d exceeds the cap budget %d", total, maxCapturedTotalBytes)
 	}
 	if !droppedText {
 		t.Error("expected later entries to drop body text once over the total budget")
 	}
 	if !keptTrueSize {
 		t.Error("true body size must be preserved even when text is dropped")
+	}
+}
+
+// TestSDKHARCaptureBuffer_totalSizeCapIsTight asserts that the budget bounds the document rather than
+// merely triggering on it: the entry that would take the total past the cap is trimmed itself, instead
+// of being retained whole and only trimming its successors. It is filled unevenly on purpose, so that
+// an entry lands astride the cap -- the case a mixed query-and-HTTP capture reaches easily, since the
+// two producers contribute entries of very different sizes.
+func TestSDKHARCaptureBuffer_totalSizeCapIsTight(t *testing.T) {
+	buf := NewBuffer()
+	addEntry := func(body string) {
+		req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp := &http.Response{Header: http.Header{}, Body: io.NopCloser(strings.NewReader(body))}
+		buf.AddEntry(req, nil, false, resp, nil, time.Now(), time.Millisecond)
+	}
+
+	// Leave the budget with less room than one full chunk, so the next entry straddles the cap.
+	big := strings.Repeat("a", maxCapturedBodyBytes)
+	for i := 0; i < (maxCapturedTotalBytes/maxCapturedBodyBytes)-1; i++ {
+		addEntry(big)
+	}
+	addEntry(strings.Repeat("b", 1024))
+	addEntry(big)
+
+	var total int
+	for _, e := range buf.entries {
+		total += len(e.Response.Content.Text)
+	}
+	if total > maxCapturedTotalBytes {
+		t.Errorf("retained body text %d exceeds the cap budget %d", total, maxCapturedTotalBytes)
+	}
+	if last := buf.entries[len(buf.entries)-1]; last.Response.Content.Text != "" {
+		t.Error("the entry that crosses the budget must drop its body text, not be retained whole")
 	}
 }

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -199,6 +199,7 @@ func (b *Buffer) ToHARString() (string, error) {
 			Version: "1.2",
 			Creator: sdkHARCreator{Name: "grafana-plugin-sdk-go", Version: "1.0"},
 			Entries: entries,
+			Format:  captureFormat,
 		},
 	}
 	raw, err := json.Marshal(doc)
@@ -212,10 +213,20 @@ type sdkHARDocument struct {
 	Log sdkHARLog `json:"log"`
 }
 
+// captureFormat identifies the dialect of an emitted document: HAR 1.2 for the HTTP entries, plus the
+// "_query" extension on entries that describe a non-HTTP datasource exchange. It is bumped when that
+// extension changes in a way a consumer has to know about.
+//
+// It exists so the artifact can be renamed, split or versioned later without a consumer having to
+// guess which shape it is holding.
+const captureFormat = "grafana-datasource-capture/1"
+
 type sdkHARLog struct {
 	Version string        `json:"version"`
 	Creator sdkHARCreator `json:"creator"`
 	Entries []sdkHAREntry `json:"entries"`
+	// Format is an extension field (see captureFormat); canonical HAR parsers ignore it.
+	Format string `json:"_format"`
 }
 
 type sdkHARCreator struct {
@@ -387,7 +398,7 @@ func buildSDKHAREntry(req *http.Request, reqBody []byte, reqTruncated bool, resp
 
 	waitMs := float64(elapsed.Milliseconds())
 	return sdkHAREntry{
-		StartedDateTime: started.UTC().Format(time.RFC3339),
+		StartedDateTime: started.UTC().Format(time.RFC3339Nano),
 		Time:            waitMs,
 		Request: sdkHARRequest{
 			Method:      req.Method,

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -82,13 +82,19 @@ func NewBuffer() *Buffer {
 }
 
 func (b *Buffer) AddEntry(req *http.Request, reqBody []byte, reqTruncated bool, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration) {
-	entry := buildSDKHAREntry(req, reqBody, reqTruncated, resp, rtErr, started, elapsed)
+	b.appendEntry(buildSDKHAREntry(req, reqBody, reqTruncated, resp, rtErr, started, elapsed))
+}
+
+// appendEntry adds an already-built entry under the buffer's cumulative retained-body budget. Every
+// producer goes through here -- HTTP round trips and non-HTTP query interactions alike -- so one
+// budget bounds the whole document whatever mix of traffic a request produced.
+func (b *Buffer) appendEntry(entry sdkHAREntry) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	// Enforce the cumulative retained-body budget: once the request's captured bodies exceed
 	// maxCapturedTotalBytes, keep the entry's metadata (headers, sizes, timings) but drop its body
-	// text so the __har__ frame can't grow without bound. Per-body truncation already happened in
-	// buildSDKHAREntry, so a single entry adds at most 2*maxCapturedBodyBytes here.
+	// text so the __har__ frame can't grow without bound. Per-body truncation already happened when
+	// the entry was built, so a single entry adds at most 2*maxCapturedBodyBytes here.
 	entryBytes := int64(len(entry.Response.Content.Text))
 	if entry.Request.PostData != nil {
 		entryBytes += int64(len(entry.Request.PostData.Text))
@@ -225,8 +231,14 @@ type sdkHAREntry struct {
 	Cache           sdkHARCache    `json:"cache"`
 	Timings         sdkHARTimings  `json:"timings"`
 	// Comment carries a transport-level error (connection refused, DNS/TLS failure, timeout) for a
-	// request that never produced an HTTP response; such entries have a zero-status response.
+	// request that never produced an HTTP response; such entries have a zero-status response. For a
+	// query entry it carries the query's own error, in the same shape.
 	Comment string `json:"comment,omitempty"`
+	// Query is set only on an entry that describes a non-HTTP datasource exchange (see
+	// AddQueryInteraction), and carries what has no HTTP counterpart: the capture kind, the datasource
+	// identity, the refID, truncation flags and the result summary. HAR reserves underscore-prefixed
+	// fields for extensions, so its presence keeps the document valid HAR.
+	Query *sdkHARQueryInfo `json:"_query,omitempty"`
 }
 
 type sdkHARRequest struct {

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -199,7 +199,6 @@ func (b *Buffer) ToHARString() (string, error) {
 			Version: "1.2",
 			Creator: sdkHARCreator{Name: "grafana-plugin-sdk-go", Version: "1.0"},
 			Entries: entries,
-			Format:  captureFormat,
 		},
 	}
 	raw, err := json.Marshal(doc)
@@ -213,20 +212,10 @@ type sdkHARDocument struct {
 	Log sdkHARLog `json:"log"`
 }
 
-// captureFormat identifies the dialect of an emitted document: HAR 1.2 for the HTTP entries, plus the
-// "_query" extension on entries that describe a non-HTTP datasource exchange. It is bumped when that
-// extension changes in a way a consumer has to know about.
-//
-// It exists so the artifact can be renamed, split or versioned later without a consumer having to
-// guess which shape it is holding.
-const captureFormat = "grafana-datasource-capture/1"
-
 type sdkHARLog struct {
 	Version string        `json:"version"`
 	Creator sdkHARCreator `json:"creator"`
 	Entries []sdkHAREntry `json:"entries"`
-	// Format is an extension field (see captureFormat); canonical HAR parsers ignore it.
-	Format string `json:"_format"`
 }
 
 type sdkHARCreator struct {

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -15,7 +15,7 @@ import (
 const (
 	// maxCapturedBodyBytes caps how much of any single request/response body is read into memory for
 	// capture; the untouched remainder is streamed on to the real consumer rather than buffered (see
-	// readAndRestoreBody). maxCapturedTotalBytes caps the total body text retained across all entries
+	// readAndRestoreBody). maxCapturedTotalBytes caps the total payload text retained across all entries
 	// in one request -- i.e. the size of the serialized __har__ frame -- keeping it well under the
 	// plugin<->core gRPC message size limit. Note this budget tracks retained HAR text only: while an
 	// over-cap body is still being streamed to the consumer, its capped head (up to
@@ -74,7 +74,7 @@ func isSensitiveQueryParamName(name string) bool {
 type Buffer struct {
 	mu       sync.Mutex
 	entries  []sdkHAREntry
-	retained int64 // running total of retained body text bytes, for the total-size cap
+	retained int64 // running total of retained payload bytes, for the total-size cap
 }
 
 func NewBuffer() *Buffer {
@@ -85,31 +85,46 @@ func (b *Buffer) AddEntry(req *http.Request, reqBody []byte, reqTruncated bool, 
 	b.appendEntry(buildSDKHAREntry(req, reqBody, reqTruncated, resp, rtErr, started, elapsed))
 }
 
-// appendEntry adds an already-built entry under the buffer's cumulative retained-body budget. Every
-// producer goes through here -- HTTP round trips and non-HTTP query interactions alike -- so one
-// budget bounds the whole document whatever mix of traffic a request produced.
+// appendEntry adds an already-built entry under the buffer's cumulative retained-payload budget.
+// Every producer goes through here -- HTTP round trips and non-HTTP query interactions alike -- so
+// one budget bounds the whole document whatever mix of traffic a request produced.
 func (b *Buffer) appendEntry(entry sdkHAREntry) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	// Enforce the cumulative retained-body budget: once the request's captured bodies exceed
-	// maxCapturedTotalBytes, keep the entry's metadata (headers, sizes, timings) but drop its body
-	// text so the __har__ frame can't grow without bound. Per-body truncation already happened when
-	// the entry was built, so a single entry adds at most 2*maxCapturedBodyBytes here.
-	entryBytes := int64(len(entry.Response.Content.Text))
-	if entry.Request.PostData != nil {
-		entryBytes += int64(len(entry.Request.PostData.Text))
-	}
-	if b.retained >= maxCapturedTotalBytes {
-		entry.Response.Content.Text = ""
-		entry.Response.Content.Encoding = ""
-		if entry.Request.PostData != nil {
-			entry.Request.PostData.Text = ""
-			entry.Request.PostData.Encoding = ""
-		}
+	// Enforce the cumulative retained-payload budget: an entry whose payload would take the request
+	// past maxCapturedTotalBytes keeps its metadata (headers, sizes, timings, error) but drops the
+	// payload itself, so the __har__ frame can't grow without bound. The check is on the sum rather
+	// than on what is already retained, so the entry that crosses the budget is trimmed too rather than
+	// kept whole.
+	payload := entry.payloadBytes()
+	if b.retained+payload > maxCapturedTotalBytes {
+		entry.dropPayload()
 	} else {
-		b.retained += entryBytes
+		b.retained += payload
 	}
 	b.entries = append(b.entries, entry)
+}
+
+// payloadBytes is what an entry contributes to the buffer's retained-payload budget: everything that
+// carries data rather than describing it, whichever producer built the entry.
+func (e *sdkHAREntry) payloadBytes() int64 {
+	n := int64(len(e.Response.Content.Text))
+	if e.Request.PostData != nil {
+		n += int64(len(e.Request.PostData.Text))
+	}
+	return n + e.Query.payloadBytes()
+}
+
+// dropPayload clears an entry's payload, keeping what tells a reader the exchange happened and how it
+// went: headers, the true sizes, timings and any error.
+func (e *sdkHAREntry) dropPayload() {
+	e.Response.Content.Text = ""
+	e.Response.Content.Encoding = ""
+	if e.Request.PostData != nil {
+		e.Request.PostData.Text = ""
+		e.Request.PostData.Encoding = ""
+	}
+	e.Query.dropPayload()
 }
 
 // DrainRequestBody reads and returns the request body (up to the capture cap) and whether it was

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -325,6 +325,13 @@ type sdkHARTimings struct {
 	Receive float64 `json:"receive"`
 }
 
+// durationMs renders a duration for HAR's millisecond-valued time and timings fields, keeping the
+// fraction: a database/sql call over a pooled connection is routinely sub-millisecond, and truncating
+// would make it indistinguishable from an instantaneous one.
+func durationMs(d time.Duration) float64 {
+	return float64(d.Nanoseconds()) / float64(time.Millisecond)
+}
+
 // buildSDKHAREntry builds a HAR entry from the request/response pair. reqBody is the request body
 // captured before the request was sent (see DrainRequestBody); it is passed in rather than read
 // from req.Body here, because by the time capture runs the transport has already drained the body.
@@ -396,7 +403,7 @@ func buildSDKHAREntry(req *http.Request, reqBody []byte, reqTruncated bool, resp
 		comment = "transport error: " + rtErr.Error()
 	}
 
-	waitMs := float64(elapsed.Milliseconds())
+	waitMs := durationMs(elapsed)
 	return sdkHAREntry{
 		StartedDateTime: started.UTC().Format(time.RFC3339Nano),
 		Time:            waitMs,

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -234,10 +234,7 @@ type sdkHAREntry struct {
 	// request that never produced an HTTP response; such entries have a zero-status response. For a
 	// query entry it carries the query's own error, in the same shape.
 	Comment string `json:"comment,omitempty"`
-	// Query is set only on an entry that describes a non-HTTP datasource exchange (see
-	// AddQueryInteraction), and carries what has no HTTP counterpart: the capture kind, the datasource
-	// identity, the refID, truncation flags and the result summary. HAR reserves underscore-prefixed
-	// fields for extensions, so its presence keeps the document valid HAR.
+	// Query is set only on an entry that describes a non-HTTP datasource exchange.
 	Query *sdkHARQueryInfo `json:"_query,omitempty"`
 }
 

--- a/backend/harcapture/parity_test.go
+++ b/backend/harcapture/parity_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	chhar "github.com/chromedp/cdproto/har"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/querycapture"
 )
 
 // TestHARParity_UnmarshalsIntoChromedpHAR verifies our hand-rolled HAR output parses into the
@@ -60,4 +62,119 @@ func TestHARParity_UnmarshalsIntoChromedpHAR(t *testing.T) {
 		t.Errorf("cache object missing")
 	}
 	t.Logf("OUR HAR (round-trips into chromedp har.HAR):\n%s", s)
+}
+
+// TestHARParity_QueryEntriesUnmarshalIntoChromedpHAR is the same guarantee for the entries that
+// describe a non-HTTP exchange, which is what makes putting them in a HAR defensible at all: a query
+// entry fills the HTTP fields with either nothing (no httpVersion, headers or cookies) or the query's
+// own equivalent (a "QUERY" method, a zero status for a failed call), and puts the rest under
+// "_query". Each of those is somewhere a stricter reader could refuse the document, so assert that
+// the canonical model takes them and that "_query" survives for a reader that wants it.
+//
+// The document mixes both producers deliberately: a plugin whose driver is itself HTTP-backed
+// (ClickHouse, BigQuery, Athena) emits both kinds into one buffer, so that -- not a query-only
+// document -- is the shape a consumer actually receives.
+func TestHARParity_QueryEntriesUnmarshalIntoChromedpHAR(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://clickhouse.example.com/ping", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Proto = "HTTP/1.1"
+	rec := httptest.NewRecorder()
+	rec.Header().Set("Content-Type", "text/plain")
+	_, _ = rec.WriteString("Ok.\n")
+	resp := rec.Result()
+	resp.Proto = "HTTP/1.1"
+
+	buf := NewBuffer()
+	buf.AddEntry(req, nil, false, resp, nil, time.Now(), 2*time.Millisecond)
+	buf.AddQueryInteraction(querycapture.Interaction{
+		Kind:           querycapture.KindSQLQuery,
+		StartedAt:      time.Now(),
+		Duration:       750 * time.Microsecond,
+		DatasourceUID:  "P1234",
+		DatasourceType: "grafana-clickhouse-datasource",
+		RefID:          "A",
+		Statement:      "SELECT host, value FROM metrics WHERE host = ?",
+		Args:           []string{"host-a"},
+		FrameCount:     1,
+		RowCount:       10,
+	})
+	// The failed call is the awkward one to parse: a zero status, no content and the error in the
+	// entry comment.
+	buf.AddQueryInteraction(querycapture.Interaction{
+		Kind:      querycapture.KindSQLQuery,
+		StartedAt: time.Now(),
+		RefID:     "B",
+		Statement: "SELECT * FROM missing",
+		RowCount:  -1,
+		Err:       "table missing does not exist",
+	})
+
+	s, err := buf.ToHARString()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var h chhar.HAR
+	if err := json.Unmarshal([]byte(s), &h); err != nil {
+		t.Fatalf("a document with query entries does NOT unmarshal into chromedp har.HAR: %v", err)
+	}
+	if h.Log == nil || len(h.Log.Entries) != 3 {
+		t.Fatalf("expected 3 entries, got %+v", h.Log)
+	}
+	if got := h.Log.Entries[0].Request.Method; got != http.MethodGet {
+		t.Errorf("HTTP entry did not survive alongside the query entries: method %q", got)
+	}
+
+	ok, failed := h.Log.Entries[1], h.Log.Entries[2]
+	if ok.Request == nil || ok.Request.Method != queryMethod {
+		t.Fatalf("query request not parsed: %+v", ok.Request)
+	}
+	if ok.Request.URL != "sql://grafana-clickhouse-datasource/P1234?refId=A" {
+		t.Errorf("query URL not parsed: %q", ok.Request.URL)
+	}
+	// The statement is the evidence the entry exists for, so it has to reach a canonical reader.
+	if ok.Request.PostData == nil || ok.Request.PostData.Text != "SELECT host, value FROM metrics WHERE host = ?" {
+		t.Errorf("statement did not survive as postData.text: %+v", ok.Request.PostData)
+	}
+	if ok.Request.PostData != nil && len(ok.Request.PostData.Params) != 0 {
+		t.Errorf("postData carries text, so params must stay absent: %+v", ok.Request.PostData.Params)
+	}
+	if ok.Response == nil || ok.Response.Status != 200 {
+		t.Errorf("successful query response not parsed: %+v", ok.Response)
+	}
+	if failed.Response == nil || failed.Response.Status != 0 {
+		t.Errorf("failed query response not parsed: %+v", failed.Response)
+	}
+	if failed.Comment != "query error: table missing does not exist" {
+		t.Errorf("query error not parsed from the entry comment: %q", failed.Comment)
+	}
+	// Nil here would mean the canonical model saw no object at all, which the spec requires per entry.
+	if ok.Cache == nil || ok.Timings == nil {
+		t.Errorf("cache/timings object missing on a query entry: cache=%v timings=%v", ok.Cache, ok.Timings)
+	}
+	if ok.Timings.Wait != 0.75 {
+		t.Errorf("sub-millisecond wait did not survive: %v", ok.Timings.Wait)
+	}
+
+	// The canonical model has no field for "_query" and drops it, which is the point -- but a consumer
+	// that does read it must still find it on the entry, so check the wire form too.
+	var raw struct {
+		Log struct {
+			Entries []map[string]json.RawMessage `json:"entries"`
+		} `json:"log"`
+	}
+	if err := json.Unmarshal([]byte(s), &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := raw.Log.Entries[0]["_query"]; present {
+		t.Errorf("an HTTP entry must not carry a _query object")
+	}
+	for _, i := range []int{1, 2} {
+		if _, present := raw.Log.Entries[i]["_query"]; !present {
+			t.Errorf("entry %d lost its _query object", i)
+		}
+	}
+	t.Logf("OUR HAR with query entries (round-trips into chromedp har.HAR):\n%s", s)
 }

--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -34,9 +34,15 @@ func (b *Buffer) AddQueryInteraction(i querycapture.Interaction) {
 	b.appendEntry(buildQueryHAREntry(i))
 }
 
+// queryInfoVersion is the current schema version of the "_query" object, bumped when its shape
+// changes in a way a consumer has to know about.
+const queryInfoVersion = 1
+
 // sdkHARQueryInfo is the "_query" extension object on a query entry. HAR reserves underscore-prefixed
 // fields for extensions, so this travels in a standard HAR document that any viewer can still open.
 type sdkHARQueryInfo struct {
+	// Version is the schema version of this object (see queryInfoVersion).
+	Version int `json:"version"`
 	// Kind is the capture point that produced the entry, e.g. querycapture.KindSQLQuery.
 	Kind string `json:"kind"`
 	// DatasourceUID, DatasourceType and DatasourceName identify which datasource instance ran the
@@ -130,6 +136,7 @@ func buildQueryHAREntry(i querycapture.Interaction) sdkHAREntry {
 		Timings:  sdkHARTimings{Send: 0, Wait: elapsedMs, Receive: 0},
 		Comment:  comment,
 		Query: &sdkHARQueryInfo{
+			Version:            queryInfoVersion,
 			Kind:               i.Kind,
 			DatasourceUID:      i.DatasourceUID,
 			DatasourceType:     i.DatasourceType,

--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -58,8 +58,9 @@ type sdkHARQueryInfo struct {
 	// rather than in the entry's postData because HAR defines postData.params for a URL-encoded body and
 	// states that params and text are mutually exclusive.
 	Args []string `json:"args,omitempty"`
-	// StatementTruncated and ArgsTruncated report that the capture point cut the statement or the
-	// arguments to fit its size bounds, so a reader can tell a long statement from a clipped one.
+	// StatementTruncated and ArgsTruncated report that the statement or the arguments were cut to fit a
+	// size bound -- the capture point's own, or the buffer's cumulative budget -- so a reader can tell a
+	// long statement from a clipped one.
 	StatementTruncated bool `json:"statementTruncated,omitempty"`
 	ArgsTruncated      bool `json:"argsTruncated,omitempty"`
 	// FrameCount and RowCount summarise what the plugin returned; RowCount is -1 when the capture
@@ -69,6 +70,31 @@ type sdkHARQueryInfo struct {
 	// Error is the error the query returned, or empty on success. It repeats the entry comment in a
 	// field an analyzer can read without string matching.
 	Error string `json:"error,omitempty"`
+}
+
+// payloadBytes is the "_query" object's share of the buffer's retained-payload budget (see
+// Buffer.appendEntry): the bind arguments, which a bulk statement can make as large as the statement
+// itself, and the error. A nil receiver is an HTTP entry, which has no "_query".
+func (q *sdkHARQueryInfo) payloadBytes() int64 {
+	if q == nil {
+		return 0
+	}
+	n := int64(len(q.Error))
+	for _, a := range q.Args {
+		n += int64(len(a))
+	}
+	return n
+}
+
+// dropPayload drops the bind arguments, flagging them truncated so their absence does not read as a
+// statement that had none. The error stays: it is what makes an over-budget entry worth keeping at
+// all, and it is small next to the arguments it accompanies.
+func (q *sdkHARQueryInfo) dropPayload() {
+	if q == nil || len(q.Args) == 0 {
+		return
+	}
+	q.Args = nil
+	q.ArgsTruncated = true
 }
 
 // querySummary is the response content of a query entry: what came back, counted rather than copied.

--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -3,6 +3,7 @@ package harcapture
 import (
 	"encoding/json"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -136,13 +137,15 @@ func buildQueryHAREntry(i querycapture.Interaction) sdkHAREntry {
 		Timings:  sdkHARTimings{Send: 0, Wait: elapsedMs, Receive: 0},
 		Comment:  comment,
 		Query: &sdkHARQueryInfo{
-			Version:            queryInfoVersion,
-			Kind:               i.Kind,
-			DatasourceUID:      i.DatasourceUID,
-			DatasourceType:     i.DatasourceType,
-			DatasourceName:     i.DatasourceName,
-			RefID:              i.RefID,
-			Args:               i.Args,
+			Version:        queryInfoVersion,
+			Kind:           i.Kind,
+			DatasourceUID:  i.DatasourceUID,
+			DatasourceType: i.DatasourceType,
+			DatasourceName: i.DatasourceName,
+			RefID:          i.RefID,
+			// Copied because the buffer outlives the Record call and ToHARString marshals outside the
+			// lock: a capture point that reuses its args slice would otherwise race the marshaller.
+			Args:               slices.Clone(i.Args),
 			StatementTruncated: i.StatementTruncated,
 			ArgsTruncated:      i.ArgsTruncated,
 			FrameCount:         i.FrameCount,

--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -1,0 +1,197 @@
+package harcapture
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/querycapture"
+)
+
+// queryMimeType labels the statement carried in a query entry's postData. HAR has no notion of a
+// non-HTTP protocol, so the statement is modelled as the request body -- which is what it is: the
+// bytes the plugin handed to the driver.
+const queryMimeType = "application/sql"
+
+// querySummaryMimeType labels the response content of a query entry. The content is a summary of what
+// the plugin got back (see querySummary), not the driver's raw reply: rows travel back to Grafana as
+// frames and are reported in the QueryData artifact, so duplicating them here would double the size of
+// a bundle to say the same thing twice.
+const querySummaryMimeType = "application/json"
+
+// AddQueryInteraction records a non-HTTP datasource exchange (a SQL statement, a native-protocol
+// command) as a HAR entry, so that it lands in the same document as the HTTP traffic captured by
+// AddEntry. It is what makes the capture usable for a datasource with no HTTP hop to wrap.
+//
+// The interaction is mapped, not translated: HAR is an HTTP format and a SQL query is not an HTTP
+// request, so the fields HTTP would fill are either empty or carry the query's own equivalent.
+// Everything that has no HTTP counterpart at all goes in the "_query" extension field, which canonical
+// HAR parsers ignore and a bundle analyzer can read without parsing prose.
+//
+// A failed query is recorded with a zero-status response and the error in the entry's comment, the
+// same shape AddEntry uses for a request that never produced an HTTP response. A failure is the most
+// valuable case for diagnostics, so it must be visible rather than absent.
+func (b *Buffer) AddQueryInteraction(i querycapture.Interaction) {
+	b.appendEntry(buildQueryHAREntry(i))
+}
+
+// sdkHARQueryInfo is the "_query" extension object on a query entry. HAR reserves underscore-prefixed
+// fields for extensions, so this travels in a standard HAR document that any viewer can still open.
+type sdkHARQueryInfo struct {
+	// Kind is the capture point that produced the entry, e.g. querycapture.KindSQLQuery.
+	Kind string `json:"kind"`
+	// DatasourceUID, DatasourceType and DatasourceName identify which datasource instance ran the
+	// statement, so a multi-datasource capture can be attributed panel by panel.
+	DatasourceUID  string `json:"datasourceUid,omitempty"`
+	DatasourceType string `json:"datasourceType,omitempty"`
+	DatasourceName string `json:"datasourceName,omitempty"`
+	// RefID ties the entry to the panel query that caused it. Empty for a statement the plugin ran
+	// outside a panel query (a schema or completion lookup).
+	RefID string `json:"refId,omitempty"`
+	// Args are the statement's bind arguments, in the order the driver received them. They live here
+	// rather than in the entry's postData because HAR defines postData.params for a URL-encoded body and
+	// states that params and text are mutually exclusive -- and text is where the statement belongs.
+	Args []string `json:"args,omitempty"`
+	// StatementTruncated and ArgsTruncated report that the capture point cut the statement or the
+	// arguments to fit its size bounds, so a reader can tell a long statement from a clipped one.
+	StatementTruncated bool `json:"statementTruncated,omitempty"`
+	ArgsTruncated      bool `json:"argsTruncated,omitempty"`
+	// FrameCount and RowCount summarise what the plugin returned; RowCount is -1 when the capture
+	// point could not determine it.
+	FrameCount int `json:"frameCount"`
+	RowCount   int `json:"rowCount"`
+	// Error is the error the query returned, or empty on success. It repeats the entry comment in a
+	// field an analyzer can read without string matching.
+	Error string `json:"error,omitempty"`
+}
+
+// querySummary is the response content of a query entry: what came back, counted rather than copied.
+type querySummary struct {
+	FrameCount int `json:"frameCount"`
+	RowCount   int `json:"rowCount"`
+}
+
+func buildQueryHAREntry(i querycapture.Interaction) sdkHAREntry {
+	elapsedMs := float64(i.Duration.Milliseconds())
+
+	statement, encoding := encodeBody([]byte(i.Statement))
+	// Report -1 ("unavailable" in HAR) when only a prefix of the statement was kept, symmetric with
+	// how an over-cap HTTP body is reported.
+	statementSize := int64(len(i.Statement))
+	if i.StatementTruncated {
+		statementSize = -1
+	}
+	postData := &sdkHARPostData{
+		MimeType: queryMimeType,
+		Text:     statement,
+		Encoding: encoding,
+	}
+
+	// Success is a 200 with a counted summary; a failure is a zero-status response, matching how
+	// AddEntry records a request that never got one. Default bodySize -1 so an absent response is not
+	// misread as an empty one.
+	resp := sdkHARResponse{Status: 0, HeadersSize: -1, BodySize: -1, Headers: []sdkHARNameValue{}, Cookies: []sdkHARCookie{}}
+	var comment string
+	if i.Err == "" {
+		summary, err := json.Marshal(querySummary{FrameCount: i.FrameCount, RowCount: i.RowCount})
+		if err != nil {
+			// Cannot happen for two ints, but a capture must never be the reason a query looks broken:
+			// fall back to no content rather than dropping the entry.
+			summary = nil
+		}
+		resp.Status = 200
+		resp.StatusText = "OK"
+		resp.BodySize = int64(len(summary))
+		resp.Content = sdkHARContent{
+			Size:     int64(len(summary)),
+			MimeType: querySummaryMimeType,
+			Text:     string(summary),
+		}
+	} else {
+		comment = "query error: " + i.Err
+	}
+
+	return sdkHAREntry{
+		StartedDateTime: i.StartedAt.UTC().Format(time.RFC3339),
+		Time:            elapsedMs,
+		Request: sdkHARRequest{
+			Method: queryMethod,
+			URL:    queryURL(i),
+			// No HTTP version, headers or cookies: this exchange never was an HTTP request, and
+			// inventing plausible-looking ones would make the capture lie about what was on the wire.
+			Headers:     []sdkHARNameValue{},
+			QueryString: []sdkHARNameValue{},
+			Cookies:     []sdkHARCookie{},
+			PostData:    postData,
+			BodySize:    statementSize,
+			HeadersSize: -1,
+		},
+		Response: resp,
+		Cache:    sdkHARCache{},
+		Timings:  sdkHARTimings{Send: 0, Wait: elapsedMs, Receive: 0},
+		Comment:  comment,
+		Query: &sdkHARQueryInfo{
+			Kind:               i.Kind,
+			DatasourceUID:      i.DatasourceUID,
+			DatasourceType:     i.DatasourceType,
+			DatasourceName:     i.DatasourceName,
+			RefID:              i.RefID,
+			Args:               i.Args,
+			StatementTruncated: i.StatementTruncated,
+			ArgsTruncated:      i.ArgsTruncated,
+			FrameCount:         i.FrameCount,
+			RowCount:           i.RowCount,
+			Error:              i.Err,
+		},
+	}
+}
+
+// queryMethod is the HAR request method of a query entry. HAR does not constrain the method string,
+// and a statement is neither a GET nor a POST, so name the operation for what it is rather than
+// dressing it up as an HTTP verb.
+const queryMethod = "QUERY"
+
+// queryURL builds the entry's URL. HAR requires one and there is no URL for a database call at this
+// seam -- the capture point sees the statement, not the driver's connection target -- so it addresses
+// the datasource that ran the statement instead: "sql://<type>/<uid>?refId=A". The scheme is taken
+// from the capture kind so a MongoDB or Redis capture point reads as "mongo://" or "redis://" without
+// this package having to know about it.
+func queryURL(i querycapture.Interaction) string {
+	scheme := "query"
+	if kind, _, found := strings.Cut(i.Kind, "."); found && kind != "" {
+		scheme = kind
+	} else if i.Kind != "" {
+		scheme = i.Kind
+	}
+
+	host := i.DatasourceType
+	if host == "" {
+		host = "datasource"
+	}
+	u := url.URL{Scheme: scheme, Host: host, Path: "/" + i.DatasourceUID}
+	if i.RefID != "" {
+		u.RawQuery = url.Values{"refId": []string{i.RefID}}.Encode()
+	}
+	return u.String()
+}
+
+// bufferRecorder adapts a Buffer to the querycapture.Recorder interface, so a capture point can write
+// straight into the document the HAR middleware is going to return. Recording inline keeps the entries
+// of one request in the order they happened, interleaved with the HTTP entries of the same request.
+type bufferRecorder struct {
+	buf *Buffer
+}
+
+// NewRecorder returns a querycapture.Recorder that appends each Interaction to buf. It is
+// concurrency-safe, as Recorder requires, because Buffer is.
+func NewRecorder(buf *Buffer) querycapture.Recorder {
+	return bufferRecorder{buf: buf}
+}
+
+func (r bufferRecorder) Record(i querycapture.Interaction) {
+	if r.buf == nil {
+		return
+	}
+	r.buf.AddQueryInteraction(i)
+}

--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -10,8 +10,7 @@ import (
 )
 
 // queryMimeType labels the statement carried in a query entry's postData. HAR has no notion of a
-// non-HTTP protocol, so the statement is modelled as the request body -- which is what it is: the
-// bytes the plugin handed to the driver.
+// non-HTTP protocol, so the statement is modelled as the request body.
 const queryMimeType = "application/sql"
 
 // querySummaryMimeType labels the response content of a query entry. The content is a summary of what
@@ -22,7 +21,7 @@ const querySummaryMimeType = "application/json"
 
 // AddQueryInteraction records a non-HTTP datasource exchange (a SQL statement, a native-protocol
 // command) as a HAR entry, so that it lands in the same document as the HTTP traffic captured by
-// AddEntry. It is what makes the capture usable for a datasource with no HTTP hop to wrap.
+// AddEntry.
 //
 // The interaction is mapped, not translated: HAR is an HTTP format and a SQL query is not an HTTP
 // request, so the fields HTTP would fill are either empty or carry the query's own equivalent.
@@ -30,8 +29,7 @@ const querySummaryMimeType = "application/json"
 // HAR parsers ignore and a bundle analyzer can read without parsing prose.
 //
 // A failed query is recorded with a zero-status response and the error in the entry's comment, the
-// same shape AddEntry uses for a request that never produced an HTTP response. A failure is the most
-// valuable case for diagnostics, so it must be visible rather than absent.
+// same shape AddEntry uses for a request that never produced an HTTP response.
 func (b *Buffer) AddQueryInteraction(i querycapture.Interaction) {
 	b.appendEntry(buildQueryHAREntry(i))
 }
@@ -51,7 +49,7 @@ type sdkHARQueryInfo struct {
 	RefID string `json:"refId,omitempty"`
 	// Args are the statement's bind arguments, in the order the driver received them. They live here
 	// rather than in the entry's postData because HAR defines postData.params for a URL-encoded body and
-	// states that params and text are mutually exclusive -- and text is where the statement belongs.
+	// states that params and text are mutually exclusive.
 	Args []string `json:"args,omitempty"`
 	// StatementTruncated and ArgsTruncated report that the capture point cut the statement or the
 	// arguments to fit its size bounds, so a reader can tell a long statement from a clipped one.

--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -111,7 +111,7 @@ func buildQueryHAREntry(i querycapture.Interaction) sdkHAREntry {
 	}
 
 	return sdkHAREntry{
-		StartedDateTime: i.StartedAt.UTC().Format(time.RFC3339),
+		StartedDateTime: i.StartedAt.UTC().Format(time.RFC3339Nano),
 		Time:            elapsedMs,
 		Request: sdkHARRequest{
 			Method: queryMethod,

--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -71,7 +71,7 @@ type querySummary struct {
 }
 
 func buildQueryHAREntry(i querycapture.Interaction) sdkHAREntry {
-	elapsedMs := float64(i.Duration.Milliseconds())
+	elapsedMs := durationMs(i.Duration)
 
 	statement, encoding := encodeBody([]byte(i.Statement))
 	// Report -1 ("unavailable" in HAR) when only a prefix of the statement was kept, symmetric with

--- a/backend/harcapture/querycapture_test.go
+++ b/backend/harcapture/querycapture_test.go
@@ -238,6 +238,54 @@ func TestAddQueryInteraction_truncationIsReported(t *testing.T) {
 	assert.True(t, e.Query.ArgsTruncated)
 }
 
+func TestAddQueryInteraction_argsAndErrorCountTowardTheTotalBudget(t *testing.T) {
+	// Bind arguments and the error are retained text just as a body is, so the budget that bounds the
+	// __har__ frame has to see them: uncounted, a request's arguments grow the frame past the cap.
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{
+		Kind:      querycapture.KindSQLQuery,
+		Statement: "SELECT * FROM t WHERE id IN (?, ?)",
+		Args:      []string{"host-a", "host-b"},
+		Err:       "code: 60, message: Unknown table expression identifier 't'",
+	})
+
+	// A failed query has no response content, so the retained total is exactly the statement, the
+	// arguments and the error.
+	want := len("SELECT * FROM t WHERE id IN (?, ?)") + len("host-a") + len("host-b") +
+		len("code: 60, message: Unknown table expression identifier 't'")
+	assert.Equal(t, int64(want), b.retained)
+}
+
+func TestAddQueryInteraction_argsAreDroppedOverTheTotalBudget(t *testing.T) {
+	// Being counted is not enough: an over-budget entry has to shed its arguments too, or the frame
+	// grows by them anyway. Inspect the entries directly rather than the marshalled document, so the
+	// test doesn't serialize the whole budget.
+	b := NewBuffer()
+	statement := strings.Repeat("x", maxCapturedBodyBytes)
+	for i := 0; i < maxCapturedTotalBytes/maxCapturedBodyBytes; i++ {
+		b.AddQueryInteraction(querycapture.Interaction{
+			Kind: querycapture.KindSQLQuery, Statement: statement, Err: "boom",
+		})
+	}
+
+	b.AddQueryInteraction(querycapture.Interaction{
+		Kind:      querycapture.KindSQLQuery,
+		Statement: statement,
+		Args:      []string{"host-a", "host-b"},
+		Err:       "code: 60, message: Unknown table expression identifier 't'",
+	})
+
+	last := b.entries[len(b.entries)-1]
+	require.NotNil(t, last.Request.PostData)
+	assert.Empty(t, last.Request.PostData.Text, "the statement is dropped over budget, as an HTTP body is")
+	require.NotNil(t, last.Query)
+	assert.Empty(t, last.Query.Args)
+	assert.True(t, last.Query.ArgsTruncated, "dropped arguments must not read as a statement that had none")
+	assert.Contains(t, last.Query.Error, "Unknown table expression",
+		"the error is kept: it is what makes an over-budget entry worth reading at all")
+	assert.LessOrEqual(t, b.retained, int64(maxCapturedTotalBytes))
+}
+
 func TestAddQueryInteraction_kindDrivesURLScheme(t *testing.T) {
 	// The scheme comes from the capture kind so a future non-SQL capture point reads correctly without
 	// this package knowing about it.

--- a/backend/harcapture/querycapture_test.go
+++ b/backend/harcapture/querycapture_test.go
@@ -39,6 +39,9 @@ type harDoc struct {
 					Size     int64  `json:"size"`
 				} `json:"content"`
 			} `json:"response"`
+			Timings struct {
+				Wait float64 `json:"wait"`
+			} `json:"timings"`
 			Comment string `json:"comment"`
 			Query   *struct {
 				Kind               string   `json:"kind"`
@@ -142,6 +145,21 @@ func TestAddQueryInteraction_startedDateTimeKeepsSubSecondPrecision(t *testing.T
 	})
 
 	assert.Equal(t, "2026-07-28T10:30:00.123456789Z", toDoc(t, b).Log.Entries[0].StartedDateTime)
+}
+
+func TestAddQueryInteraction_durationKeepsSubMillisecondPrecision(t *testing.T) {
+	// A query over a pooled connection often finishes inside a millisecond, which whole-millisecond
+	// truncation would report as instantaneous -- so a reader could not tell where a slow panel's time
+	// actually went.
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{
+		Kind:     querycapture.KindSQLQuery,
+		Duration: 750 * time.Microsecond,
+	})
+
+	e := toDoc(t, b).Log.Entries[0]
+	assert.Equal(t, 0.75, e.Time)
+	assert.Equal(t, 0.75, e.Timings.Wait)
 }
 
 func TestAddQueryInteraction_failedQueryIsRecorded(t *testing.T) {

--- a/backend/harcapture/querycapture_test.go
+++ b/backend/harcapture/querycapture_test.go
@@ -15,6 +15,7 @@ import (
 // harDoc is the parsed shape of the emitted document, enough to assert on a query entry.
 type harDoc struct {
 	Log struct {
+		Format  string `json:"_format"`
 		Entries []struct {
 			StartedDateTime string  `json:"startedDateTime"`
 			Time            float64 `json:"time"`
@@ -120,6 +121,27 @@ func TestAddQueryInteraction_successEntry(t *testing.T) {
 	assert.Equal(t, 1, e.Query.FrameCount)
 	assert.Equal(t, 10, e.Query.RowCount)
 	assert.Empty(t, e.Query.Error)
+}
+
+func TestToHARString_declaresItsFormat(t *testing.T) {
+	// The document says which dialect it is, so the artifact can be renamed, split or versioned later
+	// without a consumer having to guess what it is holding.
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{Kind: querycapture.KindSQLQuery, Statement: "SELECT 1"})
+
+	assert.Equal(t, "grafana-datasource-capture/1", toDoc(t, b).Log.Format)
+}
+
+func TestAddQueryInteraction_startedDateTimeKeepsSubSecondPrecision(t *testing.T) {
+	// The queries of one request run in parallel, one goroutine per refID, so second precision would
+	// collapse them onto one instant and lose the order they actually happened in.
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{
+		Kind:      querycapture.KindSQLQuery,
+		StartedAt: time.Date(2026, 7, 28, 10, 30, 0, 123456789, time.UTC),
+	})
+
+	assert.Equal(t, "2026-07-28T10:30:00.123456789Z", toDoc(t, b).Log.Entries[0].StartedDateTime)
 }
 
 func TestAddQueryInteraction_failedQueryIsRecorded(t *testing.T) {

--- a/backend/harcapture/querycapture_test.go
+++ b/backend/harcapture/querycapture_test.go
@@ -1,0 +1,212 @@
+package harcapture
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/querycapture"
+)
+
+// harDoc is the parsed shape of the emitted document, enough to assert on a query entry.
+type harDoc struct {
+	Log struct {
+		Entries []struct {
+			StartedDateTime string  `json:"startedDateTime"`
+			Time            float64 `json:"time"`
+			Request         struct {
+				Method   string `json:"method"`
+				URL      string `json:"url"`
+				BodySize int64  `json:"bodySize"`
+				PostData *struct {
+					MimeType string `json:"mimeType"`
+					Text     string `json:"text"`
+					// Params is raw so the test can assert the field is absent, not merely empty.
+					Params json.RawMessage `json:"params"`
+				} `json:"postData"`
+			} `json:"request"`
+			Response struct {
+				Status   int   `json:"status"`
+				BodySize int64 `json:"bodySize"`
+				Content  struct {
+					MimeType string `json:"mimeType"`
+					Text     string `json:"text"`
+					Size     int64  `json:"size"`
+				} `json:"content"`
+			} `json:"response"`
+			Comment string `json:"comment"`
+			Query   *struct {
+				Kind               string   `json:"kind"`
+				DatasourceUID      string   `json:"datasourceUid"`
+				DatasourceType     string   `json:"datasourceType"`
+				DatasourceName     string   `json:"datasourceName"`
+				RefID              string   `json:"refId"`
+				Args               []string `json:"args"`
+				StatementTruncated bool     `json:"statementTruncated"`
+				ArgsTruncated      bool     `json:"argsTruncated"`
+				FrameCount         int      `json:"frameCount"`
+				RowCount           int      `json:"rowCount"`
+				Error              string   `json:"error"`
+			} `json:"_query"`
+		} `json:"entries"`
+	} `json:"log"`
+}
+
+func toDoc(t *testing.T, b *Buffer) harDoc {
+	t.Helper()
+	raw, err := b.ToHARString()
+	require.NoError(t, err)
+	var doc harDoc
+	require.NoError(t, json.Unmarshal([]byte(raw), &doc))
+	return doc
+}
+
+func TestAddQueryInteraction_successEntry(t *testing.T) {
+	started := time.Date(2026, 7, 28, 10, 30, 0, 0, time.UTC)
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{
+		Kind:           querycapture.KindSQLQuery,
+		StartedAt:      started,
+		Duration:       25 * time.Millisecond,
+		DatasourceUID:  "P1234",
+		DatasourceType: "grafana-clickhouse-datasource",
+		DatasourceName: "ClickHouse diag",
+		RefID:          "A",
+		Statement:      "SELECT host, value FROM metrics WHERE host = ?",
+		Args:           []string{"host-a"},
+		FrameCount:     1,
+		RowCount:       10,
+	})
+
+	doc := toDoc(t, b)
+	require.Len(t, doc.Log.Entries, 1)
+	e := doc.Log.Entries[0]
+
+	// The statement is the request body, verbatim: it is the evidence, so nothing may be appended to
+	// it. The datasource identity is addressed by the URL, not smuggled into the SQL.
+	assert.Equal(t, "QUERY", e.Request.Method)
+	assert.Equal(t, "sql://grafana-clickhouse-datasource/P1234?refId=A", e.Request.URL)
+	require.NotNil(t, e.Request.PostData)
+	assert.Equal(t, "application/sql", e.Request.PostData.MimeType)
+	assert.Equal(t, "SELECT host, value FROM metrics WHERE host = ?", e.Request.PostData.Text)
+	assert.Equal(t, int64(len("SELECT host, value FROM metrics WHERE host = ?")), e.Request.BodySize)
+
+	// Bind arguments ride in the extension object rather than postData.params: HAR states params and
+	// text are mutually exclusive, and text is where the statement itself belongs.
+	assert.Nil(t, e.Request.PostData.Params, "postData carries the statement as text, so it must not also carry params")
+	require.NotNil(t, e.Query)
+	assert.Equal(t, []string{"host-a"}, e.Query.Args)
+
+	// A successful query is a 200 whose body counts what came back rather than repeating it.
+	assert.Equal(t, 200, e.Response.Status)
+	assert.Equal(t, "application/json", e.Response.Content.MimeType)
+	assert.JSONEq(t, `{"frameCount":1,"rowCount":10}`, e.Response.Content.Text)
+	assert.Equal(t, int64(len(e.Response.Content.Text)), e.Response.Content.Size)
+	assert.Empty(t, e.Comment)
+
+	assert.Equal(t, "2026-07-28T10:30:00Z", e.StartedDateTime)
+	assert.Equal(t, float64(25), e.Time)
+
+	require.NotNil(t, e.Query)
+	assert.Equal(t, querycapture.KindSQLQuery, e.Query.Kind)
+	assert.Equal(t, "P1234", e.Query.DatasourceUID)
+	assert.Equal(t, "grafana-clickhouse-datasource", e.Query.DatasourceType)
+	assert.Equal(t, "ClickHouse diag", e.Query.DatasourceName)
+	assert.Equal(t, "A", e.Query.RefID)
+	assert.Equal(t, 1, e.Query.FrameCount)
+	assert.Equal(t, 10, e.Query.RowCount)
+	assert.Empty(t, e.Query.Error)
+}
+
+func TestAddQueryInteraction_failedQueryIsRecorded(t *testing.T) {
+	// A failed query is the most valuable case for diagnostics, so it must be present, and
+	// distinguishable from a query that returned no rows.
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{
+		Kind:          querycapture.KindSQLQuery,
+		StartedAt:     time.Now(),
+		DatasourceUID: "P1234",
+		Statement:     "SELECT * FROM missing_table",
+		Err:           "code: 60, message: Unknown table expression identifier 'missing_table'",
+		RowCount:      -1,
+	})
+
+	doc := toDoc(t, b)
+	require.Len(t, doc.Log.Entries, 1)
+	e := doc.Log.Entries[0]
+
+	assert.Equal(t, 0, e.Response.Status, "a failed query has no response, so status is zero, not 200")
+	assert.Equal(t, int64(-1), e.Response.BodySize, "-1 is HAR 'unavailable'; 0 would claim an empty response body")
+	assert.Empty(t, e.Response.Content.Text)
+	assert.Contains(t, e.Comment, "query error: code: 60")
+	require.NotNil(t, e.Query)
+	assert.Contains(t, e.Query.Error, "Unknown table expression identifier")
+	assert.Equal(t, -1, e.Query.RowCount)
+}
+
+func TestAddQueryInteraction_truncationIsReported(t *testing.T) {
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{
+		Kind:               querycapture.KindSQLQuery,
+		Statement:          strings.Repeat("x", 128),
+		StatementTruncated: true,
+		Args:               []string{"a"},
+		ArgsTruncated:      true,
+		RowCount:           3,
+		FrameCount:         1,
+	})
+
+	doc := toDoc(t, b)
+	require.Len(t, doc.Log.Entries, 1)
+	e := doc.Log.Entries[0]
+	assert.Equal(t, int64(-1), e.Request.BodySize, "a clipped statement reports an unavailable size, not the clipped length")
+	require.NotNil(t, e.Query)
+	assert.True(t, e.Query.StatementTruncated)
+	assert.True(t, e.Query.ArgsTruncated)
+}
+
+func TestAddQueryInteraction_kindDrivesURLScheme(t *testing.T) {
+	// The scheme comes from the capture kind so a future non-SQL capture point reads correctly without
+	// this package knowing about it.
+	for _, tc := range []struct {
+		kind, want string
+	}{
+		{querycapture.KindSQLQuery, "sql://t/uid"},
+		{"mongo.command", "mongo://t/uid"},
+		{"redis", "redis://t/uid"},
+		{"", "query://t/uid"},
+	} {
+		b := NewBuffer()
+		b.AddQueryInteraction(querycapture.Interaction{Kind: tc.kind, DatasourceType: "t", DatasourceUID: "uid"})
+		doc := toDoc(t, b)
+		require.Len(t, doc.Log.Entries, 1)
+		assert.Equal(t, tc.want, doc.Log.Entries[0].Request.URL, "kind %q", tc.kind)
+	}
+}
+
+func TestNewRecorder_writesIntoBufferInterleavedWithHTTP(t *testing.T) {
+	// The recorder shares the HTTP buffer, which is the whole point: a plugin whose driver speaks HTTP
+	// (ClickHouse, BigQuery, Athena) produces both kinds in one request and must not have to choose.
+	b := NewBuffer()
+	rec := NewRecorder(b)
+	rec.Record(querycapture.Interaction{Kind: querycapture.KindSQLQuery, Statement: "SELECT 1", DatasourceUID: "P1"})
+	rec.Record(querycapture.Interaction{Kind: querycapture.KindSQLQuery, Statement: "SELECT 2", DatasourceUID: "P1"})
+
+	assert.Equal(t, 2, b.Len())
+	doc := toDoc(t, b)
+	require.Len(t, doc.Log.Entries, 2)
+	assert.Equal(t, "SELECT 1", doc.Log.Entries[0].Request.PostData.Text)
+	assert.Equal(t, "SELECT 2", doc.Log.Entries[1].Request.PostData.Text, "entries keep the order they were recorded in")
+}
+
+func TestNewRecorder_nilBufferIsInert(t *testing.T) {
+	// Capture must never be the reason a query fails, so a misconfigured recorder drops the
+	// interaction rather than panicking on the query path.
+	assert.NotPanics(t, func() {
+		NewRecorder(nil).Record(querycapture.Interaction{Kind: querycapture.KindSQLQuery})
+	})
+}

--- a/backend/harcapture/querycapture_test.go
+++ b/backend/harcapture/querycapture_test.go
@@ -15,7 +15,6 @@ import (
 // harDoc is the parsed shape of the emitted document, enough to assert on a query entry.
 type harDoc struct {
 	Log struct {
-		Format  string `json:"_format"`
 		Entries []struct {
 			StartedDateTime string  `json:"startedDateTime"`
 			Time            float64 `json:"time"`
@@ -44,6 +43,7 @@ type harDoc struct {
 			} `json:"timings"`
 			Comment string `json:"comment"`
 			Query   *struct {
+				Version            int      `json:"version"`
 				Kind               string   `json:"kind"`
 				DatasourceUID      string   `json:"datasourceUid"`
 				DatasourceType     string   `json:"datasourceType"`
@@ -126,13 +126,42 @@ func TestAddQueryInteraction_successEntry(t *testing.T) {
 	assert.Empty(t, e.Query.Error)
 }
 
-func TestToHARString_declaresItsFormat(t *testing.T) {
-	// The document says which dialect it is, so the artifact can be renamed, split or versioned later
-	// without a consumer having to guess what it is holding.
+func TestAddQueryInteraction_declaresItsVersionPerEntry(t *testing.T) {
+	// The version rides on the entry, not the document: Grafana merges a bundle's HAR by concatenating
+	// the entries of every plugin that captured, so entries survive that merge verbatim while a
+	// log-level field is dropped -- and a single document-level version could not describe a mix of
+	// plugins built against different SDKs anyway.
 	b := NewBuffer()
 	b.AddQueryInteraction(querycapture.Interaction{Kind: querycapture.KindSQLQuery, Statement: "SELECT 1"})
 
-	assert.Equal(t, "grafana-datasource-capture/1", toDoc(t, b).Log.Format)
+	doc := toDoc(t, b)
+	require.Len(t, doc.Log.Entries, 1)
+	require.NotNil(t, doc.Log.Entries[0].Query)
+	assert.Equal(t, queryInfoVersion, doc.Log.Entries[0].Query.Version)
+}
+
+func TestToHARString_documentShapeIsPlainHAR(t *testing.T) {
+	// The log object stays canonical HAR 1.2, so nothing on the consuming side has to be taught a new
+	// document shape to carry query entries (see queryInfoVersion).
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{Kind: querycapture.KindSQLQuery, Statement: "SELECT 1"})
+
+	raw, err := b.ToHARString()
+	require.NoError(t, err)
+
+	var doc struct {
+		Log map[string]json.RawMessage `json:"log"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &doc))
+	assert.ElementsMatch(t, []string{"version", "creator", "entries"}, keysOf(doc.Log))
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 func TestAddQueryInteraction_startedDateTimeKeepsSubSecondPrecision(t *testing.T) {

--- a/backend/querycapture/querycapture.go
+++ b/backend/querycapture/querycapture.go
@@ -152,9 +152,11 @@ type Recorder interface {
 
 // WithRecorder returns a context that activates capture for every capture point
 // reached under it. Passing a nil Recorder returns ctx unchanged, so a caller
-// can wire capture unconditionally and decide later whether to enable it.
+// can wire capture unconditionally and decide later whether to enable it. A nil
+// ctx is likewise returned unchanged, so that -- as with RecorderFromContext --
+// no part of this seam is the thing that panics.
 func WithRecorder(ctx context.Context, r Recorder) context.Context {
-	if r == nil {
+	if ctx == nil || r == nil {
 		return ctx
 	}
 	return context.WithValue(ctx, recorderContextKey{}, r)

--- a/backend/querycapture/querycapture.go
+++ b/backend/querycapture/querycapture.go
@@ -1,0 +1,156 @@
+// Package querycapture defines the capture seam for datasources that do not
+// speak HTTP.
+//
+// Grafana's on-demand datasource diagnostics can show the traffic behind a
+// failing panel because this SDK wraps the datasource's http.RoundTripper (see
+// the HAR capture middleware in package backend). A datasource that speaks its
+// own protocol over a database/sql driver, or a native wire protocol of its
+// own, has no round tripper to wrap, so its bundle shows the frames the plugin
+// returned with nothing to compare them against: "the database returned the
+// wrong rows" is indistinguishable from "the plugin mangled correct rows".
+//
+// This package is the other half of that middleware. A capture point (today
+// sqlds' DBQuery.Run; a MongoDB or Redis adapter tomorrow) looks for a Recorder
+// in the query context and, if one is there, reports what it sent and what came
+// back as an Interaction. The SDK's HAR capture middleware installs the
+// Recorder and maps the Interactions onto the same HAR document it already
+// returns, so protocol evidence and HTTP evidence land in one artifact.
+//
+// The division of labour is deliberate:
+//
+//   - Capture is off unless a Recorder is present in the context, and a nil or
+//     absent Recorder is a pure pass-through. Nothing about query execution or
+//     its results changes when capture is off, so a plugin gains capture from a
+//     dependency bump alone.
+//   - A capture point only produces Interactions. It does not decide how they
+//     are encoded or returned to Grafana, and in particular it must not attach
+//     them to the QueryDataResponse itself: the HAR middleware skips its own
+//     capture when the reserved refID is already taken, so a plugin that emitted
+//     its own capture frame would silently trade away its HTTP evidence.
+//   - The vocabulary lives here, in the SDK, rather than in any one adapter, so
+//     that every non-HTTP capture point describes itself the same way and the
+//     host needs to understand only one shape.
+//
+// # Sensitive data
+//
+// Interactions carry the statement that was executed, its bind arguments and a
+// summary of what came back. All three can contain customer data and
+// credentials. Capture points bound their size (see MaxStatementBytes and
+// MaxArgsBytes) but do not redact them; redaction and retention are the
+// Recorder's responsibility, and a Recorder must not be installed on a path
+// where the result is not treated as sensitive.
+package querycapture
+
+import (
+	"context"
+	"time"
+)
+
+// Interaction is one recorded exchange with a datasource. It is intentionally
+// protocol-neutral: Kind identifies what was captured, so that a SQL query, a
+// MongoDB command and an HTTP round trip can feed the same Recorder.
+type Interaction struct {
+	// Kind identifies the capture point, e.g. KindSQLQuery.
+	Kind string
+	// StartedAt is when the call to the datasource began.
+	StartedAt time.Time
+	// Duration is the wall-clock time spent on the call, including converting
+	// the result into frames.
+	Duration time.Duration
+
+	// DatasourceUID, DatasourceType and DatasourceName identify the datasource
+	// instance, so a consumer can correlate an Interaction with the panel query
+	// that produced it in a multi-datasource capture.
+	DatasourceUID  string
+	DatasourceType string
+	DatasourceName string
+	// RefID is the query's refID, as set by the panel query editor. It is empty
+	// for a capture point that runs outside a panel query, such as a schema or
+	// completion lookup.
+	RefID string
+
+	// Statement is the query as it was handed to the driver: after macro
+	// interpolation, which is the form the datasource actually saw. Truncated to
+	// MaxStatementBytes; StatementTruncated reports whether that happened.
+	Statement string
+	// StatementTruncated reports whether Statement was cut to fit
+	// MaxStatementBytes.
+	StatementTruncated bool
+	// Args are the bind arguments, rendered for display. Named arguments are
+	// rendered as "name=value". Truncated to MaxArgsBytes in aggregate;
+	// ArgsTruncated reports whether that happened.
+	Args []string
+	// ArgsTruncated reports whether Args was cut to fit MaxArgsBytes. When true,
+	// the arguments present are a prefix of those actually sent.
+	ArgsTruncated bool
+
+	// FrameCount and RowCount summarise what the plugin returned. RowCount is -1
+	// when it could not be determined: frames with inconsistent field lengths,
+	// or a capture point that hands back an unconsumed result set.
+	FrameCount int
+	RowCount   int
+
+	// Err is the error the call returned, or empty on success. A recorded
+	// failure is the most valuable case for diagnostics, so capture points
+	// record an Interaction on the error path too.
+	Err string
+}
+
+// Kind values for the capture points that feed a Recorder. Each capture point
+// emits its own; the set is declared here so consumers can switch on Kind
+// without redefining the vocabulary.
+const (
+	// KindSQLQuery is a statement executed against a database/sql connection.
+	KindSQLQuery = "sql.query"
+)
+
+// Size bounds a capture point applies before handing an Interaction to a
+// Recorder. A single pathological query (a large IN clause, a bulk INSERT) must
+// not be able to grow the capture without limit, and the whole
+// QueryDataResponse the capture rides back on has to fit inside the SDK's gRPC
+// message size.
+//
+// These bound one Interaction. A Recorder is still responsible for bounding the
+// total across interactions.
+const (
+	// MaxStatementBytes caps Interaction.Statement.
+	MaxStatementBytes = 64 * 1024
+	// MaxArgsBytes caps the aggregate size of Interaction.Args.
+	MaxArgsBytes = 16 * 1024
+)
+
+type recorderContextKey struct{}
+
+// Recorder receives Interactions. Implementations must be safe for concurrent
+// use: the queries of one QueryDataRequest run in parallel, one goroutine per
+// refID, so a single Recorder is written to from several goroutines at once.
+//
+// Record must not block for long and must not panic. It runs inline on the
+// query path, so a slow Recorder slows the user's query.
+type Recorder interface {
+	Record(Interaction)
+}
+
+// WithRecorder returns a context that activates capture for every capture point
+// reached under it. Passing a nil Recorder returns ctx unchanged, so a caller
+// can wire capture unconditionally and decide later whether to enable it.
+func WithRecorder(ctx context.Context, r Recorder) context.Context {
+	if r == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, recorderContextKey{}, r)
+}
+
+// RecorderFromContext returns the Recorder activated for ctx, if any. The
+// second result reports whether capture is on; when it is false the caller must
+// behave exactly as it did before capture existed.
+func RecorderFromContext(ctx context.Context) (Recorder, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	r, ok := ctx.Value(recorderContextKey{}).(Recorder)
+	if !ok || r == nil {
+		return nil, false
+	}
+	return r, true
+}

--- a/backend/querycapture/querycapture.go
+++ b/backend/querycapture/querycapture.go
@@ -31,6 +31,13 @@
 //     that every non-HTTP capture point describes itself the same way and the
 //     host needs to understand only one shape.
 //
+// # Experimental
+//
+// This package is experimental and its API may change without the usual
+// deprecation cycle. It exists to serve Grafana's on-demand datasource
+// diagnostics, and the vocabulary is expected to move as capture points beyond
+// SQL are written against it.
+//
 // # Sensitive data
 //
 // Interactions carry the statement that was executed, its bind arguments and a
@@ -39,6 +46,18 @@
 // MaxArgsBytes) but do not redact them; redaction and retention are the
 // Recorder's responsibility, and a Recorder must not be installed on a path
 // where the result is not treated as sensitive.
+//
+// # Known limitations
+//
+// The size bounds below apply to a single Interaction. Nothing bounds their sum
+// across the queries of one request, which run in parallel, so peak memory
+// scales with the number of refIDs a panel sends. The Recorder bounds the
+// document it produces, not the captures feeding it.
+//
+// Capture is off unless a request asked for it, and in Grafana the path that
+// does the asking is feature-toggled, restricted to admins and on-prem only.
+// That is what makes these acceptable for now rather than limits worth
+// engineering around.
 package querycapture
 
 import (

--- a/backend/querycapture/querycapture_test.go
+++ b/backend/querycapture/querycapture_test.go
@@ -48,6 +48,15 @@ func TestWithRecorder_nilIsNotCaptureOn(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestWithRecorder_nilContextDoesNotPanic(t *testing.T) {
+	// Symmetric with RecorderFromContext(nil): installing capture is host wiring, and no part of this
+	// seam should be the thing that turns a caller's nil context into a panic.
+	require.NotPanics(t, func() {
+		//nolint:staticcheck // deliberately exercising the nil-context case
+		require.Nil(t, WithRecorder(nil, &stubRecorder{}))
+	})
+}
+
 func TestWithRecorder_innermostRecorderWins(t *testing.T) {
 	// A host may install capture more than once on nested contexts (a dashboard-wide capture around a
 	// per-panel one); the closest one to the capture point is the one that receives the interaction.

--- a/backend/querycapture/querycapture_test.go
+++ b/backend/querycapture/querycapture_test.go
@@ -1,0 +1,63 @@
+package querycapture
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubRecorder struct{ got []Interaction }
+
+func (s *stubRecorder) Record(i Interaction) { s.got = append(s.got, i) }
+
+func TestRecorderFromContext(t *testing.T) {
+	t.Run("a plain context has no recorder", func(t *testing.T) {
+		// Capture is off by default: every capture point must behave exactly as it did before capture
+		// existed unless a host asked for it.
+		got, ok := RecorderFromContext(context.Background())
+		require.False(t, ok)
+		require.Nil(t, got)
+	})
+
+	t.Run("a nil context has no recorder", func(t *testing.T) {
+		// Capture points pass whatever context the query arrived with; a nil context must read as
+		// "capture off" rather than panic on the query path.
+		//nolint:staticcheck // deliberately exercising the nil-context case
+		got, ok := RecorderFromContext(nil)
+		require.False(t, ok)
+		require.Nil(t, got)
+	})
+
+	t.Run("round-trips the installed recorder", func(t *testing.T) {
+		rec := &stubRecorder{}
+		got, ok := RecorderFromContext(WithRecorder(context.Background(), rec))
+		require.True(t, ok)
+		require.Same(t, rec, got)
+	})
+}
+
+func TestWithRecorder_nilIsNotCaptureOn(t *testing.T) {
+	// Wiring capture unconditionally is a common host pattern, so a nil Recorder must leave the context
+	// untouched instead of installing a typed nil that later reads as "capture on".
+	ctx := context.Background()
+	got := WithRecorder(ctx, nil)
+	require.Equal(t, ctx, got)
+
+	_, ok := RecorderFromContext(got)
+	require.False(t, ok)
+}
+
+func TestWithRecorder_innermostRecorderWins(t *testing.T) {
+	// A host may install capture more than once on nested contexts (a dashboard-wide capture around a
+	// per-panel one); the closest one to the capture point is the one that receives the interaction.
+	outer, inner := &stubRecorder{}, &stubRecorder{}
+	ctx := WithRecorder(WithRecorder(context.Background(), outer), inner)
+
+	rec, ok := RecorderFromContext(ctx)
+	require.True(t, ok)
+	rec.Record(Interaction{Kind: KindSQLQuery})
+
+	require.Len(t, inner.got, 1)
+	require.Empty(t, outer.got)
+}


### PR DESCRIPTION
## Where this is going

The goal is that Grafana's on-demand datasource diagnostics work for a datasource that does not speak
HTTP, so a support bundle for a SQL datasource can show the traffic behind a failing panel
the way an HTTP-backed one already does.

That takes three pieces, in three repositories:

1. **this SDK** — the vocabulary a capture point reports in, and the mapping into the HAR document the
   middleware already returns (this PR and the two stacked on it);
2. **the capture points** — [`sqlds`'s `DBQuery.Run`](https://github.com/grafana/sqlds)
3. **Grafana core** — already reads the `__har__` frame, so it needs nothing new.

#1616 was the whole SDK side in one PR. At ~1,900 lines across three separable concerns it was too
large to review, so it is closed in favour of this stack; look there if you want the finished shape
before reviewing the pieces. The three are:

| | PR | Adds |
|---|---|---|
| 1 | this one | the seam, and the HAR mapping for statement, bind arguments, counts, timings, errors |
| 2 | to follow | the rows a datasource returned — the part that puts result data in a bundle, and so the part that belongs with the redaction question (#1281) |
| 3 | to follow | generalising the vocabulary beyond result sets, for the MongoDB capture point |

## What this does

Grafana's on-demand datasource diagnostics can show the traffic behind a failing panel because this
SDK wraps the datasource's `http.RoundTripper`. A datasource that speaks its own protocol over a
`database/sql` driver has no round tripper to wrap, so its bundle carries the frames the plugin
returned with nothing to compare them against — and "the database returned the wrong rows" is
indistinguishable from "the plugin mangled correct rows".

This adds the producer side of a capture seam for those datasources. A capture point looks for a
`Recorder` on the query context and, if one is there, reports the exchange as an `Interaction`; the HAR
capture middleware installs the `Recorder` and maps what it collects into the document it already
returns.

## Experimental, and what is deliberately unbounded

This is an experimental seam for on-demand diagnostics. Two limits are stated rather than engineered, on purpose:

- **Size bounds are per-`Interaction`.** `MaxStatementBytes` and `MaxArgsBytes` bound one interaction;
  nothing bounds their sum across the queries of a request, which run in parallel. Peak memory
  therefore scales with the number of refIDs a panel sends.
- **Nothing is redacted.** Statements and bind arguments can carry customer data and credentials.
  Redaction and retention are the `Recorder`'s responsibility — the still-open #1281.

Neither is load-bearing at this stage: capture is off unless a request asked for it, and in Grafana
the path that does the asking is behind a feature toggle, restricted to admins, and on-prem only.

## Compatibility

Capture is off unless the `X-Grafana-HAR-Capture` header asked for it, so a plugin with a capture point
sees no recorder and behaves exactly as before, and a plugin without one is unaffected either way.

## Follow-ups

*The artifact is still called a HAR, but arguably it should not*: A document carrying SQL text, bind
arguments and result rows is only nominally an HTTP archive. We have two options to address this, and neither is in this PR, as the feature is still experimental:

- **Renaming the artifact** — `meta.Custom["har"]`, the `__har__` refID prefix, the media type when a
  bundle writes it out, and so on. This however requires changes in Grafana-core and also requires ensure the fixture replay server, which targets the HAR format, doesn't have issues as side effect of the renaming.
- **Splitting it into two artifacts** (HAR for HTTP, a query archive for the rest) was considered and
  rejected: the datasources this exists for — ClickHouse, BigQuery, Athena, Snowflake — speak SQL *over*
  HTTP and emit both kinds in one request, so splitting would hand the reader a correlation problem in
  exactly the case that matters most.
