### PR TITLE
feat(config): add OpenFeature provider discovery config

### DIFF
--- a/config/openfeature.go
+++ b/config/openfeature.go
@@ -1,0 +1,165 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	// OpenFeatureProviderURL is the base URL of the OFREP-compatible endpoint
+	// exposed by the Grafana instance hosting the plugin. OpenFeature OFREP
+	// providers append /ofrep/v1/evaluate/flags[/{key}] to this URL when
+	// evaluating flags.
+	OpenFeatureProviderURL = "GF_INSTANCE_OPENFEATURE_PROVIDER_URL"
+	// OpenFeatureProviderType is the type of OpenFeature provider the URL
+	// points at, as configured on the host: "static" (the host Grafana's
+	// built-in provider serving its own feature toggle configuration),
+	// "features-service" or "ofrep" (a remote provider).
+	OpenFeatureProviderType = "GF_INSTANCE_OPENFEATURE_PROVIDER_TYPE"
+	// OpenFeatureCacheTTL is the host's advisory TTL for caching flag
+	// evaluation results, expressed as an integer number of seconds so that
+	// plugins in any language can parse it. A value of 0, like an absent
+	// variable, means the host offers no caching advice and plugins should
+	// apply their own defaults; hosts must not use 0 to demand that caching
+	// be disabled.
+	OpenFeatureCacheTTL = "GF_INSTANCE_OPENFEATURE_CACHE_TTL"
+	// OpenFeatureContext is a JSON object of host-owned evaluation context
+	// attributes (for example stackId and slug on Grafana Cloud). It is only
+	// distributed through the per-request config, never as an environment
+	// variable, because one plugin process may serve many tenants.
+	OpenFeatureContext = "GF_INSTANCE_OPENFEATURE_CONTEXT"
+)
+
+// ErrOpenFeatureNotConfigured is returned when the Grafana instance hosting
+// the plugin has not exposed an OpenFeature provider URL. Plugins should
+// treat this as "discovery unavailable" and fall back to their own defaults.
+var ErrOpenFeatureNotConfigured = errors.New("OpenFeature provider discovery not configured")
+
+// OpenFeatureConfig is the OpenFeature provider discovery information exposed
+// by the Grafana instance hosting the plugin. The SDK only exposes discovery:
+// plugins instantiate their own OpenFeature provider and client, exactly as
+// they do on the frontend.
+type OpenFeatureConfig struct {
+	// ProviderType is the kind of provider URL points at: "static",
+	// "features-service" or "ofrep".
+	ProviderType string
+	// URL is the OFREP base URL. OFREP clients append
+	// /ofrep/v1/evaluate/flags[/{key}] to it when evaluating flags.
+	URL string
+	// CacheTTL is the host's advisory TTL for caching flag evaluation
+	// results. Zero means the host gave no caching advice.
+	CacheTTL time.Duration
+	// ContextAttrs are host-owned evaluation context attributes. Plugins
+	// should merge them into their evaluation context verbatim and must not
+	// override host-asserted keys.
+	ContextAttrs map[string]string
+}
+
+// OpenFeature returns the OpenFeature provider discovery configuration
+// exposed by the Grafana instance hosting the plugin.
+//
+// Each value is resolved in the following priority order:
+//  1. The per-request config from the request context, set by WithGrafanaConfig
+//  2. The corresponding environment variable, set at plugin process start
+//
+// A key present in the per-request config is authoritative even when its
+// value is empty: the environment is only consulted for keys the host did
+// not send at all. This keeps a multi-tenant host's per-request answer from
+// being overridden by process-wide state.
+//
+// ContextAttrs is only distributed through the per-request config; use
+// PluginContext.Namespace together with ContextAttrs to build the evaluation
+// context. Before any request has arrived (for example while constructing a
+// provider at plugin start-up), use OpenFeatureConfigFromEnv instead.
+//
+// It returns an error wrapping ErrOpenFeatureNotConfigured when the host has
+// not exposed a provider URL. A more recent version of Grafana may be
+// required.
+func (c *GrafanaCfg) OpenFeature() (OpenFeatureConfig, error) {
+	url, ok := c.config[OpenFeatureProviderURL]
+	if !ok {
+		// Fallback to environment variable for hosts that only provide
+		// discovery at process start.
+		url = os.Getenv(OpenFeatureProviderURL)
+	}
+	if url == "" {
+		return OpenFeatureConfig{}, fmt.Errorf("%w: %s is empty or not set. A more recent version of Grafana may be required", ErrOpenFeatureNotConfigured, OpenFeatureProviderURL)
+	}
+
+	providerType, ok := c.config[OpenFeatureProviderType]
+	if !ok {
+		providerType = os.Getenv(OpenFeatureProviderType)
+	}
+
+	ttlString, ok := c.config[OpenFeatureCacheTTL]
+	if !ok {
+		ttlString = os.Getenv(OpenFeatureCacheTTL)
+	}
+	ttl, err := parseOpenFeatureCacheTTL(ttlString)
+	if err != nil {
+		return OpenFeatureConfig{}, err
+	}
+
+	var contextAttrs map[string]string
+	if v := c.config[OpenFeatureContext]; v != "" {
+		if err := json.Unmarshal([]byte(v), &contextAttrs); err != nil {
+			return OpenFeatureConfig{}, fmt.Errorf("parsing %s, value must be a JSON object of string attributes: %w", OpenFeatureContext, err)
+		}
+	}
+
+	return OpenFeatureConfig{
+		ProviderType: providerType,
+		URL:          url,
+		CacheTTL:     ttl,
+		ContextAttrs: contextAttrs,
+	}, nil
+}
+
+// OpenFeatureConfigFromEnv returns the OpenFeature provider discovery
+// configuration from environment variables. It is intended for use at plugin
+// process start, before any request (and therefore any per-request config)
+// has arrived. ContextAttrs is always nil since the evaluation context is
+// only distributed through the per-request config.
+//
+// It returns an error wrapping ErrOpenFeatureNotConfigured when the host has
+// not exposed a provider URL. A more recent version of Grafana may be
+// required.
+func OpenFeatureConfigFromEnv() (OpenFeatureConfig, error) {
+	url := os.Getenv(OpenFeatureProviderURL)
+	if url == "" {
+		return OpenFeatureConfig{}, fmt.Errorf("%w: %s not set in environment. A more recent version of Grafana may be required", ErrOpenFeatureNotConfigured, OpenFeatureProviderURL)
+	}
+
+	ttl, err := parseOpenFeatureCacheTTL(os.Getenv(OpenFeatureCacheTTL))
+	if err != nil {
+		return OpenFeatureConfig{}, err
+	}
+
+	return OpenFeatureConfig{
+		ProviderType: os.Getenv(OpenFeatureProviderType),
+		URL:          url,
+		CacheTTL:     ttl,
+	}, nil
+}
+
+func parseOpenFeatureCacheTTL(v string) (time.Duration, error) {
+	if v == "" {
+		return 0, nil
+	}
+	secs, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing %s, value must be an integer number of seconds: %w", OpenFeatureCacheTTL, err)
+	}
+	if secs < 0 {
+		return 0, fmt.Errorf("parsing %s, value must be a non-negative integer number of seconds", OpenFeatureCacheTTL)
+	}
+	if secs > math.MaxInt64/int64(time.Second) {
+		return 0, fmt.Errorf("parsing %s, value %d seconds does not fit in a time.Duration", OpenFeatureCacheTTL, secs)
+	}
+	return time.Duration(secs) * time.Second, nil
+}

