### PR TITLE
backend/harcapture: drop the SDK's own HTTP capture-size caps

### DIFF
--- a/backend/harcapture/bodyrestore_test.go
+++ b/backend/harcapture/bodyrestore_test.go
@@ -147,18 +147,20 @@ func TestBuildSDKHAREntry_transportError(t *testing.T) {
 	}
 }
 
-// TestReadAndRestoreBody_capsCaptureButDeliversFullBody asserts a body larger than the per-body cap
-// is only partially buffered for capture, yet the original consumer still receives every byte.
-func TestReadAndRestoreBody_capsCaptureButDeliversFullBody(t *testing.T) {
-	full := bytes.Repeat([]byte("x"), maxCapturedBodyBytes+4096)
+// TestReadAndRestoreBody_deliversFullBody asserts the whole body is both captured and delivered to
+// the original consumer, unmodified. Size limiting is an independent, upstream concern (e.g.
+// httpclient.ResponseLimitMiddleware) -- see package doc -- not something readAndRestoreBody does
+// itself.
+func TestReadAndRestoreBody_deliversFullBody(t *testing.T) {
+	full := bytes.Repeat([]byte("x"), 1<<20)
 
 	captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(full)))
 
-	if !truncated {
-		t.Fatal("a body larger than the cap must be reported as truncated")
+	if truncated {
+		t.Fatal("a body that read to completion must not be reported as truncated")
 	}
-	if len(captured) != maxCapturedBodyBytes {
-		t.Errorf("captured %d bytes, want the cap %d (capture must not buffer the whole body)", len(captured), maxCapturedBodyBytes)
+	if len(captured) != len(full) {
+		t.Errorf("captured %d bytes, want the full %d", len(captured), len(full))
 	}
 
 	got, err := io.ReadAll(restored)
@@ -170,99 +172,5 @@ func TestReadAndRestoreBody_capsCaptureButDeliversFullBody(t *testing.T) {
 	}
 	if err := restored.Close(); err != nil {
 		t.Errorf("Close: %v", err)
-	}
-}
-
-// TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize asserts an over-cap response reports bodySize
-// -1 (HAR "unavailable") since the true length isn't known, while content still holds the prefix.
-func TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize(t *testing.T) {
-	full := bytes.Repeat([]byte("y"), maxCapturedBodyBytes+4096)
-	req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp := &http.Response{Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(full))}
-
-	entry := buildSDKHAREntry(req, nil, false, resp, nil, time.Now(), time.Millisecond)
-
-	if entry.Response.BodySize != -1 {
-		t.Errorf("truncated body bodySize = %d, want -1 (unknown)", entry.Response.BodySize)
-	}
-	if entry.Response.Content.Size != int64(maxCapturedBodyBytes) {
-		t.Errorf("content size = %d, want the captured prefix length %d", entry.Response.Content.Size, maxCapturedBodyBytes)
-	}
-}
-
-// TestSDKHARCaptureBuffer_totalSizeCap asserts that once the cumulative retained body budget is
-// exhausted, later entries keep their metadata/sizes but drop the body text.
-func TestSDKHARCaptureBuffer_totalSizeCap(t *testing.T) {
-	buf := NewBuffer()
-	big := strings.Repeat("a", maxCapturedBodyBytes) // one per-body-capped chunk each
-
-	// Enough entries to blow past the total budget.
-	for i := 0; i < (maxCapturedTotalBytes/maxCapturedBodyBytes)+2; i++ {
-		req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp := &http.Response{Header: http.Header{}, Body: io.NopCloser(strings.NewReader(big))}
-		buf.AddEntry(req, nil, false, resp, nil, time.Now(), time.Millisecond)
-	}
-
-	var total int
-	var droppedText, keptTrueSize bool
-	for _, e := range buf.entries {
-		total += len(e.Response.Content.Text)
-		if e.Response.Content.Text == "" && e.Response.Content.Size == int64(len(big)) {
-			droppedText = true // metadata/size preserved, text dropped
-		}
-		if e.Response.Content.Size == int64(len(big)) {
-			keptTrueSize = true
-		}
-	}
-	if total > maxCapturedTotalBytes {
-		t.Errorf("retained body text %d exceeds the cap budget %d", total, maxCapturedTotalBytes)
-	}
-	if !droppedText {
-		t.Error("expected later entries to drop body text once over the total budget")
-	}
-	if !keptTrueSize {
-		t.Error("true body size must be preserved even when text is dropped")
-	}
-}
-
-// TestSDKHARCaptureBuffer_totalSizeCapIsTight asserts that the budget bounds the document rather than
-// merely triggering on it: the entry that would take the total past the cap is trimmed itself, instead
-// of being retained whole and only trimming its successors. It is filled unevenly on purpose, so that
-// an entry lands astride the cap -- the case a mixed query-and-HTTP capture reaches easily, since the
-// two producers contribute entries of very different sizes.
-func TestSDKHARCaptureBuffer_totalSizeCapIsTight(t *testing.T) {
-	buf := NewBuffer()
-	addEntry := func(body string) {
-		req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp := &http.Response{Header: http.Header{}, Body: io.NopCloser(strings.NewReader(body))}
-		buf.AddEntry(req, nil, false, resp, nil, time.Now(), time.Millisecond)
-	}
-
-	// Leave the budget with less room than one full chunk, so the next entry straddles the cap.
-	big := strings.Repeat("a", maxCapturedBodyBytes)
-	for i := 0; i < (maxCapturedTotalBytes/maxCapturedBodyBytes)-1; i++ {
-		addEntry(big)
-	}
-	addEntry(strings.Repeat("b", 1024))
-	addEntry(big)
-
-	var total int
-	for _, e := range buf.entries {
-		total += len(e.Response.Content.Text)
-	}
-	if total > maxCapturedTotalBytes {
-		t.Errorf("retained body text %d exceeds the cap budget %d", total, maxCapturedTotalBytes)
-	}
-	if last := buf.entries[len(buf.entries)-1]; last.Response.Content.Text != "" {
-		t.Error("the entry that crosses the budget must drop its body text, not be retained whole")
 	}
 }

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -13,18 +13,6 @@ import (
 )
 
 const (
-	// maxCapturedBodyBytes caps how much of any single request/response body is read into memory for
-	// capture; the untouched remainder is streamed on to the real consumer rather than buffered (see
-	// readAndRestoreBody). maxCapturedTotalBytes caps the total payload text retained across all entries
-	// in one request -- i.e. the size of the serialized __har__ frame -- keeping it well under the
-	// plugin<->core gRPC message size limit. Note this budget tracks retained HAR text only: while an
-	// over-cap body is still being streamed to the consumer, its capped head (up to
-	// maxCapturedBodyBytes) is also held transiently, so peak memory during capture can exceed the
-	// total budget by roughly that per concurrent over-cap response. Both are far below the
-	// unbounded full-body buffering capture would otherwise do.
-	maxCapturedBodyBytes  = 8 << 20  // 8 MiB
-	maxCapturedTotalBytes = 32 << 20 // 32 MiB
-
 	// redactedValue replaces the value of anything capture treats as sensitive (see
 	// isSensitiveHeaderName, isSensitiveQueryParamName, and sdkCookies), so the __har__ frame -- which
 	// is returned to whoever enabled capture -- never carries datasource credentials.
@@ -72,9 +60,8 @@ func isSensitiveQueryParamName(name string) bool {
 // Buffer collects HTTP request/response pairs in HAR 1.2 format in memory.
 // Used by the SDK HAR capture middleware to accumulate traffic from external plugin HTTP clients.
 type Buffer struct {
-	mu       sync.Mutex
-	entries  []sdkHAREntry
-	retained int64 // running total of retained payload bytes, for the total-size cap
+	mu      sync.Mutex
+	entries []sdkHAREntry
 }
 
 func NewBuffer() *Buffer {
@@ -85,51 +72,17 @@ func (b *Buffer) AddEntry(req *http.Request, reqBody []byte, reqTruncated bool, 
 	b.appendEntry(buildSDKHAREntry(req, reqBody, reqTruncated, resp, rtErr, started, elapsed))
 }
 
-// appendEntry adds an already-built entry under the buffer's cumulative retained-payload budget.
-// Every producer goes through here -- HTTP round trips and non-HTTP query interactions alike -- so
-// one budget bounds the whole document whatever mix of traffic a request produced.
+// appendEntry adds an already-built entry. Every producer goes through here -- HTTP round trips and
+// non-HTTP query interactions alike -- so both land in one document in the order they happened.
 func (b *Buffer) appendEntry(entry sdkHAREntry) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	// Enforce the cumulative retained-payload budget: an entry whose payload would take the request
-	// past maxCapturedTotalBytes keeps its metadata (headers, sizes, timings, error) but drops the
-	// payload itself, so the __har__ frame can't grow without bound. The check is on the sum rather
-	// than on what is already retained, so the entry that crosses the budget is trimmed too rather than
-	// kept whole.
-	payload := entry.payloadBytes()
-	if b.retained+payload > maxCapturedTotalBytes {
-		entry.dropPayload()
-	} else {
-		b.retained += payload
-	}
 	b.entries = append(b.entries, entry)
 }
 
-// payloadBytes is what an entry contributes to the buffer's retained-payload budget: everything that
-// carries data rather than describing it, whichever producer built the entry.
-func (e *sdkHAREntry) payloadBytes() int64 {
-	n := int64(len(e.Response.Content.Text))
-	if e.Request.PostData != nil {
-		n += int64(len(e.Request.PostData.Text))
-	}
-	return n + e.Query.payloadBytes()
-}
-
-// dropPayload clears an entry's payload, keeping what tells a reader the exchange happened and how it
-// went: headers, the true sizes, timings and any error.
-func (e *sdkHAREntry) dropPayload() {
-	e.Response.Content.Text = ""
-	e.Response.Content.Encoding = ""
-	if e.Request.PostData != nil {
-		e.Request.PostData.Text = ""
-		e.Request.PostData.Encoding = ""
-	}
-	e.Query.dropPayload()
-}
-
-// DrainRequestBody reads and returns the request body (up to the capture cap) and whether it was
-// larger than the cap (truncated), restoring it so the request can still be sent. It must be called
-// before the request is sent: a real http.Transport consumes (and closes) req.Body while sending, so
+// DrainRequestBody reads and returns the request body and whether the read failed partway through
+// (truncated), restoring it so the request can still be sent. It must be called before the request is
+// sent: a real http.Transport consumes (and closes) req.Body while sending, so
 // reading it afterwards yields nothing. Returns nil when there is no body.
 func DrainRequestBody(req *http.Request) ([]byte, bool) {
 	if req == nil || req.Body == nil || req.Body == http.NoBody {
@@ -140,34 +93,20 @@ func DrainRequestBody(req *http.Request) ([]byte, bool) {
 	return body, truncated
 }
 
-// readAndRestoreBody reads up to maxCapturedBodyBytes of rc for capture and returns those bytes,
-// whether the captured bytes are NOT the complete body (sizeUnknown -- the body exceeded the cap, or
-// the read failed part-way, so its true size is unavailable), and a ReadCloser that hands the
-// original consumer the full body -- the captured prefix followed by the untouched, lazily-streamed
-// remainder -- so capture never buffers more than the cap regardless of how large the body is. When
-// the read fails partway (e.g. this SDK's ResponseLimitMiddleware deliberately errors past a size
-// cap, or a transient network error), the captured bytes are what was read so far and the replay
-// reader re-surfaces the same error after them, exactly what downstream would have observed. rc is
-// closed once the returned ReadCloser is closed (or immediately when there is no remainder to stream).
+// readAndRestoreBody reads all of rc for capture and returns those bytes, whether the read failed
+// partway through (in which case the true size is unavailable), and a ReadCloser that hands the
+// original consumer the same bytes. Capture relies on an independent limit upstream (e.g.
+// httpclient.ResponseLimitMiddleware) to keep a response body from growing without bound -- see
+// package doc -- so a read failing partway here is that limit (or a transient network error), and the
+// captured bytes are what was read so far; the replay reader re-surfaces the same error after them,
+// exactly what downstream would have observed. rc is closed once read.
 func readAndRestoreBody(rc io.ReadCloser) ([]byte, bool, io.ReadCloser) {
-	// Read one byte past the cap so a full body (<= cap) can be told from a truncated one (> cap)
-	// without buffering the whole thing.
-	buf, err := io.ReadAll(io.LimitReader(rc, maxCapturedBodyBytes+1))
+	buf, err := io.ReadAll(rc)
+	_ = rc.Close()
 	if err != nil {
-		// Read failed part-way: we hold a partial prefix and the true size is unavailable.
-		_ = rc.Close()
 		return buf, true, &errorReader{r: bytes.NewReader(buf), err: err}
 	}
-	if int64(len(buf)) <= maxCapturedBodyBytes {
-		// Whole body fit within the cap; nothing left in rc.
-		_ = rc.Close()
-		return buf, false, io.NopCloser(bytes.NewReader(buf))
-	}
-	// Body is larger than the cap: retain only the capped prefix for the HAR, but let the consumer
-	// read the full buffered head (buf, which is cap+1 bytes) followed by the untouched remainder
-	// streamed lazily from rc, so we never buffer the whole body.
-	captured := buf[:maxCapturedBodyBytes]
-	return captured, true, &bodyRemainder{r: io.MultiReader(bytes.NewReader(buf), rc), c: rc}
+	return buf, false, io.NopCloser(bytes.NewReader(buf))
 }
 
 // errorReader replays buffered bytes and then returns err in place of io.EOF, reproducing a body
@@ -186,16 +125,6 @@ func (e *errorReader) Read(p []byte) (int, error) {
 }
 
 func (e *errorReader) Close() error { return nil }
-
-// bodyRemainder is a ReadCloser over a size-capped body: it replays the buffered prefix and streams
-// the untouched remainder, closing the underlying body on Close so the connection is released.
-type bodyRemainder struct {
-	r io.Reader
-	c io.Closer
-}
-
-func (b *bodyRemainder) Read(p []byte) (int, error) { return b.r.Read(p) }
-func (b *bodyRemainder) Close() error               { return b.c.Close() }
 
 func (b *Buffer) Len() int {
 	b.mu.Lock()
@@ -310,17 +239,12 @@ type sdkHARContent struct {
 
 // encodeBody renders a body for a HAR text field. It base64-encodes when the bytes are not valid
 // UTF-8, so binary payloads (protobuf, images, ...) survive json.Marshal instead of being silently
-// corrupted to U+FFFD, and caps the retained bytes at maxCapturedBodyBytes. The caller records the
-// true, uncapped size separately (bodySize/content.size).
+// corrupted to U+FFFD.
 func encodeBody(body []byte) (text, encoding string) {
-	keep := body
-	if len(keep) > maxCapturedBodyBytes {
-		keep = keep[:maxCapturedBodyBytes]
+	if utf8.Valid(body) {
+		return string(body), ""
 	}
-	if utf8.Valid(keep) {
-		return string(keep), ""
-	}
-	return base64.StdEncoding.EncodeToString(keep), "base64"
+	return base64.StdEncoding.EncodeToString(body), "base64"
 }
 
 type sdkHARTimings struct {

--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -58,9 +58,9 @@ type sdkHARQueryInfo struct {
 	// rather than in the entry's postData because HAR defines postData.params for a URL-encoded body and
 	// states that params and text are mutually exclusive.
 	Args []string `json:"args,omitempty"`
-	// StatementTruncated and ArgsTruncated report that the statement or the arguments were cut to fit a
-	// size bound -- the capture point's own, or the buffer's cumulative budget -- so a reader can tell a
-	// long statement from a clipped one.
+	// StatementTruncated and ArgsTruncated report that the statement or the arguments were cut to fit
+	// the capture point's own size bound (querycapture.MaxStatementBytes / MaxArgsBytes), so a reader
+	// can tell a long statement from a clipped one.
 	StatementTruncated bool `json:"statementTruncated,omitempty"`
 	ArgsTruncated      bool `json:"argsTruncated,omitempty"`
 	// FrameCount and RowCount summarise what the plugin returned; RowCount is -1 when the capture
@@ -70,31 +70,6 @@ type sdkHARQueryInfo struct {
 	// Error is the error the query returned, or empty on success. It repeats the entry comment in a
 	// field an analyzer can read without string matching.
 	Error string `json:"error,omitempty"`
-}
-
-// payloadBytes is the "_query" object's share of the buffer's retained-payload budget (see
-// Buffer.appendEntry): the bind arguments, which a bulk statement can make as large as the statement
-// itself, and the error. A nil receiver is an HTTP entry, which has no "_query".
-func (q *sdkHARQueryInfo) payloadBytes() int64 {
-	if q == nil {
-		return 0
-	}
-	n := int64(len(q.Error))
-	for _, a := range q.Args {
-		n += int64(len(a))
-	}
-	return n
-}
-
-// dropPayload drops the bind arguments, flagging them truncated so their absence does not read as a
-// statement that had none. The error stays: it is what makes an over-budget entry worth keeping at
-// all, and it is small next to the arguments it accompanies.
-func (q *sdkHARQueryInfo) dropPayload() {
-	if q == nil || len(q.Args) == 0 {
-		return
-	}
-	q.Args = nil
-	q.ArgsTruncated = true
 }
 
 // querySummary is the response content of a query entry: what came back, counted rather than copied.

--- a/backend/harcapture/querycapture_test.go
+++ b/backend/harcapture/querycapture_test.go
@@ -238,54 +238,6 @@ func TestAddQueryInteraction_truncationIsReported(t *testing.T) {
 	assert.True(t, e.Query.ArgsTruncated)
 }
 
-func TestAddQueryInteraction_argsAndErrorCountTowardTheTotalBudget(t *testing.T) {
-	// Bind arguments and the error are retained text just as a body is, so the budget that bounds the
-	// __har__ frame has to see them: uncounted, a request's arguments grow the frame past the cap.
-	b := NewBuffer()
-	b.AddQueryInteraction(querycapture.Interaction{
-		Kind:      querycapture.KindSQLQuery,
-		Statement: "SELECT * FROM t WHERE id IN (?, ?)",
-		Args:      []string{"host-a", "host-b"},
-		Err:       "code: 60, message: Unknown table expression identifier 't'",
-	})
-
-	// A failed query has no response content, so the retained total is exactly the statement, the
-	// arguments and the error.
-	want := len("SELECT * FROM t WHERE id IN (?, ?)") + len("host-a") + len("host-b") +
-		len("code: 60, message: Unknown table expression identifier 't'")
-	assert.Equal(t, int64(want), b.retained)
-}
-
-func TestAddQueryInteraction_argsAreDroppedOverTheTotalBudget(t *testing.T) {
-	// Being counted is not enough: an over-budget entry has to shed its arguments too, or the frame
-	// grows by them anyway. Inspect the entries directly rather than the marshalled document, so the
-	// test doesn't serialize the whole budget.
-	b := NewBuffer()
-	statement := strings.Repeat("x", maxCapturedBodyBytes)
-	for i := 0; i < maxCapturedTotalBytes/maxCapturedBodyBytes; i++ {
-		b.AddQueryInteraction(querycapture.Interaction{
-			Kind: querycapture.KindSQLQuery, Statement: statement, Err: "boom",
-		})
-	}
-
-	b.AddQueryInteraction(querycapture.Interaction{
-		Kind:      querycapture.KindSQLQuery,
-		Statement: statement,
-		Args:      []string{"host-a", "host-b"},
-		Err:       "code: 60, message: Unknown table expression identifier 't'",
-	})
-
-	last := b.entries[len(b.entries)-1]
-	require.NotNil(t, last.Request.PostData)
-	assert.Empty(t, last.Request.PostData.Text, "the statement is dropped over budget, as an HTTP body is")
-	require.NotNil(t, last.Query)
-	assert.Empty(t, last.Query.Args)
-	assert.True(t, last.Query.ArgsTruncated, "dropped arguments must not read as a statement that had none")
-	assert.Contains(t, last.Query.Error, "Unknown table expression",
-		"the error is kept: it is what makes an over-budget entry worth reading at all")
-	assert.LessOrEqual(t, b.retained, int64(maxCapturedTotalBytes))
-}
-
 func TestAddQueryInteraction_kindDrivesURLScheme(t *testing.T) {
 	// The scheme comes from the capture kind so a future non-SQL capture point reads correctly without
 	// this package knowing about it.


### PR DESCRIPTION
# backend/harcapture: drop the SDK's own HTTP capture-size caps

## What this does

Removes `maxCapturedBodyBytes` (8 MiB, per body) and `maxCapturedTotalBytes` (32 MiB, per
document) — the caps HAR capture applied on top of an already-independent backstop.

## Why this is safe

HAR capture is installed via `httpclient.WithContextualMiddleware`, and `ContextualMiddleware()` sits
*before* `ErrorSourceMiddleware`/`ResponseLimitMiddleware` in `httpclient.DefaultMiddlewares()`.
So the `resp.Body` capture reads via `readAndRestoreBody` is already the `MaxBytesReader`-wrapped body `ResponseLimitMiddleware` installed,
bounded by `GrafanaCfg.ResponseLimit()`.

Given that, the SDK's own caps were a second, redundant budget on a different axis — bounding what's
*retained for the `__har__` document*, not what the plugin is allowed to receive — for real complexity:
a streaming-prefix read, a size-capped remainder reader, a cumulative per-request budget with its own
drop-payload path, all with test coverage of their own.
