### PR TITLE
backend: capture the rows a SQL datasource returned

### DIFF
--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -74,7 +74,8 @@ type sdkHARQueryInfo struct {
 
 // payloadBytes is the "_query" object's share of the buffer's retained-payload budget (see
 // Buffer.appendEntry): the bind arguments, which a bulk statement can make as large as the statement
-// itself, and the error. A nil receiver is an HTTP entry, which has no "_query".
+// itself, and the error. The rows live in the entry's Response.Content instead, so they are already
+// counted there. A nil receiver is an HTTP entry, which has no "_query".
 func (q *sdkHARQueryInfo) payloadBytes() int64 {
 	if q == nil {
 		return 0
@@ -97,8 +98,24 @@ func (q *sdkHARQueryInfo) dropPayload() {
 	q.ArgsTruncated = true
 }
 
-// querySummary is the response content of a query entry: what came back, counted rather than copied.
+// querySummary is the response content of a query entry: the rows the datasource returned, plus what
+// the plugin made of them.
+//
+// The rows are carried in full (up to querycapture.MaxResultBytes), the same way an HTTP entry carries
+// a response body, because they are the same evidence: without them a bundle can say what was asked
+// and what the plugin returned, but has no independent account of what the datasource sent -- which is
+// the difference between localizing a wrong-data report and merely describing it.
 type querySummary struct {
+	// Columns and Rows are the result set as the driver produced it, before conversion. A null cell is
+	// a SQL NULL, distinct from an empty string.
+	Columns []string    `json:"columns,omitempty"`
+	Rows    [][]*string `json:"rows,omitempty"`
+	// TotalRows is how many rows the datasource returned; it exceeds len(Rows) when RowsTruncated is
+	// set, so a reader can tell a short result from a clipped one. Omitted when unknown.
+	TotalRows     *int `json:"totalRows,omitempty"`
+	RowsTruncated bool `json:"rowsTruncated,omitempty"`
+	// FrameCount and RowCount are what the plugin returned, so the comparison the bundle exists for
+	// can be made inside a single object.
 	FrameCount int `json:"frameCount"`
 	RowCount   int `json:"rowCount"`
 }
@@ -125,15 +142,35 @@ func buildQueryHAREntry(i querycapture.Interaction) sdkHAREntry {
 	resp := sdkHARResponse{Status: 0, HeadersSize: -1, BodySize: -1, Headers: []sdkHARNameValue{}, Cookies: []sdkHARCookie{}}
 	var comment string
 	if i.Err == "" {
-		summary, err := json.Marshal(querySummary{FrameCount: i.FrameCount, RowCount: i.RowCount})
+		body := querySummary{
+			Columns:       i.ResultColumns,
+			Rows:          i.ResultRows,
+			RowsTruncated: i.ResultRowsTruncated,
+			FrameCount:    i.FrameCount,
+			RowCount:      i.RowCount,
+		}
+		// Report the total only when the capture point actually determined it. A zero is ambiguous in a
+		// plain int -- "the datasource returned no rows" and "nobody filled this field in" look the
+		// same -- so a zero counts only alongside a captured result shape, which is proof the capture
+		// point ran and saw an empty result. Anything negative means "not determined" by contract.
+		if i.ResultTotalRows > 0 || (i.ResultTotalRows == 0 && i.ResultColumns != nil) {
+			total := i.ResultTotalRows
+			body.TotalRows = &total
+		}
+		summary, err := json.Marshal(body)
 		if err != nil {
-			// Cannot happen for two ints, but a capture must never be the reason a query looks broken:
-			// fall back to no content rather than dropping the entry.
+			// A capture must never be the reason a query looks broken: fall back to no content rather
+			// than dropping the entry or surfacing the failure as a query error.
 			summary = nil
 		}
 		resp.Status = 200
 		resp.StatusText = "OK"
 		resp.BodySize = int64(len(summary))
+		// A clipped result reports an unavailable body size, the same convention an over-cap HTTP
+		// response body uses; content.size stays what was actually retained.
+		if i.ResultRowsTruncated {
+			resp.BodySize = -1
+		}
 		resp.Content = sdkHARContent{
 			Size:     int64(len(summary)),
 			MimeType: querySummaryMimeType,
@@ -141,6 +178,26 @@ func buildQueryHAREntry(i querycapture.Interaction) sdkHAREntry {
 		}
 	} else {
 		comment = "query error: " + i.Err
+		// A query can fail after the datasource already returned rows -- a conversion that choked on
+		// row 300, a result set that errored mid-stream. Those rows are the most direct evidence there
+		// is of what went wrong, so keep them. The status stays zero: the query did not complete, and
+		// claiming a 200 because some rows arrived would misreport it.
+		if len(i.ResultRows) > 0 {
+			partial, err := json.Marshal(querySummary{
+				Columns:       i.ResultColumns,
+				Rows:          i.ResultRows,
+				RowsTruncated: i.ResultRowsTruncated,
+				FrameCount:    i.FrameCount,
+				RowCount:      i.RowCount,
+			})
+			if err == nil {
+				resp.Content = sdkHARContent{
+					Size:     int64(len(partial)),
+					MimeType: querySummaryMimeType,
+					Text:     string(partial),
+				}
+			}
+		}
 	}
 
 	return sdkHAREntry{

--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -99,17 +99,17 @@ func (q *sdkHARQueryInfo) dropPayload() {
 // querySummary is the response content of a query entry: the rows the datasource returned, plus what
 // the plugin made of them.
 //
-// The rows are carried in full (up to querycapture.MaxResultBytes), the same way an HTTP entry carries
-// a response body, because they are the same evidence: without them a bundle can say what was asked
-// and what the plugin returned, but has no independent account of what the datasource sent -- which is
-// the difference between localizing a wrong-data report and merely describing it.
+// The rows are carried in full, up to querycapture.MaxResultBytes; past that, Rows is empty rather
+// than a prefix, and RowsTruncated says so, on the same reasoning the on-demand diagnostics bundle
+// applies to a whole artifact: a partial result answers a wrong-data report no better than none.
 type querySummary struct {
 	// Columns and Rows are the result set as the driver produced it, before conversion. A null cell is
-	// a SQL NULL, distinct from an empty string.
+	// a SQL NULL, distinct from an empty string. Rows is empty when RowsTruncated is set; Columns
+	// survives, since the shape alone is not the partial-result evidence this drops.
 	Columns []string    `json:"columns,omitempty"`
 	Rows    [][]*string `json:"rows,omitempty"`
-	// TotalRows is how many rows the datasource returned; it exceeds len(Rows) when RowsTruncated is
-	// set, so a reader can tell a short result from a clipped one. Omitted when unknown.
+	// TotalRows is how many rows the datasource returned, so a reader still learns how much there was
+	// even when RowsTruncated dropped the rows themselves. Omitted when unknown.
 	TotalRows     *int `json:"totalRows,omitempty"`
 	RowsTruncated bool `json:"rowsTruncated,omitempty"`
 	// FrameCount and RowCount are what the plugin returned, so the comparison the bundle exists for
@@ -164,8 +164,8 @@ func buildQueryHAREntry(i querycapture.Interaction) sdkHAREntry {
 		resp.Status = 200
 		resp.StatusText = "OK"
 		resp.BodySize = int64(len(summary))
-		// A clipped result reports an unavailable body size, the same convention an over-cap HTTP
-		// response body uses; content.size stays what was actually retained.
+		// A dropped result reports an unavailable body size, the same convention an over-cap HTTP
+		// response body uses; content.size stays what was actually retained (the counts alone).
 		if i.ResultRowsTruncated {
 			resp.BodySize = -1
 		}

--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -14,10 +14,8 @@ import (
 // non-HTTP protocol, so the statement is modelled as the request body.
 const queryMimeType = "application/sql"
 
-// querySummaryMimeType labels the response content of a query entry. The content is a summary of what
-// the plugin got back (see querySummary), not the driver's raw reply: rows travel back to Grafana as
-// frames and are reported in the QueryData artifact, so duplicating them here would double the size of
-// a bundle to say the same thing twice.
+// querySummaryMimeType labels the response content of a query entry: the rows the datasource returned
+// plus the counts the plugin produced from them (see querySummary), rendered as JSON.
 const querySummaryMimeType = "application/json"
 
 // AddQueryInteraction records a non-HTTP datasource exchange (a SQL statement, a native-protocol

--- a/backend/harcapture/querycapture_test.go
+++ b/backend/harcapture/querycapture_test.go
@@ -363,13 +363,12 @@ func TestAddQueryInteraction_carriesReturnedRows(t *testing.T) {
 	assert.Equal(t, int64(len(e.Response.Content.Text)), e.Response.BodySize)
 }
 
-func TestAddQueryInteraction_clippedRowsAreReported(t *testing.T) {
+func TestAddQueryInteraction_droppedRowsAreReported(t *testing.T) {
 	b := NewBuffer()
 	b.AddQueryInteraction(querycapture.Interaction{
 		Kind:                querycapture.KindSQLQuery,
 		Statement:           "SELECT * FROM big",
 		ResultColumns:       []string{"host"},
-		ResultRows:          [][]*string{{strPtr("host-a")}},
 		ResultRowsTruncated: true,
 		ResultTotalRows:     900,
 		FrameCount:          1,
@@ -379,10 +378,12 @@ func TestAddQueryInteraction_clippedRowsAreReported(t *testing.T) {
 	doc := toDoc(t, b)
 	e := doc.Log.Entries[0]
 	assert.Equal(t, int64(-1), e.Response.BodySize,
-		"a clipped result reports an unavailable body size, the same as an over-cap HTTP body")
+		"a dropped result reports an unavailable body size, the same as an over-cap HTTP body")
 	assert.Contains(t, e.Response.Content.Text, `"rowsTruncated":true`)
+	assert.NotContains(t, e.Response.Content.Text, `"rows":`,
+		"a partial result is not evidence of the whole result, so no rows are reported at all")
 	assert.Contains(t, e.Response.Content.Text, `"totalRows":900`,
-		"the total says how much there was, so a prefix is not mistaken for the whole result")
+		"the total says how much there was, even though the rows themselves were dropped")
 }
 
 func TestAddQueryInteraction_unknownTotalIsOmitted(t *testing.T) {

--- a/backend/harcapture/querycapture_test.go
+++ b/backend/harcapture/querycapture_test.go
@@ -60,6 +60,8 @@ type harDoc struct {
 	} `json:"log"`
 }
 
+func strPtr(s string) *string { return &s }
+
 func toDoc(t *testing.T, b *Buffer) harDoc {
 	t.Helper()
 	raw, err := b.ToHARString()
@@ -326,4 +328,115 @@ func TestNewRecorder_nilBufferIsInert(t *testing.T) {
 	assert.NotPanics(t, func() {
 		NewRecorder(nil).Record(querycapture.Interaction{Kind: querycapture.KindSQLQuery})
 	})
+}
+
+func TestAddQueryInteraction_carriesReturnedRows(t *testing.T) {
+	// The rows the database returned are the evidence that makes a bundle able to localize a wrong-data
+	// report: without them, "the database returned the wrong rows" and "the plugin mangled correct rows"
+	// look identical. They ride in the response body, exactly where an HTTP entry carries its body.
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{
+		Kind:            querycapture.KindSQLQuery,
+		DatasourceUID:   "P1234",
+		Statement:       "SELECT host, value FROM metrics",
+		ResultColumns:   []string{"host", "value"},
+		ResultRows:      [][]*string{{strPtr("host-a"), strPtr("1")}, {strPtr("host-b"), nil}},
+		ResultTotalRows: 2,
+		FrameCount:      1,
+		RowCount:        1,
+	})
+
+	doc := toDoc(t, b)
+	require.Len(t, doc.Log.Entries, 1)
+	e := doc.Log.Entries[0]
+	assert.Equal(t, 200, e.Response.Status)
+	assert.Equal(t, "application/json", e.Response.Content.MimeType)
+	// A NULL stays null and is not flattened into an empty string; the plugin's own counts sit alongside
+	// the rows so the comparison can be made inside one object.
+	assert.JSONEq(t, `{
+		"columns": ["host","value"],
+		"rows": [["host-a","1"],["host-b",null]],
+		"totalRows": 2,
+		"frameCount": 1,
+		"rowCount": 1
+	}`, e.Response.Content.Text)
+	assert.Equal(t, int64(len(e.Response.Content.Text)), e.Response.BodySize)
+}
+
+func TestAddQueryInteraction_clippedRowsAreReported(t *testing.T) {
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{
+		Kind:                querycapture.KindSQLQuery,
+		Statement:           "SELECT * FROM big",
+		ResultColumns:       []string{"host"},
+		ResultRows:          [][]*string{{strPtr("host-a")}},
+		ResultRowsTruncated: true,
+		ResultTotalRows:     900,
+		FrameCount:          1,
+		RowCount:            900,
+	})
+
+	doc := toDoc(t, b)
+	e := doc.Log.Entries[0]
+	assert.Equal(t, int64(-1), e.Response.BodySize,
+		"a clipped result reports an unavailable body size, the same as an over-cap HTTP body")
+	assert.Contains(t, e.Response.Content.Text, `"rowsTruncated":true`)
+	assert.Contains(t, e.Response.Content.Text, `"totalRows":900`,
+		"the total says how much there was, so a prefix is not mistaken for the whole result")
+}
+
+func TestAddQueryInteraction_unknownTotalIsOmitted(t *testing.T) {
+	// A capture point that hands back an unconsumed result set cannot count it (-1); claiming zero would
+	// assert an empty result that was never observed.
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{
+		Kind:            querycapture.KindSQLQuery,
+		Statement:       "SELECT 1",
+		ResultTotalRows: -1,
+		RowCount:        -1,
+	})
+
+	doc := toDoc(t, b)
+	assert.NotContains(t, doc.Log.Entries[0].Response.Content.Text, "totalRows")
+}
+
+func TestAddQueryInteraction_failedQueryKeepsPartialRows(t *testing.T) {
+	// A query that failed after the database had already returned rows: those rows are the most direct
+	// evidence of what went wrong, so they are kept -- while the status stays zero, because the query
+	// did not complete.
+	b := NewBuffer()
+	b.AddQueryInteraction(querycapture.Interaction{
+		Kind:            querycapture.KindSQLQuery,
+		Statement:       "SELECT host, value FROM metrics",
+		ResultColumns:   []string{"host", "value"},
+		ResultRows:      [][]*string{{strPtr("host-a"), strPtr("not-a-number")}},
+		ResultTotalRows: 1,
+		Err:             "converting driver.Value type string to a float64",
+	})
+
+	doc := toDoc(t, b)
+	e := doc.Log.Entries[0]
+	assert.Equal(t, 0, e.Response.Status)
+	assert.Contains(t, e.Comment, "query error: converting driver.Value")
+	assert.Contains(t, e.Response.Content.Text, "not-a-number")
+}
+
+func TestAddQueryInteraction_emptyResultIsDistinctFromUncaptured(t *testing.T) {
+	// Zero rows is an answer; "nobody recorded a result" is not. The two must not look alike.
+	emptyResult := NewBuffer()
+	emptyResult.AddQueryInteraction(querycapture.Interaction{
+		Kind:          querycapture.KindSQLQuery,
+		Statement:     "SELECT host FROM metrics WHERE 1 = 0",
+		ResultColumns: []string{"host"},
+	})
+	assert.Contains(t, toDoc(t, emptyResult).Log.Entries[0].Response.Content.Text, `"totalRows":0`,
+		"a capture point that ran and saw no rows reports zero")
+
+	uncaptured := NewBuffer()
+	uncaptured.AddQueryInteraction(querycapture.Interaction{
+		Kind:      querycapture.KindSQLQuery,
+		Statement: "SELECT host FROM metrics",
+	})
+	assert.NotContains(t, toDoc(t, uncaptured).Log.Entries[0].Response.Content.Text, "totalRows",
+		"an interaction with no result capture claims nothing about how many rows there were")
 }

--- a/backend/querycapture/querycapture.go
+++ b/backend/querycapture/querycapture.go
@@ -119,10 +119,11 @@ type Interaction struct {
 	// "" and NULL are different answers to a wrong-data question.
 	ResultColumns []string
 	ResultRows    [][]*string
-	// ResultRowsTruncated reports that ResultRows is a prefix, because the result
-	// exceeded MaxResultBytes. ResultTotalRows is how many rows the capture point
-	// saw in total (which may exceed len(ResultRows)), or -1 when it could not
-	// tell -- a capture point that never consumes the result set cannot count it.
+	// ResultRowsTruncated reports that the result exceeded MaxResultBytes, in
+	// which case ResultRows is empty rather than a partial result: a prefix of
+	// the result is not evidence of the whole result. ResultTotalRows is how many
+	// rows the capture point saw in total, or -1 when it could not tell -- a
+	// capture point that never consumes the result set cannot count it.
 	ResultRowsTruncated bool
 	ResultTotalRows     int
 
@@ -153,12 +154,14 @@ const (
 	MaxStatementBytes = 64 * 1024
 	// MaxArgsBytes caps the aggregate size of Interaction.Args.
 	MaxArgsBytes = 16 * 1024
-	// MaxResultBytes caps the rendered result rows of one Interaction. It matches
-	// the cap the HTTP capture applies to a single response body, deliberately: the
-	// rows a SQL datasource returns are the same evidence as the body an HTTP
-	// datasource returns, and there is no reason for one to be retained more
-	// generously than the other.
-	MaxResultBytes = 8 << 20
+	// MaxResultBytes caps the rendered result rows of one Interaction. Crossing it
+	// drops the rows entirely rather than keeping a prefix -- a partial result set
+	// answers the wrong-data question the capture exists for no better than none
+	// at all -- so ResultCapture reports a count instead. This is deliberately a
+	// single guardrail rather than an engineered budget: it matches the one
+	// ceiling grafana/grafana#129691 applies to the whole diagnostics bundle
+	// (1 GiB), rather than a separately-tuned number for this one path.
+	MaxResultBytes = 1 << 30
 )
 
 type recorderContextKey struct{}

--- a/backend/querycapture/querycapture.go
+++ b/backend/querycapture/querycapture.go
@@ -109,6 +109,23 @@ type Interaction struct {
 	FrameCount int
 	RowCount   int
 
+	// ResultColumns and ResultRows are what the datasource itself returned, as
+	// the driver handed it over and before any conversion the plugin applies. They
+	// are the reason this capture can localize a wrong-data report at all: without
+	// them the capture shows what was asked and the returned frames show what
+	// arrived, with no independent account of what the datasource actually sent.
+	//
+	// A nil cell is a NULL, which is why a row is []*string rather than []string:
+	// "" and NULL are different answers to a wrong-data question.
+	ResultColumns []string
+	ResultRows    [][]*string
+	// ResultRowsTruncated reports that ResultRows is a prefix, because the result
+	// exceeded MaxResultBytes. ResultTotalRows is how many rows the capture point
+	// saw in total (which may exceed len(ResultRows)), or -1 when it could not
+	// tell -- a capture point that never consumes the result set cannot count it.
+	ResultRowsTruncated bool
+	ResultTotalRows     int
+
 	// Err is the error the call returned, or empty on success. A recorded
 	// failure is the most valuable case for diagnostics, so capture points
 	// record an Interaction on the error path too.
@@ -136,6 +153,12 @@ const (
 	MaxStatementBytes = 64 * 1024
 	// MaxArgsBytes caps the aggregate size of Interaction.Args.
 	MaxArgsBytes = 16 * 1024
+	// MaxResultBytes caps the rendered result rows of one Interaction. It matches
+	// the cap the HTTP capture applies to a single response body, deliberately: the
+	// rows a SQL datasource returns are the same evidence as the body an HTTP
+	// datasource returns, and there is no reason for one to be retained more
+	// generously than the other.
+	MaxResultBytes = 8 << 20
 )
 
 type recorderContextKey struct{}

--- a/backend/querycapture/resultcapture.go
+++ b/backend/querycapture/resultcapture.go
@@ -1,0 +1,145 @@
+package querycapture
+
+import (
+	"context"
+	"sync"
+)
+
+// ResultCapture collects the rows a datasource returned, bounded by MaxResultBytes.
+//
+// It is separate from Recorder because the two have different owners and different
+// lifetimes. A Recorder is installed once per request by the host that activated
+// capture; a ResultCapture is created per query by the capture point itself, which
+// is the only code positioned between the driver and the conversion into frames.
+// The capture point installs it on the context it passes down into row scanning,
+// then reads it back and puts the rows on the Interaction it reports.
+//
+// Rows are recorded as rendered strings rather than driver values: a result set can
+// hold any type a driver invents, and a capture is read by a human comparing it
+// against returned frames, not re-executed. A nil cell means NULL.
+//
+// Safe for concurrent use, since scanning and reading back can happen on different
+// goroutines, and cheap to leave installed: with no capture on the context the
+// scanning path skips it entirely.
+type ResultCapture struct {
+	mu        sync.Mutex
+	columns   []string
+	rows      [][]*string
+	bytes     int
+	total     int
+	truncated bool
+}
+
+// NewResultCapture returns an empty ResultCapture.
+func NewResultCapture() *ResultCapture {
+	return &ResultCapture{total: 0}
+}
+
+// SetColumns records the column names of the result set. Calling it more than once
+// keeps the first set: a multi-result-set query reports the shape of the first,
+// which is the one the row cells were rendered against.
+func (c *ResultCapture) SetColumns(names []string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.columns != nil {
+		return
+	}
+	c.columns = append([]string(nil), names...)
+}
+
+// AddRow records one scanned row. Cells must not be retained by the caller after
+// the call -- AddRow takes ownership of the slice.
+//
+// Once MaxResultBytes is reached the row is counted but not kept, so the capture
+// degrades into "here is the beginning, and here is how much there was" rather than
+// silently presenting a prefix as the whole result.
+func (c *ResultCapture) AddRow(cells []*string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.total++
+	if c.truncated {
+		return
+	}
+	size := 0
+	for _, cell := range cells {
+		if cell != nil {
+			size += len(*cell)
+		}
+		// Per-cell allowance for the JSON punctuation this row will serialize into, so
+		// the cap bounds the emitted document and not just the sum of the payloads.
+		size += 4
+	}
+	if c.bytes+size > MaxResultBytes {
+		c.truncated = true
+		return
+	}
+	c.bytes += size
+	c.rows = append(c.rows, cells)
+}
+
+// CapturedResult is what a ResultCapture collected.
+type CapturedResult struct {
+	// Columns are the result set's column names, empty when nothing was captured.
+	Columns []string
+	// Rows are the retained rows. A nil cell is a NULL.
+	Rows [][]*string
+	// Truncated reports that Rows is a prefix, because the result exceeded
+	// MaxResultBytes.
+	Truncated bool
+	// TotalRows is how many rows the capture point saw, which exceeds len(Rows)
+	// when Truncated is set. It is -1 when the capture point could not tell.
+	TotalRows int
+}
+
+// Result returns what was captured. The rows are copied, so a caller reading them
+// back while another goroutine is still scanning is safe. A nil ResultCapture
+// reports a total of -1 ("not determined"), which is not the same as zero rows.
+func (c *ResultCapture) Result() CapturedResult {
+	if c == nil {
+		return CapturedResult{TotalRows: -1}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	rows := make([][]*string, len(c.rows))
+	for i, r := range c.rows {
+		rows[i] = append([]*string(nil), r...)
+	}
+	return CapturedResult{
+		Columns:   append([]string(nil), c.columns...),
+		Rows:      rows,
+		Truncated: c.truncated,
+		TotalRows: c.total,
+	}
+}
+
+type resultCaptureContextKey struct{}
+
+// WithResultCapture returns a context that collects returned rows into c. Passing a
+// nil ResultCapture returns ctx unchanged, so a capture point can wire it
+// unconditionally and decide later whether capture is on.
+func WithResultCapture(ctx context.Context, c *ResultCapture) context.Context {
+	if c == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, resultCaptureContextKey{}, c)
+}
+
+// ResultCaptureFromContext returns the ResultCapture rows should be collected into,
+// if any. When the second result is false the scanning path must behave exactly as
+// it did before capture existed.
+func ResultCaptureFromContext(ctx context.Context) (*ResultCapture, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	c, ok := ctx.Value(resultCaptureContextKey{}).(*ResultCapture)
+	if !ok || c == nil {
+		return nil, false
+	}
+	return c, true
+}

--- a/backend/querycapture/resultcapture.go
+++ b/backend/querycapture/resultcapture.go
@@ -53,9 +53,11 @@ func (c *ResultCapture) SetColumns(names []string) {
 // AddRow records one scanned row. Cells must not be retained by the caller after
 // the call -- AddRow takes ownership of the slice.
 //
-// Once MaxResultBytes is reached the row is counted but not kept, so the capture
-// degrades into "here is the beginning, and here is how much there was" rather than
-// silently presenting a prefix as the whole result.
+// Once MaxResultBytes would be exceeded, every row is discarded, not just the ones
+// past the cap: a prefix of the result is not evidence of the whole result, and
+// presenting one invites exactly the "did the database or the plugin get this
+// wrong" confusion the capture exists to resolve. Rows keeps counting either way,
+// so a reader still learns how much there was.
 func (c *ResultCapture) AddRow(cells []*string) {
 	if c == nil {
 		return
@@ -77,6 +79,7 @@ func (c *ResultCapture) AddRow(cells []*string) {
 	}
 	if c.bytes+size > MaxResultBytes {
 		c.truncated = true
+		c.rows = nil
 		return
 	}
 	c.bytes += size
@@ -87,10 +90,11 @@ func (c *ResultCapture) AddRow(cells []*string) {
 type CapturedResult struct {
 	// Columns are the result set's column names, empty when nothing was captured.
 	Columns []string
-	// Rows are the retained rows. A nil cell is a NULL.
+	// Rows are the retained rows. A nil cell is a NULL. Empty when Truncated, since
+	// a prefix of the result is not evidence of the whole result.
 	Rows [][]*string
-	// Truncated reports that Rows is a prefix, because the result exceeded
-	// MaxResultBytes.
+	// Truncated reports that the result exceeded MaxResultBytes, so Rows is empty
+	// rather than a partial result.
 	Truncated bool
 	// TotalRows is how many rows the capture point saw, which exceeds len(Rows)
 	// when Truncated is set. It is -1 when the capture point could not tell.

--- a/backend/querycapture/resultcapture_test.go
+++ b/backend/querycapture/resultcapture_test.go
@@ -1,0 +1,118 @@
+package querycapture
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cell(s string) *string { return &s }
+
+func TestResultCapture_keepsRowsInOrder(t *testing.T) {
+	c := NewResultCapture()
+	c.SetColumns([]string{"host", "value"})
+	c.AddRow([]*string{cell("host-a"), cell("1")})
+	c.AddRow([]*string{cell("host-b"), nil})
+
+	got := c.Result()
+	assert.Equal(t, []string{"host", "value"}, got.Columns)
+	assert.False(t, got.Truncated)
+	assert.Equal(t, 2, got.TotalRows)
+	require.Len(t, got.Rows, 2)
+	assert.Equal(t, "host-a", *got.Rows[0][0])
+	assert.Nil(t, got.Rows[1][1], "a NULL survives as a nil cell rather than becoming an empty string")
+}
+
+func TestResultCapture_boundsRetainedRowsAndKeepsCounting(t *testing.T) {
+	// Past the cap the capture must become "here is the beginning, and here is how much there was",
+	// never a prefix presented as the whole result.
+	c := NewResultCapture()
+	big := strings.Repeat("x", 1<<20)
+	for i := 0; i < 16; i++ {
+		c.AddRow([]*string{cell(big)})
+	}
+
+	got := c.Result()
+	assert.True(t, got.Truncated)
+	assert.Equal(t, 16, got.TotalRows)
+	assert.Less(t, len(got.Rows), 16)
+	assert.LessOrEqual(t, len(got.Rows)*(1<<20), MaxResultBytes)
+}
+
+func TestResultCapture_firstColumnsWin(t *testing.T) {
+	// The cells were rendered against the first result set's shape, so a later set's columns must not
+	// relabel them.
+	c := NewResultCapture()
+	c.SetColumns([]string{"host"})
+	c.SetColumns([]string{"something", "else"})
+
+	assert.Equal(t, []string{"host"}, c.Result().Columns)
+}
+
+func TestResultCapture_resultIsACopy(t *testing.T) {
+	c := NewResultCapture()
+	c.AddRow([]*string{cell("host-a")})
+
+	got := c.Result()
+	got.Rows[0][0] = cell("mutated")
+
+	assert.Equal(t, "host-a", *c.Result().Rows[0][0])
+}
+
+func TestResultCapture_nilIsInert(t *testing.T) {
+	// sqlds passes whatever it has; a nil capture means capture is off and must never panic on the
+	// query path. A total of -1 says "not determined", which is not the same as zero rows.
+	var c *ResultCapture
+	assert.NotPanics(t, func() {
+		c.SetColumns([]string{"host"})
+		c.AddRow([]*string{cell("host-a")})
+	})
+	got := c.Result()
+	assert.Nil(t, got.Columns)
+	assert.Nil(t, got.Rows)
+	assert.False(t, got.Truncated)
+	assert.Equal(t, -1, got.TotalRows)
+}
+
+func TestResultCapture_concurrentUse(t *testing.T) {
+	// Scanning and reading back can happen on different goroutines. Run with -race.
+	c := NewResultCapture()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.SetColumns([]string{"host"})
+			c.AddRow([]*string{cell("host-a")})
+			_ = c.Result()
+		}()
+	}
+	wg.Wait()
+
+	got := c.Result()
+	assert.Equal(t, 50, got.TotalRows)
+	assert.Len(t, got.Rows, 50)
+}
+
+func TestResultCaptureFromContext(t *testing.T) {
+	t.Run("absent by default", func(t *testing.T) {
+		got, ok := ResultCaptureFromContext(t.Context())
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+
+	t.Run("nil capture leaves the context alone", func(t *testing.T) {
+		ctx := t.Context()
+		assert.Equal(t, ctx, WithResultCapture(ctx, nil))
+	})
+
+	t.Run("round-trips", func(t *testing.T) {
+		c := NewResultCapture()
+		got, ok := ResultCaptureFromContext(WithResultCapture(t.Context(), c))
+		require.True(t, ok)
+		assert.Same(t, c, got)
+	})
+}

--- a/backend/querycapture/resultcapture_test.go
+++ b/backend/querycapture/resultcapture_test.go
@@ -26,20 +26,18 @@ func TestResultCapture_keepsRowsInOrder(t *testing.T) {
 	assert.Nil(t, got.Rows[1][1], "a NULL survives as a nil cell rather than becoming an empty string")
 }
 
-func TestResultCapture_boundsRetainedRowsAndKeepsCounting(t *testing.T) {
-	// Past the cap the capture must become "here is the beginning, and here is how much there was",
-	// never a prefix presented as the whole result.
+func TestResultCapture_dropsAllRowsPastTheCapButKeepsCounting(t *testing.T) {
+	// Past the cap the capture must become "here is how much there was", never a prefix presented as
+	// the whole result -- so every row is dropped, including the one already collected before the row
+	// that crosses the budget, not just the one that overran it.
 	c := NewResultCapture()
-	big := strings.Repeat("x", 1<<20)
-	for i := 0; i < 16; i++ {
-		c.AddRow([]*string{cell(big)})
-	}
+	c.AddRow([]*string{cell("host-a")})
+	c.AddRow([]*string{cell(strings.Repeat("x", MaxResultBytes))})
 
 	got := c.Result()
 	assert.True(t, got.Truncated)
-	assert.Equal(t, 16, got.TotalRows)
-	assert.Less(t, len(got.Rows), 16)
-	assert.LessOrEqual(t, len(got.Rows)*(1<<20), MaxResultBytes)
+	assert.Equal(t, 2, got.TotalRows)
+	assert.Empty(t, got.Rows, "a partial result is not evidence of the whole result")
 }
 
 func TestResultCapture_firstColumnsWin(t *testing.T) {

--- a/data/sqlutil/dynamic_frame.go
+++ b/data/sqlutil/dynamic_frame.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend/querycapture"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/converters"
 )
@@ -107,11 +108,25 @@ func findDataTypes(rows Rows, rowLimit int64, types []*sql.ColumnType) ([]Field,
 	return fieldList, returnData, nil
 }
 
-func frameDynamic(rows Rows, rowLimit int64, types []*sql.ColumnType, converters []Converter) (*data.Frame, error) {
+// frameDynamic builds a frame for a result set whose types are discovered from the data. It takes the
+// result capture (rather than reading it off a context) because it is only ever reached from
+// frameFromRows, which has already resolved it; a nil capture means capture is off.
+func frameDynamic(rows Rows, rowLimit int64, types []*sql.ColumnType, converters []Converter, resultCapture *querycapture.ResultCapture) (*data.Frame, error) {
 	// find data type(s) from the data
 	fields, rawRows, err := findDataTypes(rows, rowLimit, types)
 	if err != nil {
 		return nil, err
+	}
+
+	// Capture what the driver returned before the discovered converters touch it, matching the
+	// non-dynamic path. This path scans every row up front, so the rows are recorded here in one go
+	// rather than as they are scanned. Without this the dynamic framer would be a silent hole in the
+	// capture for the plugins that use it.
+	if resultCapture != nil {
+		resultCapture.SetColumns(columnNamesFromTypes(types))
+		for _, row := range rawRows {
+			captureScannedRow(resultCapture, row)
+		}
 	}
 
 	// if a converter is defined by column name, override data type that was found

--- a/data/sqlutil/dynamic_frame_test.go
+++ b/data/sqlutil/dynamic_frame_test.go
@@ -30,7 +30,7 @@ func TestDynamicFrame(t *testing.T) {
 	}
 
 	_, converters = removeDynamicConverter(converters)
-	frame, err := frameDynamic(rows, 100, types, converters)
+	frame, err := frameDynamic(rows, 100, types, converters, nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, frame)
 
@@ -85,7 +85,7 @@ func TestDynamicFrameShouldNotPanic(t *testing.T) {
 	}
 
 	_, converters = removeDynamicConverter(converters)
-	frame, err := frameDynamic(rows, 100, types, converters)
+	frame, err := frameDynamic(rows, 100, types, converters, nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, frame)
 

--- a/data/sqlutil/querycapture.go
+++ b/data/sqlutil/querycapture.go
@@ -1,0 +1,96 @@
+package sqlutil
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/querycapture"
+)
+
+// captureScannedRow renders one just-scanned row for a querycapture.ResultCapture.
+//
+// It is called with the scan buffer, i.e. the values as the driver produced them and
+// before any Converter has run. That ordering is the point: a converter is supplied by
+// the plugin, so a capture taken after conversion could not tell a datasource that
+// returned the wrong rows from a converter that mangled the right ones -- which is the
+// question the capture exists to answer.
+func captureScannedRow(c *querycapture.ResultCapture, scanned []interface{}) {
+	cells := make([]*string, len(scanned))
+	for i, v := range scanned {
+		cells[i] = renderCell(v)
+	}
+	c.AddRow(cells)
+}
+
+// columnNamesFromTypes returns the column names of a result set described by its
+// column types, for the scanning paths that hold types rather than names.
+func columnNamesFromTypes(types []*sql.ColumnType) []string {
+	names := make([]string, len(types))
+	for i, t := range types {
+		names[i] = t.Name()
+	}
+	return names
+}
+
+// renderCell renders a scanned value as the text a capture carries, or nil for NULL.
+//
+// Scan buffers hold pointers (rows.Scan writes through them) and driver types vary
+// wildly -- sql.NullString, custom decimal types, []byte for strings -- so the value is
+// unwrapped in the order that preserves meaning: dereference the scan pointer, ask a
+// driver.Valuer what it holds (this is what distinguishes a NULL sql.NullString from an
+// empty one), then render.
+func renderCell(v interface{}) *string {
+	if v == nil {
+		return nil
+	}
+
+	// Unwrap scan pointers, including the *interface{} the dynamic framer scans into.
+	for {
+		rv := reflect.ValueOf(v)
+		if rv.Kind() != reflect.Pointer {
+			break
+		}
+		if rv.IsNil() {
+			return nil
+		}
+		v = rv.Elem().Interface()
+		if v == nil {
+			return nil
+		}
+	}
+
+	// sql.NullString and friends implement driver.Valuer: a NULL is a nil value, which
+	// must render as NULL rather than as the zero value it wraps.
+	if valuer, ok := v.(driver.Valuer); ok {
+		got, err := valuer.Value()
+		if err != nil {
+			// A Valuer that fails says nothing useful about the row; record the failure
+			// in place of the cell rather than dropping the row or failing the query.
+			return strPtr(fmt.Sprintf("<value error: %v>", err))
+		}
+		if got == nil {
+			return nil
+		}
+		v = got
+	}
+
+	switch t := v.(type) {
+	case string:
+		return strPtr(t)
+	case []byte:
+		// Drivers return text columns as bytes; rendering them as text is what makes the
+		// capture comparable against the returned frames.
+		return strPtr(string(t))
+	case time.Time:
+		// A fixed, sortable rendering, so a timestamp in the capture can be matched
+		// against the same timestamp in the returned frames without reformatting.
+		return strPtr(t.UTC().Format(time.RFC3339Nano))
+	default:
+		return strPtr(fmt.Sprintf("%v", v))
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/data/sqlutil/querycapture_test.go
+++ b/data/sqlutil/querycapture_test.go
@@ -1,0 +1,144 @@
+package sqlutil_test
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/querycapture"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+)
+
+func cells(t *testing.T, row []*string) []string {
+	t.Helper()
+	out := make([]string, len(row))
+	for i, c := range row {
+		if c == nil {
+			out[i] = "<NULL>"
+			continue
+		}
+		out[i] = *c
+	}
+	return out
+}
+
+func captureCtx(t *testing.T) (context.Context, *querycapture.ResultCapture) {
+	t.Helper()
+	capture := querycapture.NewResultCapture()
+	return querycapture.WithResultCapture(context.Background(), capture), capture
+}
+
+func TestFrameFromRowsWithContext_capturesReturnedRows(t *testing.T) {
+	rows := makeSingleResultSet( //nolint:rowserrcheck
+		[]string{"host", "value"},
+		[]interface{}{"host-a", int64(1)},
+		[]interface{}{"host-b", int64(2)},
+	)
+
+	ctx, capture := captureCtx(t)
+	frame, err := sqlutil.FrameFromRowsWithContext(ctx, rows, -1, 0)
+	require.NoError(t, err)
+	require.NotNil(t, frame)
+
+	got := capture.Result()
+	assert.Equal(t, []string{"host", "value"}, got.Columns)
+	assert.False(t, got.Truncated)
+	assert.Equal(t, 2, got.TotalRows)
+	require.Len(t, got.Rows, 2)
+	assert.Equal(t, []string{"host-a", "1"}, cells(t, got.Rows[0]))
+	assert.Equal(t, []string{"host-b", "2"}, cells(t, got.Rows[1]))
+}
+
+func TestFrameFromRowsWithContext_capturesBeforeConverters(t *testing.T) {
+	// The whole point of capturing at the scan is that converters are supplied by the plugin: a capture
+	// taken after conversion could not tell a database that returned the wrong value from a converter
+	// that mangled the right one. This converter rewrites every value, so the capture must disagree with
+	// the frame.
+	rows := makeSingleResultSet([]string{"host"}, []interface{}{"host-b"}) //nolint:rowserrcheck
+	mangling := sqlutil.Converter{
+		Name:             "mangle",
+		InputScanType:    reflect.TypeOf(""),
+		InputTypeMatcher: func(string) bool { return true },
+		FrameConverter: sqlutil.FrameConverter{
+			FieldType: data.FieldTypeString,
+			ConverterFunc: func(interface{}) (interface{}, error) {
+				return "host-a", nil
+			},
+		},
+	}
+
+	ctx, capture := captureCtx(t)
+	frame, err := sqlutil.FrameFromRowsWithContext(ctx, rows, -1, 0, mangling)
+	require.NoError(t, err)
+
+	value, ok := frame.Fields[0].ConcreteAt(0)
+	require.True(t, ok)
+	assert.Equal(t, "host-a", value, "the converter rewrote the value, standing in for a plugin-side bug")
+
+	captured := capture.Result().Rows
+	require.Len(t, captured, 1)
+	assert.Equal(t, []string{"host-b"}, cells(t, captured[0]),
+		"the capture must hold what the database sent, which is what localizes the bug to the plugin")
+}
+
+func TestFrameFromRowsWithContext_nullIsDistinctFromEmpty(t *testing.T) {
+	// "" and NULL are different answers to a wrong-data question, so they must not render alike.
+	rows := makeSingleResultSet( //nolint:rowserrcheck
+		[]string{"host"},
+		[]interface{}{nil},
+		[]interface{}{""},
+	)
+
+	ctx, capture := captureCtx(t)
+	_, err := sqlutil.FrameFromRowsWithContext(ctx, rows, -1, 0)
+	require.NoError(t, err)
+
+	captured := capture.Result().Rows
+	require.Len(t, captured, 2)
+	assert.Nil(t, captured[0][0], "a NULL is captured as null")
+	require.NotNil(t, captured[1][0])
+	assert.Equal(t, "", *captured[1][0], "an empty string is captured as an empty string")
+}
+
+func TestFrameFromRowsWithContext_noCaptureOnContextIsUnchanged(t *testing.T) {
+	// Capture is off by default and must not alter the frame in any way.
+	row := func() []interface{} { return []interface{}{"host-a", int64(1)} }
+	plainRows := makeSingleResultSet([]string{"host", "value"}, row()) //nolint:rowserrcheck
+	plain, err := sqlutil.FrameFromRows(plainRows, -1)
+	require.NoError(t, err)
+
+	ctxRows := makeSingleResultSet([]string{"host", "value"}, row()) //nolint:rowserrcheck
+	viaCtx, err := sqlutil.FrameFromRowsWithContext(context.Background(), ctxRows, -1, 0)
+	require.NoError(t, err)
+
+	assert.Equal(t, plain.Fields[0].Len(), viaCtx.Fields[0].Len())
+	assert.Equal(t, plain.Fields[1].At(0), viaCtx.Fields[1].At(0))
+}
+
+func TestFrameFromRowsWithContext_boundedByMaxResultBytes(t *testing.T) {
+	// A pathological result must not be able to grow the capture without limit, and the capture must
+	// say so rather than presenting a prefix as the whole result.
+	wide := strings.Repeat("x", 1<<20) // 1 MiB per row
+	rowsData := make([][]interface{}, 0, 16)
+	for i := 0; i < 16; i++ {
+		rowsData = append(rowsData, []interface{}{wide})
+	}
+	rows := makeSingleResultSet([]string{"blob"}, rowsData...) //nolint:rowserrcheck
+
+	ctx, capture := captureCtx(t)
+	frame, err := sqlutil.FrameFromRowsWithContext(ctx, rows, -1, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 16, frame.Fields[0].Len(),
+		"every row still reaches the frame; capture never drops data from the query")
+
+	got := capture.Result()
+	assert.True(t, got.Truncated)
+	assert.Equal(t, 16, got.TotalRows, "the total counts what the database returned, not what was kept")
+	assert.Less(t, len(got.Rows), 16)
+	assert.LessOrEqual(t, len(got.Rows)*(1<<20), querycapture.MaxResultBytes)
+}

--- a/data/sqlutil/querycapture_test.go
+++ b/data/sqlutil/querycapture_test.go
@@ -123,22 +123,17 @@ func TestFrameFromRowsWithContext_noCaptureOnContextIsUnchanged(t *testing.T) {
 func TestFrameFromRowsWithContext_boundedByMaxResultBytes(t *testing.T) {
 	// A pathological result must not be able to grow the capture without limit, and the capture must
 	// say so rather than presenting a prefix as the whole result.
-	wide := strings.Repeat("x", 1<<20) // 1 MiB per row
-	rowsData := make([][]interface{}, 0, 16)
-	for i := 0; i < 16; i++ {
-		rowsData = append(rowsData, []interface{}{wide})
-	}
-	rows := makeSingleResultSet([]string{"blob"}, rowsData...) //nolint:rowserrcheck
+	huge := strings.Repeat("x", querycapture.MaxResultBytes)
+	rows := makeSingleResultSet([]string{"blob"}, []interface{}{"host-a"}, []interface{}{huge}) //nolint:rowserrcheck
 
 	ctx, capture := captureCtx(t)
 	frame, err := sqlutil.FrameFromRowsWithContext(ctx, rows, -1, 0)
 	require.NoError(t, err)
-	assert.Equal(t, 16, frame.Fields[0].Len(),
+	assert.Equal(t, 2, frame.Fields[0].Len(),
 		"every row still reaches the frame; capture never drops data from the query")
 
 	got := capture.Result()
 	assert.True(t, got.Truncated)
-	assert.Equal(t, 16, got.TotalRows, "the total counts what the database returned, not what was kept")
-	assert.Less(t, len(got.Rows), 16)
-	assert.LessOrEqual(t, len(got.Rows)*(1<<20), querycapture.MaxResultBytes)
+	assert.Equal(t, 2, got.TotalRows, "the total counts what the database returned, not what was kept")
+	assert.Empty(t, got.Rows, "a partial result is not evidence of the whole result")
 }

--- a/data/sqlutil/sql.go
+++ b/data/sqlutil/sql.go
@@ -1,11 +1,13 @@
 package sqlutil
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"math"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/querycapture"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
@@ -22,7 +24,7 @@ import (
 // The converter defines what type to use for scanning, what type to place in the data frame, and a function for converting from one to the other.
 // If you find yourself here after upgrading, you can continue to your StringConverters here by using the `ToConverters` function.
 func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*data.Frame, error) {
-	return frameFromRows(rows, rowLimit, 0, converters...)
+	return frameFromRows(context.Background(), rows, rowLimit, 0, converters...)
 }
 
 // FrameFromRowsWithCapacity is like FrameFromRows but reserves capacity for the
@@ -30,10 +32,21 @@ func FrameFromRows(rows *sql.Rows, rowLimit int64, converters ...Converter) (*da
 // large result sets. Pass the row count returned by the database (or an upper
 // bound). A capacity of 0 behaves identically to FrameFromRows.
 func FrameFromRowsWithCapacity(rows *sql.Rows, rowLimit int64, capacity int, converters ...Converter) (*data.Frame, error) {
-	return frameFromRows(rows, rowLimit, capacity, converters...)
+	return frameFromRows(context.Background(), rows, rowLimit, capacity, converters...)
 }
 
-func frameFromRows(rows *sql.Rows, rowLimit int64, capacity int, converters ...Converter) (*data.Frame, error) {
+// FrameFromRowsWithContext is FrameFromRowsWithCapacity plus diagnostics: when ctx carries a
+// querycapture.ResultCapture, every row is also recorded there as the driver returned it, before any
+// Converter runs. That is what lets a diagnostics bundle for a SQL datasource say what the datasource
+// sent, not only what the plugin made of it. With no capture on ctx it is identical to
+// FrameFromRowsWithCapacity, down to not touching the scan path.
+//
+// Pass a capacity of 0 for FrameFromRows behaviour.
+func FrameFromRowsWithContext(ctx context.Context, rows *sql.Rows, rowLimit int64, capacity int, converters ...Converter) (*data.Frame, error) {
+	return frameFromRows(ctx, rows, rowLimit, capacity, converters...)
+}
+
+func frameFromRows(ctx context.Context, rows *sql.Rows, rowLimit int64, capacity int, converters ...Converter) (*data.Frame, error) {
 	types, err := rows.ColumnTypes()
 	if err != nil {
 		return nil, err
@@ -44,16 +57,21 @@ func frameFromRows(rows *sql.Rows, rowLimit int64, capacity int, converters ...C
 		rowLimit = math.MaxInt64
 	}
 
+	resultCapture, capturing := querycapture.ResultCaptureFromContext(ctx)
+
 	// If there is a dynamic converter, we need to use the dynamic framer
 	// and remove the dynamic converter from the list of converters ( it is not valid, just a flag )
 	if isDynamic, converters := removeDynamicConverter(converters); isDynamic {
 		rows := Rows{itr: rows}
-		return frameDynamic(rows, rowLimit, types, converters)
+		return frameDynamic(rows, rowLimit, types, converters, resultCapture)
 	}
 
 	names, err := rows.Columns()
 	if err != nil {
 		return nil, err
+	}
+	if capturing {
+		resultCapture.SetColumns(names)
 	}
 
 	scanRow, err := MakeScanRow(types, names, converters...)
@@ -86,6 +104,12 @@ outer:
 		for rows.Next() {
 			if err := rows.Scan(scannable...); err != nil {
 				return nil, err
+			}
+
+			// Capture before conversion, and before appendConvertedRow can fail: a row the
+			// converters choke on is exactly the row a wrong-data investigation wants to see.
+			if capturing {
+				captureScannedRow(resultCapture, scannable)
 			}
 
 			if err := appendConvertedRow(frame, scannable, converted, scanRow.Converters); err != nil {


### PR DESCRIPTION
# backend: capture the rows a SQL datasource returned

## Where this fits

Second of the three-PR stack from #1617 ("the seam, and the HAR mapping for statement, bind
arguments, counts, timings, errors").

## What this does

This captures the rows themselves, bounded by `MaxResultBytes` (1 GiB). Past that cap the rows are
dropped entirely rather than kept as a prefix — `rowsTruncated` + `totalRows` say how much there was, but
not a partial version of it, since a partial result set answers "did the database or the plugin get this
wrong" no better than none at all.

This is deliberately a simple guardrail, not an engineered budget: `sqlutil.FrameFromRows`'s `rowLimit`
caps row *count*, not bytes, and is caller-supplied (commonly unbounded), so without this cap a single
pathological result would have nothing bounding it in the SDK at all. One obviously-large-enough number
beats a precisely-tuned smaller one with its own edge cases, given the feature is experimental, off by
default, and admin/on-prem-only. `MaxStatementBytes`/`MaxArgsBytes` (statement text / bind arguments) are
untouched — different kind of input, not the wrong-data evidence this change is about.

## Redaction

This widens what a bundle can hold from SQL text + bind arguments to full result data. Same
class of evidence as the HTTP response bodies already captured, but it's customer data by
default now.

## Compatibility

No change in behavior for a plugin without a capture point. Capture stays off unless
`X-Grafana-HAR-Capture` asked for it.