--- a/config/openfeature.go
+++ b/config/openfeature.go
@@ -5,33 +5,32 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"os"
 	"strconv"
 	"time"
 )
 
 const (
-	// OpenFeatureProviderURL is the base URL of the OFREP-compatible endpoint
-	// exposed by the Grafana instance hosting the plugin. OpenFeature OFREP
-	// providers append /ofrep/v1/evaluate/flags[/{key}] to this URL when
-	// evaluating flags.
+	// OpenFeatureProviderURL is the per-request config key carrying the base
+	// URL of the OFREP-compatible endpoint exposed by the Grafana instance
+	// hosting the plugin. OpenFeature OFREP providers append
+	// /ofrep/v1/evaluate/flags[/{key}] to this URL when evaluating flags.
 	OpenFeatureProviderURL = "GF_INSTANCE_OPENFEATURE_PROVIDER_URL"
-	// OpenFeatureProviderType is the type of OpenFeature provider the URL
-	// points at, as configured on the host: "static" (the host Grafana's
-	// built-in provider serving its own feature toggle configuration),
-	// "features-service" or "ofrep" (a remote provider).
+	// OpenFeatureProviderType is the per-request config key carrying the type
+	// of OpenFeature provider the URL points at, as configured on the host:
+	// "static" (the host Grafana's built-in provider serving its own feature
+	// toggle configuration), "features-service" or "ofrep" (a remote
+	// provider).
 	OpenFeatureProviderType = "GF_INSTANCE_OPENFEATURE_PROVIDER_TYPE"
-	// OpenFeatureCacheTTL is the host's advisory TTL for caching flag
-	// evaluation results, expressed as an integer number of seconds so that
-	// plugins in any language can parse it. A value of 0, like an absent
-	// variable, means the host offers no caching advice and plugins should
-	// apply their own defaults; hosts must not use 0 to demand that caching
-	// be disabled.
+	// OpenFeatureCacheTTL is the per-request config key carrying the host's
+	// advisory TTL for caching flag evaluation results, expressed as an
+	// integer number of seconds so that plugins in any language can parse it.
+	// A value of 0, like an absent key, means the host offers no caching
+	// advice and plugins should apply their own defaults; hosts must not use
+	// 0 to demand that caching be disabled.
 	OpenFeatureCacheTTL = "GF_INSTANCE_OPENFEATURE_CACHE_TTL"
-	// OpenFeatureContext is a JSON object of host-owned evaluation context
-	// attributes (for example stackId and slug on Grafana Cloud). It is only
-	// distributed through the per-request config, never as an environment
-	// variable, because one plugin process may serve many tenants.
+	// OpenFeatureContext is the per-request config key carrying a JSON object
+	// of host-owned evaluation context attributes (for example stackId and
+	// slug on Grafana Cloud).
 	OpenFeatureContext = "GF_INSTANCE_OPENFEATURE_CONTEXT"
 )
 
@@ -61,46 +60,24 @@ type OpenFeatureConfig struct {
 }
 
 // OpenFeature returns the OpenFeature provider discovery configuration
-// exposed by the Grafana instance hosting the plugin.
+// exposed by the Grafana instance hosting the plugin, resolved from the
+// per-request config set by WithGrafanaConfig. Discovery is therefore only
+// available once a request has arrived: plugins should construct their
+// OpenFeature provider lazily on first use rather than at process start.
 //
-// Each value is resolved in the following priority order:
-//  1. The per-request config from the request context, set by WithGrafanaConfig
-//  2. The corresponding environment variable, set at plugin process start
-//
-// A key present in the per-request config is authoritative even when its
-// value is empty: the environment is only consulted for keys the host did
-// not send at all. This keeps a multi-tenant host's per-request answer from
-// being overridden by process-wide state.
-//
-// ContextAttrs is only distributed through the per-request config; use
-// PluginContext.Namespace together with ContextAttrs to build the evaluation
-// context. Before any request has arrived (for example while constructing a
-// provider at plugin start-up), use OpenFeatureConfigFromEnv instead.
+// Use PluginContext.Namespace together with ContextAttrs to build the
+// evaluation context.
 //
 // It returns an error wrapping ErrOpenFeatureNotConfigured when the host has
 // not exposed a provider URL. A more recent version of Grafana may be
 // required.
 func (c *GrafanaCfg) OpenFeature() (OpenFeatureConfig, error) {
-	url, ok := c.config[OpenFeatureProviderURL]
-	if !ok {
-		// Fallback to environment variable for hosts that only provide
-		// discovery at process start.
-		url = os.Getenv(OpenFeatureProviderURL)
-	}
+	url := c.config[OpenFeatureProviderURL]
 	if url == "" {
 		return OpenFeatureConfig{}, fmt.Errorf("%w: %s is empty or not set. A more recent version of Grafana may be required", ErrOpenFeatureNotConfigured, OpenFeatureProviderURL)
 	}
 
-	providerType, ok := c.config[OpenFeatureProviderType]
-	if !ok {
-		providerType = os.Getenv(OpenFeatureProviderType)
-	}
-
-	ttlString, ok := c.config[OpenFeatureCacheTTL]
-	if !ok {
-		ttlString = os.Getenv(OpenFeatureCacheTTL)
-	}
-	ttl, err := parseOpenFeatureCacheTTL(ttlString)
+	ttl, err := parseOpenFeatureCacheTTL(c.config[OpenFeatureCacheTTL])
 	if err != nil {
 		return OpenFeatureConfig{}, err
 	}
@@ -113,37 +90,10 @@ func (c *GrafanaCfg) OpenFeature() (OpenFeatureConfig, error) {
 	}
 
 	return OpenFeatureConfig{
-		ProviderType: providerType,
+		ProviderType: c.config[OpenFeatureProviderType],
 		URL:          url,
 		CacheTTL:     ttl,
 		ContextAttrs: contextAttrs,
-	}, nil
-}
-
-// OpenFeatureConfigFromEnv returns the OpenFeature provider discovery
-// configuration from environment variables. It is intended for use at plugin
-// process start, before any request (and therefore any per-request config)
-// has arrived. ContextAttrs is always nil since the evaluation context is
-// only distributed through the per-request config.
-//
-// It returns an error wrapping ErrOpenFeatureNotConfigured when the host has
-// not exposed a provider URL. A more recent version of Grafana may be
-// required.
-func OpenFeatureConfigFromEnv() (OpenFeatureConfig, error) {
-	url := os.Getenv(OpenFeatureProviderURL)
-	if url == "" {
-		return OpenFeatureConfig{}, fmt.Errorf("%w: %s not set in environment. A more recent version of Grafana may be required", ErrOpenFeatureNotConfigured, OpenFeatureProviderURL)
-	}
-
-	ttl, err := parseOpenFeatureCacheTTL(os.Getenv(OpenFeatureCacheTTL))
-	if err != nil {
-		return OpenFeatureConfig{}, err
-	}
-
-	return OpenFeatureConfig{
-		ProviderType: os.Getenv(OpenFeatureProviderType),
-		URL:          url,
-		CacheTTL:     ttl,
 	}, nil
 }
 

--- a/config/openfeature_test.go
+++ b/config/openfeature_test.go
@@ -1,0 +1,170 @@
+package config
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenFeature(t *testing.T) {
+	t.Run("it should return the configured OpenFeature provider", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{
+			OpenFeatureProviderType: "ofrep",
+			OpenFeatureProviderURL:  "http://localhost:3000",
+			OpenFeatureCacheTTL:     "30",
+			OpenFeatureContext:      `{"grafana_version":"12.3.0","namespace":"stacks-123"}`,
+		})
+		v, err := cfg.OpenFeature()
+		require.NoError(t, err)
+		require.Equal(t, "ofrep", v.ProviderType)
+		require.Equal(t, "http://localhost:3000", v.URL)
+		require.Equal(t, 30*time.Second, v.CacheTTL)
+		require.Equal(t, map[string]string{"grafana_version": "12.3.0", "namespace": "stacks-123"}, v.ContextAttrs)
+	})
+
+	t.Run("it should not require the cache TTL and context attributes", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{
+			OpenFeatureProviderType: "static",
+			OpenFeatureProviderURL:  "http://localhost:3000",
+		})
+		v, err := cfg.OpenFeature()
+		require.NoError(t, err)
+		require.Equal(t, "static", v.ProviderType)
+		require.Equal(t, "http://localhost:3000", v.URL)
+		require.Zero(t, v.CacheTTL)
+		require.Nil(t, v.ContextAttrs)
+	})
+
+	t.Run("it should fall back to environment variables when not set in config", func(t *testing.T) {
+		t.Setenv(OpenFeatureProviderType, "features-service")
+		t.Setenv(OpenFeatureProviderURL, "http://localhost-env:3000")
+		t.Setenv(OpenFeatureCacheTTL, "60")
+		cfg := NewGrafanaCfg(map[string]string{})
+		v, err := cfg.OpenFeature()
+		require.NoError(t, err)
+		require.Equal(t, "features-service", v.ProviderType)
+		require.Equal(t, "http://localhost-env:3000", v.URL)
+		require.Equal(t, time.Minute, v.CacheTTL)
+		require.Nil(t, v.ContextAttrs)
+	})
+
+	t.Run("it should prefer config values over environment variables", func(t *testing.T) {
+		t.Setenv(OpenFeatureProviderType, "static")
+		t.Setenv(OpenFeatureProviderURL, "http://localhost-env:3000")
+		t.Setenv(OpenFeatureCacheTTL, "60")
+		cfg := NewGrafanaCfg(map[string]string{
+			OpenFeatureProviderType: "ofrep",
+			OpenFeatureProviderURL:  "http://localhost:3000",
+			OpenFeatureCacheTTL:     "30",
+		})
+		v, err := cfg.OpenFeature()
+		require.NoError(t, err)
+		require.Equal(t, "ofrep", v.ProviderType)
+		require.Equal(t, "http://localhost:3000", v.URL)
+		require.Equal(t, 30*time.Second, v.CacheTTL)
+	})
+
+	t.Run("it should return ErrOpenFeatureNotConfigured if the provider URL is missing", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{})
+		_, err := cfg.OpenFeature()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrOpenFeatureNotConfigured))
+	})
+
+	t.Run("it should return ErrOpenFeatureNotConfigured if the provider URL is empty", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{
+			OpenFeatureProviderURL: "",
+		})
+		_, err := cfg.OpenFeature()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrOpenFeatureNotConfigured))
+	})
+
+	t.Run("it should return an error if the cache TTL is not an integer", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{
+			OpenFeatureProviderURL: "http://localhost:3000",
+			OpenFeatureCacheTTL:    "30s",
+		})
+		_, err := cfg.OpenFeature()
+		require.ErrorContains(t, err, "integer number of seconds")
+	})
+
+	t.Run("it should return an error if the cache TTL is negative", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{
+			OpenFeatureProviderURL: "http://localhost:3000",
+			OpenFeatureCacheTTL:    "-1",
+		})
+		_, err := cfg.OpenFeature()
+		require.ErrorContains(t, err, "non-negative")
+	})
+
+	t.Run("it should return an error if the cache TTL does not fit in a duration", func(t *testing.T) {
+		cfg := NewGrafanaCfg(map[string]string{
+			OpenFeatureProviderURL: "http://localhost:3000",
+			OpenFeatureCacheTTL:    "10000000000",
+		})
+		_, err := cfg.OpenFeature()
+		require.ErrorContains(t, err, "does not fit in a time.Duration")
+	})
+
+	t.Run("it should not consult the environment for keys present but empty in config", func(t *testing.T) {
+		t.Setenv(OpenFeatureProviderURL, "http://localhost-env:3000")
+		cfg := NewGrafanaCfg(map[string]string{
+			OpenFeatureProviderURL: "",
+		})
+		_, err := cfg.OpenFeature()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrOpenFeatureNotConfigured))
+	})
+
+	t.Run("it should return an error if the context is not a JSON object of strings", func(t *testing.T) {
+		for _, v := range []string{"not-json", `{"stackId":123}`, `["a","b"]`} {
+			cfg := NewGrafanaCfg(map[string]string{
+				OpenFeatureProviderURL: "http://localhost:3000",
+				OpenFeatureContext:     v,
+			})
+			_, err := cfg.OpenFeature()
+			require.ErrorContains(t, err, "JSON object")
+		}
+	})
+
+	t.Run("it should not read context attributes from the environment", func(t *testing.T) {
+		t.Setenv(OpenFeatureContext, `{"stackId":"123"}`)
+		cfg := NewGrafanaCfg(map[string]string{
+			OpenFeatureProviderURL: "http://localhost:3000",
+		})
+		v, err := cfg.OpenFeature()
+		require.NoError(t, err)
+		require.Nil(t, v.ContextAttrs)
+	})
+}
+
+func TestOpenFeatureConfigFromEnv(t *testing.T) {
+	t.Run("it should return the provider configured in environment variables", func(t *testing.T) {
+		t.Setenv(OpenFeatureProviderType, "static")
+		t.Setenv(OpenFeatureProviderURL, "http://localhost:3000")
+		t.Setenv(OpenFeatureCacheTTL, "30")
+		v, err := OpenFeatureConfigFromEnv()
+		require.NoError(t, err)
+		require.Equal(t, "static", v.ProviderType)
+		require.Equal(t, "http://localhost:3000", v.URL)
+		require.Equal(t, 30*time.Second, v.CacheTTL)
+		require.Nil(t, v.ContextAttrs)
+	})
+
+	t.Run("it should return ErrOpenFeatureNotConfigured if the provider URL is missing", func(t *testing.T) {
+		t.Setenv(OpenFeatureProviderURL, "")
+		_, err := OpenFeatureConfigFromEnv()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrOpenFeatureNotConfigured))
+	})
+
+	t.Run("it should return an error if the cache TTL is not an integer", func(t *testing.T) {
+		t.Setenv(OpenFeatureProviderURL, "http://localhost:3000")
+		t.Setenv(OpenFeatureCacheTTL, "1m")
+		_, err := OpenFeatureConfigFromEnv()
+		require.ErrorContains(t, err, "integer number of seconds")
+	})
+}

--- a/config/openfeature_test.go
+++ b/config/openfeature_test.go
@@ -37,35 +37,6 @@ func TestOpenFeature(t *testing.T) {
 		require.Nil(t, v.ContextAttrs)
 	})
 
-	t.Run("it should fall back to environment variables when not set in config", func(t *testing.T) {
-		t.Setenv(OpenFeatureProviderType, "features-service")
-		t.Setenv(OpenFeatureProviderURL, "http://localhost-env:3000")
-		t.Setenv(OpenFeatureCacheTTL, "60")
-		cfg := NewGrafanaCfg(map[string]string{})
-		v, err := cfg.OpenFeature()
-		require.NoError(t, err)
-		require.Equal(t, "features-service", v.ProviderType)
-		require.Equal(t, "http://localhost-env:3000", v.URL)
-		require.Equal(t, time.Minute, v.CacheTTL)
-		require.Nil(t, v.ContextAttrs)
-	})
-
-	t.Run("it should prefer config values over environment variables", func(t *testing.T) {
-		t.Setenv(OpenFeatureProviderType, "static")
-		t.Setenv(OpenFeatureProviderURL, "http://localhost-env:3000")
-		t.Setenv(OpenFeatureCacheTTL, "60")
-		cfg := NewGrafanaCfg(map[string]string{
-			OpenFeatureProviderType: "ofrep",
-			OpenFeatureProviderURL:  "http://localhost:3000",
-			OpenFeatureCacheTTL:     "30",
-		})
-		v, err := cfg.OpenFeature()
-		require.NoError(t, err)
-		require.Equal(t, "ofrep", v.ProviderType)
-		require.Equal(t, "http://localhost:3000", v.URL)
-		require.Equal(t, 30*time.Second, v.CacheTTL)
-	})
-
 	t.Run("it should return ErrOpenFeatureNotConfigured if the provider URL is missing", func(t *testing.T) {
 		cfg := NewGrafanaCfg(map[string]string{})
 		_, err := cfg.OpenFeature()
@@ -77,6 +48,14 @@ func TestOpenFeature(t *testing.T) {
 		cfg := NewGrafanaCfg(map[string]string{
 			OpenFeatureProviderURL: "",
 		})
+		_, err := cfg.OpenFeature()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrOpenFeatureNotConfigured))
+	})
+
+	t.Run("it should not read the provider from the environment", func(t *testing.T) {
+		t.Setenv(OpenFeatureProviderURL, "http://localhost-env:3000")
+		cfg := NewGrafanaCfg(map[string]string{})
 		_, err := cfg.OpenFeature()
 		require.Error(t, err)
 		require.True(t, errors.Is(err, ErrOpenFeatureNotConfigured))
@@ -109,16 +88,6 @@ func TestOpenFeature(t *testing.T) {
 		require.ErrorContains(t, err, "does not fit in a time.Duration")
 	})
 
-	t.Run("it should not consult the environment for keys present but empty in config", func(t *testing.T) {
-		t.Setenv(OpenFeatureProviderURL, "http://localhost-env:3000")
-		cfg := NewGrafanaCfg(map[string]string{
-			OpenFeatureProviderURL: "",
-		})
-		_, err := cfg.OpenFeature()
-		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrOpenFeatureNotConfigured))
-	})
-
 	t.Run("it should return an error if the context is not a JSON object of strings", func(t *testing.T) {
 		for _, v := range []string{"not-json", `{"stackId":123}`, `["a","b"]`} {
 			cfg := NewGrafanaCfg(map[string]string{
@@ -128,43 +97,5 @@ func TestOpenFeature(t *testing.T) {
 			_, err := cfg.OpenFeature()
 			require.ErrorContains(t, err, "JSON object")
 		}
-	})
-
-	t.Run("it should not read context attributes from the environment", func(t *testing.T) {
-		t.Setenv(OpenFeatureContext, `{"stackId":"123"}`)
-		cfg := NewGrafanaCfg(map[string]string{
-			OpenFeatureProviderURL: "http://localhost:3000",
-		})
-		v, err := cfg.OpenFeature()
-		require.NoError(t, err)
-		require.Nil(t, v.ContextAttrs)
-	})
-}
-
-func TestOpenFeatureConfigFromEnv(t *testing.T) {
-	t.Run("it should return the provider configured in environment variables", func(t *testing.T) {
-		t.Setenv(OpenFeatureProviderType, "static")
-		t.Setenv(OpenFeatureProviderURL, "http://localhost:3000")
-		t.Setenv(OpenFeatureCacheTTL, "30")
-		v, err := OpenFeatureConfigFromEnv()
-		require.NoError(t, err)
-		require.Equal(t, "static", v.ProviderType)
-		require.Equal(t, "http://localhost:3000", v.URL)
-		require.Equal(t, 30*time.Second, v.CacheTTL)
-		require.Nil(t, v.ContextAttrs)
-	})
-
-	t.Run("it should return ErrOpenFeatureNotConfigured if the provider URL is missing", func(t *testing.T) {
-		t.Setenv(OpenFeatureProviderURL, "")
-		_, err := OpenFeatureConfigFromEnv()
-		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrOpenFeatureNotConfigured))
-	})
-
-	t.Run("it should return an error if the cache TTL is not an integer", func(t *testing.T) {
-		t.Setenv(OpenFeatureProviderURL, "http://localhost:3000")
-		t.Setenv(OpenFeatureCacheTTL, "1m")
-		_, err := OpenFeatureConfigFromEnv()
-		require.ErrorContains(t, err, "integer number of seconds")
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds standard **OpenFeature provider discovery** to the SDK `config` package: a typed getter that tells a plugin backend where the host Grafana's OpenFeature provider lives and what evaluation context the host asserts. It deliberately does **not** wrap the OpenFeature client. Plugins instantiate their own provider and client in their own domain, exactly as they do on the frontend (the frontend NPM packages expose `config.namespace` and the OpenFeature context, not a client).

### Problem

The only feature-flag channel plugin backends have today is `GF_INSTANCE_FEATURE_TOGGLES_ENABLE`, a flat comma-separated list of enabled toggle names. It has three structural problems:

1. **It never carries remotely managed flags.** Nothing forwards OpenFeature evaluations into it, so flags managed by a remote provider (for example Grafana Cloud's rollout tooling) are invisible to every plugin backend. Targeting, percentages and staged rollouts simply do not reach plugins.
2. **It is boolean-only.** `[feature_toggles]` and OpenFeature both support string, integer, float and JSON variants that a comma-separated name list cannot express.
3. **It is built from a deprecated API.** `featuremgmt.FeatureToggles.IsEnabled` is deprecated in favour of OpenFeature evaluation, and the internal migration guide explicitly lists the plugin SDK path as unresolved.

In the absence of a standard, two plugins have already hand-rolled OFREP evaluation independently:

| Plugin | Language | URL discovery | Targeting context |
|---|---|---|---|
| Elasticsearch ([grafana-elasticsearch-datasource#316](https://github.com/grafana/grafana-elasticsearch-datasource/pull/316)) | Go | `GF_PLUGIN_ELASTICSEARCH_OFREP_URL`, hardcoded cloud-only default | derived from `tenantID` gRPC metadata |
| IBM Db2 | Java | `GF_PLUGIN_IBMDB2_OFREP_URL`, hardcoded cloud-only default | derived from `tenantID` gRPC metadata |

Each invented its own discovery key, hardcoded a cloud-only default URL, and re-derived tenant identity from wire metadata. The cost of unstandardised context is already on record: an internal escalation was caused by the frontend evaluating a flag with one context attribute set while the backend derived a different one, so the same flag evaluated differently per tier ([internal link](https://github.com/grafana/support-escalations/issues/22643)). A third hand-rolled implementation is a matter of time.

### What the SDK exposes

Four per-request config keys, one struct, one getter, all in `config/` (the `backend/` re-export surface is deprecated, so no aliases are added there):

| Key | Value |
|---|---|
| `GF_INSTANCE_OPENFEATURE_PROVIDER_URL` | OFREP base URL (OFREP clients append `/ofrep/v1/evaluate/flags[/{key}]`) |
| `GF_INSTANCE_OPENFEATURE_PROVIDER_TYPE` | `static`, `features-service` or `ofrep` |
| `GF_INSTANCE_OPENFEATURE_CACHE_TTL` | advisory evaluation cache TTL, integer seconds (0 or absent means no caching advice) |
| `GF_INSTANCE_OPENFEATURE_CONTEXT` | JSON object of host-owned evaluation context attributes |

```go
func (c *GrafanaCfg) OpenFeature() (OpenFeatureConfig, error)
```

The getter returns an error wrapping `ErrOpenFeatureNotConfigured` when the host exposes no provider URL, so a plugin on an older Grafana falls back to its own default with a plain `errors.Is` check.

**Discovery flows only through the per-request config** (the `GrafanaConfig` map on `PluginContext`), never through environment variables. One channel means one resolution rule, and a multi-tenant host's per-request answer can never be shadowed by process-wide state. The consequence for plugin authors: discovery is unavailable before the first request, so construct the OpenFeature provider lazily on first use rather than at process start.

The **config key names are the cross-language contract**: the Db2 plugin (Java) participates by reading the same keys from the `GrafanaConfig` map in the plugin protocol, with no Go SDK involved. This is also why the SDK hardcodes **no** default URL. Key absent means discovery is unavailable. A cloud-only in-cluster URL never gets baked into a place where self-hosted installs would try to use it.

### Evaluation-context contract for plugins

- `targetingKey` = `PluginContext.Namespace` (`default`, `org-N`, or `stacks-N`), identical to the frontend's `config.namespace`
- `namespace` attribute = the same value
- merge the host-supplied `ContextAttrs` verbatim, never overriding host keys
- plugins may add plugin-scoped attributes (for example `pluginId`)
- plugins must **not** invent `slug` or other identity attributes the host has not asserted

### How the host fills these in (companion PRs)

- **grafana core** emits the per-request keys from `pluginconfig`, resolving the URL host-side: the static provider advertises Grafana's own root OFREP route (which serves `[feature_toggles]` ini flags, including custom names and non-boolean variants, verified end-to-end on 12.3.0), remote providers pass their URL through. Companion PR: https://github.com/grafana/grafana/pull/129735.
- **the multi-tenant datasource apiserver** (grafana-enterprise) feeds its existing `--openfeature-*` flags into the same shared `pluginconfig` request path and asserts tenant context (`stackId`, `slug`) per request. Companion PR: https://github.com/grafana/grafana-enterprise/pull/12873 (internal).

Nothing breaks if the PRs land out of order. Plugins keep their current fallbacks until discovery appears.

### Non-goals

- No OpenFeature client or provider wrapper in the SDK. Plugins instantiate their own provider, as on the frontend.
- No flag definition, registration or management from plugins.
- No change to `GF_INSTANCE_FEATURE_TOGGLES_ENABLE`. The legacy boolean channel remains as-is.
- No auth. The contract is that the URL is an OFREP endpoint reachable with ambient credentials. Because plugins send `namespace` in the evaluation context from day one, a future authenticated cutover is a URL swap plus a credential mechanism (a new provider type value or a `GF_INSTANCE_OPENFEATURE_AUTH_*` family), with no change to the evaluation contract.

**Which issue(s) this PR fixes**:

No linked issue in this repo. Related: [grafana-elasticsearch-datasource#317](https://github.com/grafana/grafana-elasticsearch-datasource/issues/317) tracks the first planned adopter, which would swap its bespoke `GF_PLUGIN_ELASTICSEARCH_OFREP_URL` for `config.OpenFeature()` and keep the old env var as a deprecated fallback for one release.

**Special notes for your reviewer**:

Open questions this proposal would like your steer on:

1. **TTL wire format.** Integer seconds was chosen over Go duration strings so non-Go plugins (the Db2 backend is Java) can parse it without a Go duration parser, matching the precedent of `GF_SQL_MAX_CONN_LIFETIME_SECONDS_DEFAULT`. If you would rather encode the unit in the name (`GF_INSTANCE_OPENFEATURE_CACHE_TTL_SECONDS`), now is the time.
2. **Naming freeze.** `GF_INSTANCE_OPENFEATURE_*` is proposed over `GF_INSTANCE_OFREP_*` to match core's `[feature_toggles.openfeature]` section and the MT apiserver's `--openfeature-*` flags. Once a plugin ships against these names they are frozen.
3. **`ErrOpenFeatureNotConfigured`.** This file has no sentinel errors today. The sentinel lets plugins distinguish "old host, use my fallback" from "host sent something malformed" without string matching. Happy to drop it for plain errors if you prefer the existing style.
4. **No `backend/` aliases.** Every type alias in `backend/config.go` carries a "Deprecated: use the config package" notice, so new aliases would be deprecated on arrival. Constants parity there was deliberately skipped.

One semantic worth calling out explicitly, pinned by tests: the TTL parser rejects negatives and values that would overflow `time.Duration`, and the getter treats `0` as "no caching advice" rather than "caching forbidden". The host-side emitters clamp accordingly (see companion PRs).

Discussed with the plugin platform and backend services squads before this PR was raised. The design doc behind this proposal is available internally.
