### PR TITLE
backend: raise HAR and SQL capture size limits

### DIFF
--- a/backend/har_capture_middleware.go
+++ b/backend/har_capture_middleware.go
@@ -75,7 +75,7 @@ func (h *harCaptureHandler) QueryData(ctx context.Context, req *QueryDataRequest
 		return httpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			// Capture the request body before RoundTrip: the transport drains r.Body while
 			// sending, so reading it afterwards would yield nothing for POST/PUT/PATCH calls.
-			reqBody, reqTruncated := harcapture.DrainRequestBody(r)
+			reqBody, reqTruncated := buf.DrainRequestBody(r)
 			started := time.Now()
 			resp, err := next.RoundTrip(r)
 			elapsed := time.Since(started)

--- a/backend/harcapture/bodyrestore_test.go
+++ b/backend/harcapture/bodyrestore_test.go
@@ -30,6 +30,18 @@ func (f *flakyBody) Read(p []byte) (int, error) {
 
 func (f *flakyBody) Close() error { return nil }
 
+// withCaptureLimits overrides the package's body/total capture caps for the duration of the test, so
+// cap-boundary tests exercise the capping algorithm against small fixtures rather than allocating and
+// copying data sized to the real multi-GiB production caps.
+func withCaptureLimits(t *testing.T, body, total int64) {
+	t.Helper()
+	origBody, origTotal := maxCapturedBodyBytes, maxCapturedTotalBytes
+	maxCapturedBodyBytes, maxCapturedTotalBytes = body, total
+	t.Cleanup(func() {
+		maxCapturedBodyBytes, maxCapturedTotalBytes = origBody, origTotal
+	})
+}
+
 // TestBuildSDKHAREntry_restoresBodyOnReadError asserts that capturing a response whose body read
 // fails still restores resp.Body, so the plugin's downstream consumer sees the same bytes and the
 // same error it would have without capture (capture must never truncate the real response).
@@ -150,14 +162,15 @@ func TestBuildSDKHAREntry_transportError(t *testing.T) {
 // TestReadAndRestoreBody_capsCaptureButDeliversFullBody asserts a body larger than the per-body cap
 // is only partially buffered for capture, yet the original consumer still receives every byte.
 func TestReadAndRestoreBody_capsCaptureButDeliversFullBody(t *testing.T) {
-	full := bytes.Repeat([]byte("x"), maxCapturedBodyBytes+4096)
+	withCaptureLimits(t, 4096, 16384)
+	full := bytes.Repeat([]byte("x"), int(maxCapturedBodyBytes)+4096)
 
 	captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(full)))
 
 	if !truncated {
 		t.Fatal("a body larger than the cap must be reported as truncated")
 	}
-	if len(captured) != maxCapturedBodyBytes {
+	if int64(len(captured)) != maxCapturedBodyBytes {
 		t.Errorf("captured %d bytes, want the cap %d (capture must not buffer the whole body)", len(captured), maxCapturedBodyBytes)
 	}
 
@@ -176,7 +189,8 @@ func TestReadAndRestoreBody_capsCaptureButDeliversFullBody(t *testing.T) {
 // TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize asserts an over-cap response reports bodySize
 // -1 (HAR "unavailable") since the true length isn't known, while content still holds the prefix.
 func TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize(t *testing.T) {
-	full := bytes.Repeat([]byte("y"), maxCapturedBodyBytes+4096)
+	withCaptureLimits(t, 4096, 16384)
+	full := bytes.Repeat([]byte("y"), int(maxCapturedBodyBytes)+4096)
 	req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -196,11 +210,12 @@ func TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize(t *testing.T) {
 // TestSDKHARCaptureBuffer_totalSizeCap asserts that once the cumulative retained body budget is
 // exhausted, later entries keep their metadata/sizes but drop the body text.
 func TestSDKHARCaptureBuffer_totalSizeCap(t *testing.T) {
+	withCaptureLimits(t, 4096, 16384)
 	buf := NewBuffer()
-	big := strings.Repeat("a", maxCapturedBodyBytes) // one per-body-capped chunk each
+	big := strings.Repeat("a", int(maxCapturedBodyBytes)) // one per-body-capped chunk each
 
 	// Enough entries to blow past the total budget.
-	for i := 0; i < (maxCapturedTotalBytes/maxCapturedBodyBytes)+2; i++ {
+	for i := int64(0); i < (maxCapturedTotalBytes/maxCapturedBodyBytes)+2; i++ {
 		req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)
 		if err != nil {
 			t.Fatal(err)
@@ -220,7 +235,7 @@ func TestSDKHARCaptureBuffer_totalSizeCap(t *testing.T) {
 			keptTrueSize = true
 		}
 	}
-	if total > maxCapturedTotalBytes {
+	if int64(total) > maxCapturedTotalBytes {
 		t.Errorf("retained body text %d exceeds the cap budget %d", total, maxCapturedTotalBytes)
 	}
 	if !droppedText {
@@ -237,6 +252,7 @@ func TestSDKHARCaptureBuffer_totalSizeCap(t *testing.T) {
 // an entry lands astride the cap -- the case a mixed query-and-HTTP capture reaches easily, since the
 // two producers contribute entries of very different sizes.
 func TestSDKHARCaptureBuffer_totalSizeCapIsTight(t *testing.T) {
+	withCaptureLimits(t, 4096, 16384)
 	buf := NewBuffer()
 	addEntry := func(body string) {
 		req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)
@@ -248,8 +264,8 @@ func TestSDKHARCaptureBuffer_totalSizeCapIsTight(t *testing.T) {
 	}
 
 	// Leave the budget with less room than one full chunk, so the next entry straddles the cap.
-	big := strings.Repeat("a", maxCapturedBodyBytes)
-	for i := 0; i < (maxCapturedTotalBytes/maxCapturedBodyBytes)-1; i++ {
+	big := strings.Repeat("a", int(maxCapturedBodyBytes))
+	for i := int64(0); i < (maxCapturedTotalBytes/maxCapturedBodyBytes)-1; i++ {
 		addEntry(big)
 	}
 	addEntry(strings.Repeat("b", 1024))
@@ -259,7 +275,7 @@ func TestSDKHARCaptureBuffer_totalSizeCapIsTight(t *testing.T) {
 	for _, e := range buf.entries {
 		total += len(e.Response.Content.Text)
 	}
-	if total > maxCapturedTotalBytes {
+	if int64(total) > maxCapturedTotalBytes {
 		t.Errorf("retained body text %d exceeds the cap budget %d", total, maxCapturedTotalBytes)
 	}
 	if last := buf.entries[len(buf.entries)-1]; last.Response.Content.Text != "" {

--- a/backend/harcapture/bodyrestore_test.go
+++ b/backend/harcapture/bodyrestore_test.go
@@ -32,7 +32,8 @@ func (f *flakyBody) Close() error { return nil }
 
 // withCaptureLimits overrides the package's body/total capture caps for the duration of the test, so
 // cap-boundary tests exercise the capping algorithm against small fixtures rather than allocating and
-// copying data sized to the real multi-GiB production caps.
+// copying data sized to the real caps. Must not be used by a test (or subtest) that calls
+// t.Parallel(): it mutates package-level vars with no synchronization.
 func withCaptureLimits(t *testing.T) {
 	t.Helper()
 	const body, total = 4096, 16384

--- a/backend/harcapture/bodyrestore_test.go
+++ b/backend/harcapture/bodyrestore_test.go
@@ -30,18 +30,19 @@ func (f *flakyBody) Read(p []byte) (int, error) {
 
 func (f *flakyBody) Close() error { return nil }
 
-// withCaptureLimits overrides the package's body/total capture caps for the duration of the test, so
-// cap-boundary tests exercise the capping algorithm against small fixtures rather than allocating and
-// copying data sized to the real caps. Must not be used by a test (or subtest) that calls
-// t.Parallel(): it mutates package-level vars with no synchronization.
-func withCaptureLimits(t *testing.T) {
-	t.Helper()
-	const body, total = 4096, 16384
-	origBody, origTotal := maxCapturedBodyBytes, maxCapturedTotalBytes
-	maxCapturedBodyBytes, maxCapturedTotalBytes = body, total
-	t.Cleanup(func() {
-		maxCapturedBodyBytes, maxCapturedTotalBytes = origBody, origTotal
-	})
+// testMaxBodyBytes and testMaxTotalBytes are small stand-ins for the real caps, so cap-boundary tests
+// exercise the capping algorithm against small fixtures instead of allocating and copying data sized
+// to the real caps.
+const (
+	testMaxBodyBytes  int64 = 4096
+	testMaxTotalBytes int64 = 16384
+)
+
+// newBufferWithLimits returns a Buffer with the given caps instead of the real defaults, for
+// cap-boundary tests. Each Buffer holds its own caps (see NewBuffer), so unlike a package-level
+// override this needs no cleanup and is safe alongside any other test's Buffer, parallel or not.
+func newBufferWithLimits(maxBodyBytes, maxTotalBytes int64) *Buffer {
+	return &Buffer{maxBodyBytes: maxBodyBytes, maxTotalBytes: maxTotalBytes}
 }
 
 // TestBuildSDKHAREntry_restoresBodyOnReadError asserts that capturing a response whose body read
@@ -61,7 +62,7 @@ func TestBuildSDKHAREntry_restoresBodyOnReadError(t *testing.T) {
 		Body:       &flakyBody{data: []byte("partial-body"), err: wantErr},
 	}
 
-	entry := buildSDKHAREntry(req, nil, false, resp, nil, time.Now(), time.Millisecond)
+	entry := buildSDKHAREntry(req, nil, false, resp, nil, time.Now(), time.Millisecond, testMaxBodyBytes)
 
 	// The HAR entry captures whatever bytes were read before the error.
 	if entry.Response.Content.Text != "partial-body" {
@@ -88,7 +89,7 @@ func TestBuildSDKHAREntry_multiValuedHeadersAndQuery(t *testing.T) {
 	req.Header.Add("X-Multi", "one")
 	req.Header.Add("X-Multi", "two")
 
-	entry := buildSDKHAREntry(req, nil, false, &http.Response{Header: http.Header{}}, nil, time.Now(), time.Millisecond)
+	entry := buildSDKHAREntry(req, nil, false, &http.Response{Header: http.Header{}}, nil, time.Now(), time.Millisecond, testMaxBodyBytes)
 
 	countHeader := func(pairs []sdkHARNameValue, name, value string) bool {
 		for _, p := range pairs {
@@ -123,7 +124,7 @@ func TestBuildSDKHAREntry_binaryBodyBase64(t *testing.T) {
 	}
 	resp := &http.Response{Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(binary))}
 
-	entry := buildSDKHAREntry(req, nil, false, resp, nil, time.Now(), time.Millisecond)
+	entry := buildSDKHAREntry(req, nil, false, resp, nil, time.Now(), time.Millisecond, testMaxBodyBytes)
 
 	if entry.Response.Content.Encoding != "base64" {
 		t.Fatalf("non-UTF-8 body must be marked encoding=base64, got %q", entry.Response.Content.Encoding)
@@ -145,7 +146,7 @@ func TestBuildSDKHAREntry_transportError(t *testing.T) {
 	}
 	rtErr := errors.New("dial tcp: connection refused")
 
-	entry := buildSDKHAREntry(req, nil, false, nil, rtErr, time.Now(), time.Millisecond)
+	entry := buildSDKHAREntry(req, nil, false, nil, rtErr, time.Now(), time.Millisecond, testMaxBodyBytes)
 
 	if entry.Request.URL != "http://ds.example.com/q" {
 		t.Errorf("failed request must still be captured, got URL %q", entry.Request.URL)
@@ -164,16 +165,15 @@ func TestBuildSDKHAREntry_transportError(t *testing.T) {
 // TestReadAndRestoreBody_capsCaptureButDeliversFullBody asserts a body larger than the per-body cap
 // is only partially buffered for capture, yet the original consumer still receives every byte.
 func TestReadAndRestoreBody_capsCaptureButDeliversFullBody(t *testing.T) {
-	withCaptureLimits(t)
-	full := bytes.Repeat([]byte("x"), int(maxCapturedBodyBytes)+4096)
+	full := bytes.Repeat([]byte("x"), int(testMaxBodyBytes)+4096)
 
-	captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(full)), -1)
+	captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(full)), -1, testMaxBodyBytes)
 
 	if !truncated {
 		t.Fatal("a body larger than the cap must be reported as truncated")
 	}
-	if int64(len(captured)) != maxCapturedBodyBytes {
-		t.Errorf("captured %d bytes, want the cap %d (capture must not buffer the whole body)", len(captured), maxCapturedBodyBytes)
+	if int64(len(captured)) != testMaxBodyBytes {
+		t.Errorf("captured %d bytes, want the cap %d (capture must not buffer the whole body)", len(captured), testMaxBodyBytes)
 	}
 
 	got, err := io.ReadAll(restored)
@@ -193,11 +193,9 @@ func TestReadAndRestoreBody_capsCaptureButDeliversFullBody(t *testing.T) {
 // the declared length is itself larger than the cap (the buffer must still grow only to the cap, not
 // to the declared length).
 func TestReadAndRestoreBody_knownContentLength(t *testing.T) {
-	withCaptureLimits(t)
-
 	t.Run("within the cap", func(t *testing.T) {
 		body := []byte("hello world")
-		captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(body)), int64(len(body)))
+		captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(body)), int64(len(body)), testMaxBodyBytes)
 		if truncated {
 			t.Error("a body within the cap must not be reported as truncated")
 		}
@@ -214,13 +212,13 @@ func TestReadAndRestoreBody_knownContentLength(t *testing.T) {
 	})
 
 	t.Run("declared length past the cap", func(t *testing.T) {
-		full := bytes.Repeat([]byte("x"), int(maxCapturedBodyBytes)+4096)
-		captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(full)), int64(len(full)))
+		full := bytes.Repeat([]byte("x"), int(testMaxBodyBytes)+4096)
+		captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(full)), int64(len(full)), testMaxBodyBytes)
 		if !truncated {
 			t.Fatal("a body larger than the cap must be reported as truncated")
 		}
-		if int64(len(captured)) != maxCapturedBodyBytes {
-			t.Errorf("captured %d bytes, want the cap %d", len(captured), maxCapturedBodyBytes)
+		if int64(len(captured)) != testMaxBodyBytes {
+			t.Errorf("captured %d bytes, want the cap %d", len(captured), testMaxBodyBytes)
 		}
 		got, err := io.ReadAll(restored)
 		if err != nil {
@@ -235,33 +233,31 @@ func TestReadAndRestoreBody_knownContentLength(t *testing.T) {
 // TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize asserts an over-cap response reports bodySize
 // -1 (HAR "unavailable") since the true length isn't known, while content still holds the prefix.
 func TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize(t *testing.T) {
-	withCaptureLimits(t)
-	full := bytes.Repeat([]byte("y"), int(maxCapturedBodyBytes)+4096)
+	full := bytes.Repeat([]byte("y"), int(testMaxBodyBytes)+4096)
 	req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	resp := &http.Response{Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(full))}
 
-	entry := buildSDKHAREntry(req, nil, false, resp, nil, time.Now(), time.Millisecond)
+	entry := buildSDKHAREntry(req, nil, false, resp, nil, time.Now(), time.Millisecond, testMaxBodyBytes)
 
 	if entry.Response.BodySize != -1 {
 		t.Errorf("truncated body bodySize = %d, want -1 (unknown)", entry.Response.BodySize)
 	}
-	if entry.Response.Content.Size != maxCapturedBodyBytes {
-		t.Errorf("content size = %d, want the captured prefix length %d", entry.Response.Content.Size, maxCapturedBodyBytes)
+	if entry.Response.Content.Size != testMaxBodyBytes {
+		t.Errorf("content size = %d, want the captured prefix length %d", entry.Response.Content.Size, testMaxBodyBytes)
 	}
 }
 
 // TestSDKHARCaptureBuffer_totalSizeCap asserts that once the cumulative retained body budget is
 // exhausted, later entries keep their metadata/sizes but drop the body text.
 func TestSDKHARCaptureBuffer_totalSizeCap(t *testing.T) {
-	withCaptureLimits(t)
-	buf := NewBuffer()
-	big := strings.Repeat("a", int(maxCapturedBodyBytes)) // one per-body-capped chunk each
+	buf := newBufferWithLimits(testMaxBodyBytes, testMaxTotalBytes)
+	big := strings.Repeat("a", int(testMaxBodyBytes)) // one per-body-capped chunk each
 
 	// Enough entries to blow past the total budget.
-	for i := int64(0); i < (maxCapturedTotalBytes/maxCapturedBodyBytes)+2; i++ {
+	for i := int64(0); i < (testMaxTotalBytes/testMaxBodyBytes)+2; i++ {
 		req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)
 		if err != nil {
 			t.Fatal(err)
@@ -281,8 +277,8 @@ func TestSDKHARCaptureBuffer_totalSizeCap(t *testing.T) {
 			keptTrueSize = true
 		}
 	}
-	if int64(total) > maxCapturedTotalBytes {
-		t.Errorf("retained body text %d exceeds the cap budget %d", total, maxCapturedTotalBytes)
+	if int64(total) > testMaxTotalBytes {
+		t.Errorf("retained body text %d exceeds the cap budget %d", total, testMaxTotalBytes)
 	}
 	if !droppedText {
 		t.Error("expected later entries to drop body text once over the total budget")
@@ -298,8 +294,7 @@ func TestSDKHARCaptureBuffer_totalSizeCap(t *testing.T) {
 // an entry lands astride the cap -- the case a mixed query-and-HTTP capture reaches easily, since the
 // two producers contribute entries of very different sizes.
 func TestSDKHARCaptureBuffer_totalSizeCapIsTight(t *testing.T) {
-	withCaptureLimits(t)
-	buf := NewBuffer()
+	buf := newBufferWithLimits(testMaxBodyBytes, testMaxTotalBytes)
 	addEntry := func(body string) {
 		req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)
 		if err != nil {
@@ -310,8 +305,8 @@ func TestSDKHARCaptureBuffer_totalSizeCapIsTight(t *testing.T) {
 	}
 
 	// Leave the budget with less room than one full chunk, so the next entry straddles the cap.
-	big := strings.Repeat("a", int(maxCapturedBodyBytes))
-	for i := int64(0); i < (maxCapturedTotalBytes/maxCapturedBodyBytes)-1; i++ {
+	big := strings.Repeat("a", int(testMaxBodyBytes))
+	for i := int64(0); i < (testMaxTotalBytes/testMaxBodyBytes)-1; i++ {
 		addEntry(big)
 	}
 	addEntry(strings.Repeat("b", 1024))
@@ -321,8 +316,8 @@ func TestSDKHARCaptureBuffer_totalSizeCapIsTight(t *testing.T) {
 	for _, e := range buf.entries {
 		total += len(e.Response.Content.Text)
 	}
-	if int64(total) > maxCapturedTotalBytes {
-		t.Errorf("retained body text %d exceeds the cap budget %d", total, maxCapturedTotalBytes)
+	if int64(total) > testMaxTotalBytes {
+		t.Errorf("retained body text %d exceeds the cap budget %d", total, testMaxTotalBytes)
 	}
 	if last := buf.entries[len(buf.entries)-1]; last.Response.Content.Text != "" {
 		t.Error("the entry that crosses the budget must drop its body text, not be retained whole")

--- a/backend/harcapture/bodyrestore_test.go
+++ b/backend/harcapture/bodyrestore_test.go
@@ -167,7 +167,7 @@ func TestReadAndRestoreBody_capsCaptureButDeliversFullBody(t *testing.T) {
 	withCaptureLimits(t)
 	full := bytes.Repeat([]byte("x"), int(maxCapturedBodyBytes)+4096)
 
-	captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(full)))
+	captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(full)), -1)
 
 	if !truncated {
 		t.Fatal("a body larger than the cap must be reported as truncated")
@@ -186,6 +186,50 @@ func TestReadAndRestoreBody_capsCaptureButDeliversFullBody(t *testing.T) {
 	if err := restored.Close(); err != nil {
 		t.Errorf("Close: %v", err)
 	}
+}
+
+// TestReadAndRestoreBody_knownContentLength asserts a known Content-Length only changes how the
+// capture buffer is pre-sized, never what is captured or delivered to the consumer -- including when
+// the declared length is itself larger than the cap (the buffer must still grow only to the cap, not
+// to the declared length).
+func TestReadAndRestoreBody_knownContentLength(t *testing.T) {
+	withCaptureLimits(t)
+
+	t.Run("within the cap", func(t *testing.T) {
+		body := []byte("hello world")
+		captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(body)), int64(len(body)))
+		if truncated {
+			t.Error("a body within the cap must not be reported as truncated")
+		}
+		if string(captured) != string(body) {
+			t.Errorf("captured %q, want %q", captured, body)
+		}
+		got, err := io.ReadAll(restored)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != string(body) {
+			t.Errorf("consumer received %q, want %q", got, body)
+		}
+	})
+
+	t.Run("declared length past the cap", func(t *testing.T) {
+		full := bytes.Repeat([]byte("x"), int(maxCapturedBodyBytes)+4096)
+		captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(full)), int64(len(full)))
+		if !truncated {
+			t.Fatal("a body larger than the cap must be reported as truncated")
+		}
+		if int64(len(captured)) != maxCapturedBodyBytes {
+			t.Errorf("captured %d bytes, want the cap %d", len(captured), maxCapturedBodyBytes)
+		}
+		got, err := io.ReadAll(restored)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != len(full) {
+			t.Errorf("consumer received %d bytes, want the full %d", len(got), len(full))
+		}
+	})
 }
 
 // TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize asserts an over-cap response reports bodySize

--- a/backend/harcapture/bodyrestore_test.go
+++ b/backend/harcapture/bodyrestore_test.go
@@ -33,8 +33,9 @@ func (f *flakyBody) Close() error { return nil }
 // withCaptureLimits overrides the package's body/total capture caps for the duration of the test, so
 // cap-boundary tests exercise the capping algorithm against small fixtures rather than allocating and
 // copying data sized to the real multi-GiB production caps.
-func withCaptureLimits(t *testing.T, body, total int64) {
+func withCaptureLimits(t *testing.T) {
 	t.Helper()
+	const body, total = 4096, 16384
 	origBody, origTotal := maxCapturedBodyBytes, maxCapturedTotalBytes
 	maxCapturedBodyBytes, maxCapturedTotalBytes = body, total
 	t.Cleanup(func() {
@@ -162,7 +163,7 @@ func TestBuildSDKHAREntry_transportError(t *testing.T) {
 // TestReadAndRestoreBody_capsCaptureButDeliversFullBody asserts a body larger than the per-body cap
 // is only partially buffered for capture, yet the original consumer still receives every byte.
 func TestReadAndRestoreBody_capsCaptureButDeliversFullBody(t *testing.T) {
-	withCaptureLimits(t, 4096, 16384)
+	withCaptureLimits(t)
 	full := bytes.Repeat([]byte("x"), int(maxCapturedBodyBytes)+4096)
 
 	captured, truncated, restored := readAndRestoreBody(io.NopCloser(bytes.NewReader(full)))
@@ -189,7 +190,7 @@ func TestReadAndRestoreBody_capsCaptureButDeliversFullBody(t *testing.T) {
 // TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize asserts an over-cap response reports bodySize
 // -1 (HAR "unavailable") since the true length isn't known, while content still holds the prefix.
 func TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize(t *testing.T) {
-	withCaptureLimits(t, 4096, 16384)
+	withCaptureLimits(t)
 	full := bytes.Repeat([]byte("y"), int(maxCapturedBodyBytes)+4096)
 	req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)
 	if err != nil {
@@ -202,7 +203,7 @@ func TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize(t *testing.T) {
 	if entry.Response.BodySize != -1 {
 		t.Errorf("truncated body bodySize = %d, want -1 (unknown)", entry.Response.BodySize)
 	}
-	if entry.Response.Content.Size != int64(maxCapturedBodyBytes) {
+	if entry.Response.Content.Size != maxCapturedBodyBytes {
 		t.Errorf("content size = %d, want the captured prefix length %d", entry.Response.Content.Size, maxCapturedBodyBytes)
 	}
 }
@@ -210,7 +211,7 @@ func TestBuildSDKHAREntry_truncatedBodyReportsUnknownSize(t *testing.T) {
 // TestSDKHARCaptureBuffer_totalSizeCap asserts that once the cumulative retained body budget is
 // exhausted, later entries keep their metadata/sizes but drop the body text.
 func TestSDKHARCaptureBuffer_totalSizeCap(t *testing.T) {
-	withCaptureLimits(t, 4096, 16384)
+	withCaptureLimits(t)
 	buf := NewBuffer()
 	big := strings.Repeat("a", int(maxCapturedBodyBytes)) // one per-body-capped chunk each
 
@@ -252,7 +253,7 @@ func TestSDKHARCaptureBuffer_totalSizeCap(t *testing.T) {
 // an entry lands astride the cap -- the case a mixed query-and-HTTP capture reaches easily, since the
 // two producers contribute entries of very different sizes.
 func TestSDKHARCaptureBuffer_totalSizeCapIsTight(t *testing.T) {
-	withCaptureLimits(t, 4096, 16384)
+	withCaptureLimits(t)
 	buf := NewBuffer()
 	addEntry := func(body string) {
 		req, err := http.NewRequest(http.MethodGet, "http://ds.example.com", nil)

--- a/backend/harcapture/escapelen_test.go
+++ b/backend/harcapture/escapelen_test.go
@@ -1,0 +1,65 @@
+package harcapture
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// marshaledLen returns the byte length of s once json.Marshal encodes it as a JSON string value,
+// the ground truth jsonEscapedLen must never fall short of.
+func marshaledLen(t *testing.T, s string) int64 {
+	t.Helper()
+	raw, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("json.Marshal(%q): %v", s, err)
+	}
+	return int64(len(raw))
+}
+
+func TestJSONEscapedLen_matchesOrExceedsRealMarshal(t *testing.T) {
+	cases := map[string]string{
+		"empty":                  "",
+		"plain":                  "hello world",
+		"quote and backslash":    "quote \" and backslash \\",
+		"short escapes":          "newline\ntab\treturn\rbackspace\bformfeed\f",
+		"other control bytes":    string([]byte{0x00, 0x01, 0x02, 0x1f}), // -> \u00XX
+		"html unsafe":            "<script>&amp;</script>",
+		"line/paragraph sep":     "before\u2028middle\u2029after",
+		"multibyte no escaping":  "café éèê",
+		"astral plane (emoji)":   "emoji \U0001F600 rocket \U0001F680",
+		"invalid utf8":           string([]byte{0xff, 0xfe, 0x80}),
+		"valid bytes around bad": string([]byte{'a', 0xff, 'b'}),
+		"literal replacement":    "�",
+		"mixed":                  "mixed <tag> and \"quotes\" and \bbell and \u2028sep and 日本語",
+	}
+
+	for name, s := range cases {
+		t.Run(name, func(t *testing.T) {
+			estimate := jsonEscapedLen(s)
+			real := marshaledLen(t, s)
+			if estimate < real {
+				t.Errorf("jsonEscapedLen(%q) = %d, underestimates real marshaled length %d", s, estimate, real)
+			}
+		})
+	}
+}
+
+// FuzzJSONEscapedLen proves the safety invariant across arbitrary input, not just the hand-picked
+// cases above: jsonEscapedLen must never fall below the real json.Marshal length, for any string.
+func FuzzJSONEscapedLen(f *testing.F) {
+	for _, seed := range []string{
+		"", "a", "\"", "\\", "\n", "\t", "<>&", "\u2028\u2029", "日本語", "\U0001F600",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		estimate := jsonEscapedLen(s)
+		raw, err := json.Marshal(s)
+		if err != nil {
+			t.Fatalf("json.Marshal(%q): %v", s, err)
+		}
+		if real := int64(len(raw)); estimate < real {
+			t.Errorf("jsonEscapedLen(%q) = %d, underestimates real marshaled length %d", s, estimate, real)
+		}
+	})
+}

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -16,17 +16,22 @@ import (
 // capture; the untouched remainder is streamed on to the real consumer rather than buffered (see
 // readAndRestoreBody). maxCapturedTotalBytes caps the total payload text retained across all entries
 // in one request -- i.e. the size of the serialized __har__ frame -- keeping it well under the
-// plugin<->core gRPC message size limit. Note this budget tracks retained HAR text only: while an
-// over-cap body is still being streamed to the consumer, its capped head (up to
-// maxCapturedBodyBytes) is also held transiently, so peak memory during capture can exceed the
-// total budget by roughly that per concurrent over-cap response. Both are far below the
-// unbounded full-body buffering capture would otherwise do.
+// plugin<->core gRPC message size limit, which defaults to math.MaxInt32 (~2 GiB, see
+// GRPCSettings.MaxSendMsgSize) on the sending side. That limit bounds the serialized message, not the
+// retained bytes tracked here: json.Marshal can expand a payload considerably (e.g. every byte below
+// 0x20 becomes a 6-byte \u00XX escape), so maxCapturedTotalBytes leaves enough headroom below the gRPC
+// limit to absorb that worst case rather than tracking raw bytes 1:1 against it.
 //
-// These are vars, not consts, so cap-boundary tests can shrink them for the duration of a test
-// instead of generating fixture data sized to the real multi-GiB caps.
+// Note this budget tracks retained HAR text only: while an over-cap body is still being streamed to
+// the consumer, its capped head (up to maxCapturedBodyBytes) is also held transiently, so peak memory
+// during capture can exceed the total budget by roughly that per concurrent over-cap response. Both
+// are far below the unbounded full-body buffering capture would otherwise do.
+//
+// These are vars, not consts, so cap-boundary tests can shrink them for the duration of a test instead
+// of generating fixture data sized to the real caps.
 var (
-	maxCapturedBodyBytes  int64 = 1 << 30 // 1 GiB
-	maxCapturedTotalBytes int64 = 4 << 30 // 4 GiB
+	maxCapturedBodyBytes  int64 = 64 << 20  // 64 MiB
+	maxCapturedTotalBytes int64 = 256 << 20 // 256 MiB
 )
 
 // redactedValue replaces the value of anything capture treats as sensitive (see
@@ -153,24 +158,31 @@ func DrainRequestBody(req *http.Request) ([]byte, bool) {
 // reader re-surfaces the same error after them, exactly what downstream would have observed. rc is
 // closed once the returned ReadCloser is closed (or immediately when there is no remainder to stream).
 func readAndRestoreBody(rc io.ReadCloser) ([]byte, bool, io.ReadCloser) {
+	// Grow the buffer to the cap up front instead of letting io.ReadAll's internal buffer double
+	// repeatedly as it fills: at the caps this SDK allows, that repeated doubling can transiently
+	// hold close to twice the final size in memory for no reason, on top of every later copy
+	// (encodeBody, json.Marshal) that already has to pay for the real size.
+	var buf bytes.Buffer
+	buf.Grow(int(maxCapturedBodyBytes) + 1)
 	// Read one byte past the cap so a full body (<= cap) can be told from a truncated one (> cap)
 	// without buffering the whole thing.
-	buf, err := io.ReadAll(io.LimitReader(rc, maxCapturedBodyBytes+1))
+	_, err := io.Copy(&buf, io.LimitReader(rc, maxCapturedBodyBytes+1))
+	captured := buf.Bytes()
 	if err != nil {
 		// Read failed part-way: we hold a partial prefix and the true size is unavailable.
 		_ = rc.Close()
-		return buf, true, &errorReader{r: bytes.NewReader(buf), err: err}
+		return captured, true, &errorReader{r: bytes.NewReader(captured), err: err}
 	}
-	if int64(len(buf)) <= maxCapturedBodyBytes {
+	if int64(len(captured)) <= maxCapturedBodyBytes {
 		// Whole body fit within the cap; nothing left in rc.
 		_ = rc.Close()
-		return buf, false, io.NopCloser(bytes.NewReader(buf))
+		return captured, false, io.NopCloser(bytes.NewReader(captured))
 	}
 	// Body is larger than the cap: retain only the capped prefix for the HAR, but let the consumer
-	// read the full buffered head (buf, which is cap+1 bytes) followed by the untouched remainder
+	// read the full buffered head (captured, which is cap+1 bytes) followed by the untouched remainder
 	// streamed lazily from rc, so we never buffer the whole body.
-	captured := buf[:maxCapturedBodyBytes]
-	return captured, true, &bodyRemainder{r: io.MultiReader(bytes.NewReader(buf), rc), c: rc}
+	head := captured[:maxCapturedBodyBytes]
+	return head, true, &bodyRemainder{r: io.MultiReader(bytes.NewReader(captured), rc), c: rc}
 }
 
 // errorReader replays buffered bytes and then returns err in place of io.EOF, reproducing a body

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -143,7 +143,7 @@ func DrainRequestBody(req *http.Request) ([]byte, bool) {
 	if req == nil || req.Body == nil || req.Body == http.NoBody {
 		return nil, false
 	}
-	body, truncated, restored := readAndRestoreBody(req.Body)
+	body, truncated, restored := readAndRestoreBody(req.Body, req.ContentLength)
 	req.Body = restored
 	return body, truncated
 }
@@ -157,13 +157,23 @@ func DrainRequestBody(req *http.Request) ([]byte, bool) {
 // cap, or a transient network error), the captured bytes are what was read so far and the replay
 // reader re-surfaces the same error after them, exactly what downstream would have observed. rc is
 // closed once the returned ReadCloser is closed (or immediately when there is no remainder to stream).
-func readAndRestoreBody(rc io.ReadCloser) ([]byte, bool, io.ReadCloser) {
-	// Grow the buffer to the cap up front instead of letting io.ReadAll's internal buffer double
-	// repeatedly as it fills: at the caps this SDK allows, that repeated doubling can transiently
-	// hold close to twice the final size in memory for no reason, on top of every later copy
-	// (encodeBody, json.Marshal) that already has to pay for the real size.
+//
+// contentLength is the body's declared Content-Length (-1/0 if unknown, matching http.Request/
+// http.Response's own convention) -- used only to size the capture buffer up front; it never changes
+// what is read or returned.
+func readAndRestoreBody(rc io.ReadCloser, contentLength int64) ([]byte, bool, io.ReadCloser) {
+	// Grow the buffer up front instead of letting io.Copy's internal buffer double repeatedly as it
+	// fills: at the caps this SDK allows, that repeated doubling can transiently hold close to twice
+	// the final size in memory for no reason, on top of every later copy (encodeBody, json.Marshal)
+	// that already has to pay for the real size. Only do this when contentLength is known (a chunked
+	// body reports -1): growing to the cap for every capture regardless of the real body size would
+	// itself waste memory on the common case of a small body.
 	var buf bytes.Buffer
-	buf.Grow(int(maxCapturedBodyBytes) + 1)
+	if contentLength > 0 {
+		// A declared length past the cap is truncated anyway, so cap the grow target too -- there is
+		// no reason to pre-allocate for bytes we already know we won't retain.
+		buf.Grow(int(min(contentLength, maxCapturedBodyBytes)) + 1)
+	}
 	// Read one byte past the cap so a full body (<= cap) can be told from a truncated one (> cap)
 	// without buffering the whole thing.
 	_, err := io.Copy(&buf, io.LimitReader(rc, maxCapturedBodyBytes+1))
@@ -399,7 +409,7 @@ func buildSDKHAREntry(req *http.Request, reqBody []byte, reqTruncated bool, resp
 		if resp.Body != nil {
 			// Always restore resp.Body -- even on a read error -- so capturing never truncates the
 			// response the plugin actually receives (see readAndRestoreBody).
-			body, truncated, restored := readAndRestoreBody(resp.Body)
+			body, truncated, restored := readAndRestoreBody(resp.Body, resp.ContentLength)
 			resp.Body = restored
 			text, encoding := encodeBody(body)
 			// When the body exceeded the capture cap we hold only a prefix, so the true size is

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -12,24 +12,27 @@ import (
 	"unicode/utf8"
 )
 
-const (
-	// maxCapturedBodyBytes caps how much of any single request/response body is read into memory for
-	// capture; the untouched remainder is streamed on to the real consumer rather than buffered (see
-	// readAndRestoreBody). maxCapturedTotalBytes caps the total payload text retained across all entries
-	// in one request -- i.e. the size of the serialized __har__ frame -- keeping it well under the
-	// plugin<->core gRPC message size limit. Note this budget tracks retained HAR text only: while an
-	// over-cap body is still being streamed to the consumer, its capped head (up to
-	// maxCapturedBodyBytes) is also held transiently, so peak memory during capture can exceed the
-	// total budget by roughly that per concurrent over-cap response. Both are far below the
-	// unbounded full-body buffering capture would otherwise do.
-	maxCapturedBodyBytes  = 1 << 30 // 1 GiB
-	maxCapturedTotalBytes = 4 << 30 // 4 GiB
-
-	// redactedValue replaces the value of anything capture treats as sensitive (see
-	// isSensitiveHeaderName, isSensitiveQueryParamName, and sdkCookies), so the __har__ frame -- which
-	// is returned to whoever enabled capture -- never carries datasource credentials.
-	redactedValue = "REDACTED"
+// maxCapturedBodyBytes caps how much of any single request/response body is read into memory for
+// capture; the untouched remainder is streamed on to the real consumer rather than buffered (see
+// readAndRestoreBody). maxCapturedTotalBytes caps the total payload text retained across all entries
+// in one request -- i.e. the size of the serialized __har__ frame -- keeping it well under the
+// plugin<->core gRPC message size limit. Note this budget tracks retained HAR text only: while an
+// over-cap body is still being streamed to the consumer, its capped head (up to
+// maxCapturedBodyBytes) is also held transiently, so peak memory during capture can exceed the
+// total budget by roughly that per concurrent over-cap response. Both are far below the
+// unbounded full-body buffering capture would otherwise do.
+//
+// These are vars, not consts, so cap-boundary tests can shrink them for the duration of a test
+// instead of generating fixture data sized to the real multi-GiB caps.
+var (
+	maxCapturedBodyBytes  int64 = 1 << 30 // 1 GiB
+	maxCapturedTotalBytes int64 = 4 << 30 // 4 GiB
 )
+
+// redactedValue replaces the value of anything capture treats as sensitive (see
+// isSensitiveHeaderName, isSensitiveQueryParamName, and sdkCookies), so the __har__ frame -- which
+// is returned to whoever enabled capture -- never carries datasource credentials.
+const redactedValue = "REDACTED"
 
 // sensitiveHeaderNames are header names whose values are redacted before capture (matched
 // case-insensitively by isSensitiveHeaderName), since they routinely carry datasource credentials
@@ -314,7 +317,7 @@ type sdkHARContent struct {
 // true, uncapped size separately (bodySize/content.size).
 func encodeBody(body []byte) (text, encoding string) {
 	keep := body
-	if len(keep) > maxCapturedBodyBytes {
+	if int64(len(keep)) > maxCapturedBodyBytes {
 		keep = keep[:maxCapturedBodyBytes]
 	}
 	if utf8.Valid(keep) {

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -22,8 +22,8 @@ const (
 	// maxCapturedBodyBytes) is also held transiently, so peak memory during capture can exceed the
 	// total budget by roughly that per concurrent over-cap response. Both are far below the
 	// unbounded full-body buffering capture would otherwise do.
-	maxCapturedBodyBytes  = 8 << 20  // 8 MiB
-	maxCapturedTotalBytes = 32 << 20 // 32 MiB
+	maxCapturedBodyBytes  = 1 << 30 // 1 GiB
+	maxCapturedTotalBytes = 4 << 30 // 4 GiB
 
 	// redactedValue replaces the value of anything capture treats as sensitive (see
 	// isSensitiveHeaderName, isSensitiveQueryParamName, and sdkCookies), so the __har__ frame -- which

--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -12,26 +12,26 @@ import (
 	"unicode/utf8"
 )
 
-// maxCapturedBodyBytes caps how much of any single request/response body is read into memory for
-// capture; the untouched remainder is streamed on to the real consumer rather than buffered (see
-// readAndRestoreBody). maxCapturedTotalBytes caps the total payload text retained across all entries
-// in one request -- i.e. the size of the serialized __har__ frame -- keeping it well under the
-// plugin<->core gRPC message size limit, which defaults to math.MaxInt32 (~2 GiB, see
-// GRPCSettings.MaxSendMsgSize) on the sending side. That limit bounds the serialized message, not the
-// retained bytes tracked here: json.Marshal can expand a payload considerably (e.g. every byte below
-// 0x20 becomes a 6-byte \u00XX escape), so maxCapturedTotalBytes leaves enough headroom below the gRPC
-// limit to absorb that worst case rather than tracking raw bytes 1:1 against it.
+// defaultMaxCapturedBodyBytes caps how much of one request/response body capture reads into memory;
+// the untouched remainder streams straight to the real consumer (see readAndRestoreBody). Deliberately
+// generous: for this experimental, admin-only, on-prem feature the worst case is a trusted operator's
+// own memory pressure, not a shared or adversarial resource.
 //
-// Note this budget tracks retained HAR text only: while an over-cap body is still being streamed to
-// the consumer, its capped head (up to maxCapturedBodyBytes) is also held transiently, so peak memory
-// during capture can exceed the total budget by roughly that per concurrent over-cap response. Both
-// are far below the unbounded full-body buffering capture would otherwise do.
+// defaultMaxCapturedTotalBytes caps the total payload retained across one request's entries -- the
+// size of the serialized __har__ frame -- to stay under the plugin<->core gRPC message limit (~2 GiB,
+// GRPCSettings.MaxSendMsgSize), shared with the actual QueryDataResponse data riding the same message.
+// It's measured in jsonEscapedLen, not raw bytes, since that's what actually crosses the wire:
+// json.Marshal can expand a byte into a 6-byte \u00XX escape, so budgeting the estimated escaped size
+// spends real headroom on ordinary text while still holding worst-case content to the same ceiling.
 //
-// These are vars, not consts, so cap-boundary tests can shrink them for the duration of a test instead
-// of generating fixture data sized to the real caps.
-var (
-	maxCapturedBodyBytes  int64 = 64 << 20  // 64 MiB
-	maxCapturedTotalBytes int64 = 256 << 20 // 256 MiB
+// Peak memory can exceed defaultMaxCapturedTotalBytes by up to defaultMaxCapturedBodyBytes per
+// concurrent over-cap response, since a capped head is held transiently before being dropped.
+//
+// Each Buffer holds its own copy of these caps (see NewBuffer), rather than reading package vars, so
+// a test can shrink them for one Buffer without a data race against any other test's Buffer.
+const (
+	defaultMaxCapturedBodyBytes  int64 = 1 << 30    // 1 GiB
+	defaultMaxCapturedTotalBytes int64 = 1536 << 20 // 1.5 GiB, measured post-escaping (see jsonEscapedLen)
 )
 
 // redactedValue replaces the value of anything capture treats as sensitive (see
@@ -83,14 +83,22 @@ type Buffer struct {
 	mu       sync.Mutex
 	entries  []sdkHAREntry
 	retained int64 // running total of retained payload bytes, for the total-size cap
+
+	// maxBodyBytes and maxTotalBytes are set once, at construction, and never modified afterwards, so
+	// reading them needs no synchronization of its own.
+	maxBodyBytes  int64
+	maxTotalBytes int64
 }
 
 func NewBuffer() *Buffer {
-	return &Buffer{}
+	return &Buffer{
+		maxBodyBytes:  defaultMaxCapturedBodyBytes,
+		maxTotalBytes: defaultMaxCapturedTotalBytes,
+	}
 }
 
 func (b *Buffer) AddEntry(req *http.Request, reqBody []byte, reqTruncated bool, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration) {
-	b.appendEntry(buildSDKHAREntry(req, reqBody, reqTruncated, resp, rtErr, started, elapsed))
+	b.appendEntry(buildSDKHAREntry(req, reqBody, reqTruncated, resp, rtErr, started, elapsed, b.maxBodyBytes))
 }
 
 // appendEntry adds an already-built entry under the buffer's cumulative retained-payload budget.
@@ -100,12 +108,12 @@ func (b *Buffer) appendEntry(entry sdkHAREntry) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	// Enforce the cumulative retained-payload budget: an entry whose payload would take the request
-	// past maxCapturedTotalBytes keeps its metadata (headers, sizes, timings, error) but drops the
-	// payload itself, so the __har__ frame can't grow without bound. The check is on the sum rather
-	// than on what is already retained, so the entry that crosses the budget is trimmed too rather than
-	// kept whole.
+	// past maxTotalBytes keeps its metadata (headers, sizes, timings, error) but drops the payload
+	// itself, so the __har__ frame can't grow without bound. The check is on the sum rather than on
+	// what is already retained, so the entry that crosses the budget is trimmed too rather than kept
+	// whole.
 	payload := entry.payloadBytes()
-	if b.retained+payload > maxCapturedTotalBytes {
+	if b.retained+payload > b.maxTotalBytes {
 		entry.dropPayload()
 	} else {
 		b.retained += payload
@@ -113,12 +121,14 @@ func (b *Buffer) appendEntry(entry sdkHAREntry) {
 	b.entries = append(b.entries, entry)
 }
 
-// payloadBytes is what an entry contributes to the buffer's retained-payload budget: everything that
-// carries data rather than describing it, whichever producer built the entry.
+// payloadBytes is what an entry contributes to the buffer's retained-payload budget. Measured as
+// jsonEscapedLen rather than raw length: the budget bounds the serialized __har__ frame that actually
+// crosses the plugin<->core gRPC boundary (see Buffer.maxTotalBytes), and json.Marshal's own escaping
+// is what determines that size, not how many bytes are held in memory before marshaling runs.
 func (e *sdkHAREntry) payloadBytes() int64 {
-	n := int64(len(e.Response.Content.Text))
+	n := jsonEscapedLen(e.Response.Content.Text)
 	if e.Request.PostData != nil {
-		n += int64(len(e.Request.PostData.Text))
+		n += jsonEscapedLen(e.Request.PostData.Text)
 	}
 	return n + e.Query.payloadBytes()
 }
@@ -135,33 +145,33 @@ func (e *sdkHAREntry) dropPayload() {
 	e.Query.dropPayload()
 }
 
-// DrainRequestBody reads and returns the request body (up to the capture cap) and whether it was
-// larger than the cap (truncated), restoring it so the request can still be sent. It must be called
-// before the request is sent: a real http.Transport consumes (and closes) req.Body while sending, so
-// reading it afterwards yields nothing. Returns nil when there is no body.
-func DrainRequestBody(req *http.Request) ([]byte, bool) {
+// DrainRequestBody reads and returns the request body (up to b's per-body capture cap) and whether
+// it was larger than the cap (truncated), restoring it so the request can still be sent. It must be
+// called before the request is sent: a real http.Transport consumes (and closes) req.Body while
+// sending, so reading it afterwards yields nothing. Returns nil when there is no body.
+func (b *Buffer) DrainRequestBody(req *http.Request) ([]byte, bool) {
 	if req == nil || req.Body == nil || req.Body == http.NoBody {
 		return nil, false
 	}
-	body, truncated, restored := readAndRestoreBody(req.Body, req.ContentLength)
+	body, truncated, restored := readAndRestoreBody(req.Body, req.ContentLength, b.maxBodyBytes)
 	req.Body = restored
 	return body, truncated
 }
 
-// readAndRestoreBody reads up to maxCapturedBodyBytes of rc for capture and returns those bytes,
-// whether the captured bytes are NOT the complete body (sizeUnknown -- the body exceeded the cap, or
-// the read failed part-way, so its true size is unavailable), and a ReadCloser that hands the
-// original consumer the full body -- the captured prefix followed by the untouched, lazily-streamed
-// remainder -- so capture never buffers more than the cap regardless of how large the body is. When
-// the read fails partway (e.g. this SDK's ResponseLimitMiddleware deliberately errors past a size
-// cap, or a transient network error), the captured bytes are what was read so far and the replay
-// reader re-surfaces the same error after them, exactly what downstream would have observed. rc is
-// closed once the returned ReadCloser is closed (or immediately when there is no remainder to stream).
+// readAndRestoreBody reads up to maxBodyBytes of rc for capture and returns those bytes, whether the
+// captured bytes are NOT the complete body (sizeUnknown -- the body exceeded the cap, or the read
+// failed part-way, so its true size is unavailable), and a ReadCloser that hands the original
+// consumer the full body -- the captured prefix followed by the untouched, lazily-streamed remainder
+// -- so capture never buffers more than the cap regardless of how large the body is. When the read
+// fails partway (e.g. this SDK's ResponseLimitMiddleware deliberately errors past a size cap, or a
+// transient network error), the captured bytes are what was read so far and the replay reader
+// re-surfaces the same error after them, exactly what downstream would have observed. rc is closed
+// once the returned ReadCloser is closed (or immediately when there is no remainder to stream).
 //
 // contentLength is the body's declared Content-Length (-1/0 if unknown, matching http.Request/
 // http.Response's own convention) -- used only to size the capture buffer up front; it never changes
 // what is read or returned.
-func readAndRestoreBody(rc io.ReadCloser, contentLength int64) ([]byte, bool, io.ReadCloser) {
+func readAndRestoreBody(rc io.ReadCloser, contentLength, maxBodyBytes int64) ([]byte, bool, io.ReadCloser) {
 	// Grow the buffer up front instead of letting io.Copy's internal buffer double repeatedly as it
 	// fills: at the caps this SDK allows, that repeated doubling can transiently hold close to twice
 	// the final size in memory for no reason, on top of every later copy (encodeBody, json.Marshal)
@@ -172,18 +182,18 @@ func readAndRestoreBody(rc io.ReadCloser, contentLength int64) ([]byte, bool, io
 	if contentLength > 0 {
 		// A declared length past the cap is truncated anyway, so cap the grow target too -- there is
 		// no reason to pre-allocate for bytes we already know we won't retain.
-		buf.Grow(int(min(contentLength, maxCapturedBodyBytes)) + 1)
+		buf.Grow(int(min(contentLength, maxBodyBytes)) + 1)
 	}
 	// Read one byte past the cap so a full body (<= cap) can be told from a truncated one (> cap)
 	// without buffering the whole thing.
-	_, err := io.Copy(&buf, io.LimitReader(rc, maxCapturedBodyBytes+1))
+	_, err := io.Copy(&buf, io.LimitReader(rc, maxBodyBytes+1))
 	captured := buf.Bytes()
 	if err != nil {
 		// Read failed part-way: we hold a partial prefix and the true size is unavailable.
 		_ = rc.Close()
 		return captured, true, &errorReader{r: bytes.NewReader(captured), err: err}
 	}
-	if int64(len(captured)) <= maxCapturedBodyBytes {
+	if int64(len(captured)) <= maxBodyBytes {
 		// Whole body fit within the cap; nothing left in rc.
 		_ = rc.Close()
 		return captured, false, io.NopCloser(bytes.NewReader(captured))
@@ -191,7 +201,7 @@ func readAndRestoreBody(rc io.ReadCloser, contentLength int64) ([]byte, bool, io
 	// Body is larger than the cap: retain only the capped prefix for the HAR, but let the consumer
 	// read the full buffered head (captured, which is cap+1 bytes) followed by the untouched remainder
 	// streamed lazily from rc, so we never buffer the whole body.
-	head := captured[:maxCapturedBodyBytes]
+	head := captured[:maxBodyBytes]
 	return head, true, &bodyRemainder{r: io.MultiReader(bytes.NewReader(captured), rc), c: rc}
 }
 
@@ -335,17 +345,51 @@ type sdkHARContent struct {
 
 // encodeBody renders a body for a HAR text field. It base64-encodes when the bytes are not valid
 // UTF-8, so binary payloads (protobuf, images, ...) survive json.Marshal instead of being silently
-// corrupted to U+FFFD, and caps the retained bytes at maxCapturedBodyBytes. The caller records the
-// true, uncapped size separately (bodySize/content.size).
-func encodeBody(body []byte) (text, encoding string) {
+// corrupted to U+FFFD, and caps the retained bytes at maxBodyBytes. The caller records the true,
+// uncapped size separately (bodySize/content.size).
+func encodeBody(body []byte, maxBodyBytes int64) (text, encoding string) {
 	keep := body
-	if int64(len(keep)) > maxCapturedBodyBytes {
-		keep = keep[:maxCapturedBodyBytes]
+	if int64(len(keep)) > maxBodyBytes {
+		keep = keep[:maxBodyBytes]
 	}
 	if utf8.Valid(keep) {
 		return string(keep), ""
 	}
 	return base64.StdEncoding.EncodeToString(keep), "base64"
+}
+
+// jsonEscapedLen returns a lower bound on how many bytes s occupies once json.Marshal encodes it as a
+// JSON string, including the wrapping quotes -- used to budget the aggregate retained-payload cap
+// against the actual serialized size instead of raw length (see Buffer.maxTotalBytes). It never
+// underestimates: every rune json.Marshal escapes is charged its real cost --
+//   - 2 bytes for the short escapes: \" \\ \b \f \n \r \t
+//   - 6 bytes for \u00XX (every other byte below 0x20), for the HTML-unsafe runes Marshal always
+//     escapes regardless of content (<, >, &), for U+2028/U+2029 (also unconditional), and for a
+//     malformed byte (encoded as �) -- charging 6 here even for a literal, validly-encoded
+//     U+FFFD character (which Marshal does NOT escape, and which costs only 3) is a deliberate
+//     over-estimate: telling the two apart isn't worth the complexity when erring high is safe.
+//   - its own byte length for everything else, since a valid, unescaped UTF-8 sequence passes through
+//     unchanged.
+//
+// Matched against encoding/json's actual escaping table (encode.go's appendString / tables.go's
+// htmlSafeSet) rather than assumed, since an incorrect table here would silently undercount.
+func jsonEscapedLen(s string) int64 {
+	n := int64(2) // the wrapping quotes
+	for _, r := range s {
+		switch r {
+		case '"', '\\', '\b', '\f', '\n', '\r', '\t':
+			n += 2
+		case '<', '>', '&', '\u2028', '\u2029', utf8.RuneError:
+			n += 6
+		default:
+			if r < 0x20 {
+				n += 6
+			} else {
+				n += int64(utf8.RuneLen(r))
+			}
+		}
+	}
+	return n
 }
 
 type sdkHARTimings struct {
@@ -366,7 +410,7 @@ func durationMs(d time.Duration) float64 {
 // from req.Body here, because by the time capture runs the transport has already drained the body.
 // rtErr is the RoundTrip error (nil on success): a transport-level failure (connection refused,
 // DNS/TLS error, timeout) leaves resp nil, and the entry records the error in Comment.
-func buildSDKHAREntry(req *http.Request, reqBody []byte, reqTruncated bool, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration) sdkHAREntry {
+func buildSDKHAREntry(req *http.Request, reqBody []byte, reqTruncated bool, resp *http.Response, rtErr error, started time.Time, elapsed time.Duration, maxBodyBytes int64) sdkHAREntry {
 	reqHeaders := sdkHeadersToNameValue(req.Header)
 	queryString := make([]sdkHARNameValue, 0, len(req.URL.Query()))
 	for k, vals := range req.URL.Query() {
@@ -387,7 +431,7 @@ func buildSDKHAREntry(req *http.Request, reqBody []byte, reqTruncated bool, resp
 		reqBodySize = -1
 	}
 	if len(reqBody) > 0 {
-		text, encoding := encodeBody(reqBody)
+		text, encoding := encodeBody(reqBody, maxBodyBytes)
 		postData = &sdkHARPostData{
 			MimeType: req.Header.Get("Content-Type"),
 			Text:     text,
@@ -409,9 +453,9 @@ func buildSDKHAREntry(req *http.Request, reqBody []byte, reqTruncated bool, resp
 		if resp.Body != nil {
 			// Always restore resp.Body -- even on a read error -- so capturing never truncates the
 			// response the plugin actually receives (see readAndRestoreBody).
-			body, truncated, restored := readAndRestoreBody(resp.Body, resp.ContentLength)
+			body, truncated, restored := readAndRestoreBody(resp.Body, resp.ContentLength, maxBodyBytes)
 			resp.Body = restored
-			text, encoding := encodeBody(body)
+			text, encoding := encodeBody(body, maxBodyBytes)
 			// When the body exceeded the capture cap we hold only a prefix, so the true size is
 			// unknown: report -1 (HAR "unavailable") for bodySize; content.size is what we captured.
 			harResp.BodySize = int64(len(body))

--- a/backend/harcapture/querycapture.go
+++ b/backend/harcapture/querycapture.go
@@ -32,7 +32,7 @@ const querySummaryMimeType = "application/json"
 // A failed query is recorded with a zero-status response and the error in the entry's comment, the
 // same shape AddEntry uses for a request that never produced an HTTP response.
 func (b *Buffer) AddQueryInteraction(i querycapture.Interaction) {
-	b.appendEntry(buildQueryHAREntry(i))
+	b.appendEntry(buildQueryHAREntry(i, b.maxBodyBytes))
 }
 
 // queryInfoVersion is the current schema version of the "_query" object, bumped when its shape
@@ -74,14 +74,16 @@ type sdkHARQueryInfo struct {
 
 // payloadBytes is the "_query" object's share of the buffer's retained-payload budget (see
 // Buffer.appendEntry): the bind arguments, which a bulk statement can make as large as the statement
-// itself, and the error. A nil receiver is an HTTP entry, which has no "_query".
+// itself, and the error. A nil receiver is an HTTP entry, which has no "_query". Measured as
+// jsonEscapedLen for the same reason as sdkHAREntry.payloadBytes -- the budget bounds the serialized
+// size, not the raw byte count.
 func (q *sdkHARQueryInfo) payloadBytes() int64 {
 	if q == nil {
 		return 0
 	}
-	n := int64(len(q.Error))
+	n := jsonEscapedLen(q.Error)
 	for _, a := range q.Args {
-		n += int64(len(a))
+		n += jsonEscapedLen(a)
 	}
 	return n
 }
@@ -103,10 +105,10 @@ type querySummary struct {
 	RowCount   int `json:"rowCount"`
 }
 
-func buildQueryHAREntry(i querycapture.Interaction) sdkHAREntry {
+func buildQueryHAREntry(i querycapture.Interaction, maxBodyBytes int64) sdkHAREntry {
 	elapsedMs := durationMs(i.Duration)
 
-	statement, encoding := encodeBody([]byte(i.Statement))
+	statement, encoding := encodeBody([]byte(i.Statement), maxBodyBytes)
 	// Report -1 ("unavailable" in HAR) when only a prefix of the statement was kept, symmetric with
 	// how an over-cap HTTP body is reported.
 	statementSize := int64(len(i.Statement))

--- a/backend/harcapture/querycapture_test.go
+++ b/backend/harcapture/querycapture_test.go
@@ -260,7 +260,7 @@ func TestAddQueryInteraction_argsAreDroppedOverTheTotalBudget(t *testing.T) {
 	// Being counted is not enough: an over-budget entry has to shed its arguments too, or the frame
 	// grows by them anyway. Inspect the entries directly rather than the marshalled document, so the
 	// test doesn't serialize the whole budget.
-	withCaptureLimits(t, 4096, 16384)
+	withCaptureLimits(t)
 	b := NewBuffer()
 	statement := strings.Repeat("x", int(maxCapturedBodyBytes))
 	for i := int64(0); i < maxCapturedTotalBytes/maxCapturedBodyBytes; i++ {
@@ -284,7 +284,7 @@ func TestAddQueryInteraction_argsAreDroppedOverTheTotalBudget(t *testing.T) {
 	assert.True(t, last.Query.ArgsTruncated, "dropped arguments must not read as a statement that had none")
 	assert.Contains(t, last.Query.Error, "Unknown table expression",
 		"the error is kept: it is what makes an over-budget entry worth reading at all")
-	assert.LessOrEqual(t, b.retained, int64(maxCapturedTotalBytes))
+	assert.LessOrEqual(t, b.retained, maxCapturedTotalBytes)
 }
 
 func TestAddQueryInteraction_kindDrivesURLScheme(t *testing.T) {

--- a/backend/harcapture/querycapture_test.go
+++ b/backend/harcapture/querycapture_test.go
@@ -260,9 +260,10 @@ func TestAddQueryInteraction_argsAreDroppedOverTheTotalBudget(t *testing.T) {
 	// Being counted is not enough: an over-budget entry has to shed its arguments too, or the frame
 	// grows by them anyway. Inspect the entries directly rather than the marshalled document, so the
 	// test doesn't serialize the whole budget.
+	withCaptureLimits(t, 4096, 16384)
 	b := NewBuffer()
-	statement := strings.Repeat("x", maxCapturedBodyBytes)
-	for i := 0; i < maxCapturedTotalBytes/maxCapturedBodyBytes; i++ {
+	statement := strings.Repeat("x", int(maxCapturedBodyBytes))
+	for i := int64(0); i < maxCapturedTotalBytes/maxCapturedBodyBytes; i++ {
 		b.AddQueryInteraction(querycapture.Interaction{
 			Kind: querycapture.KindSQLQuery, Statement: statement, Err: "boom",
 		})

--- a/backend/harcapture/querycapture_test.go
+++ b/backend/harcapture/querycapture_test.go
@@ -250,20 +250,21 @@ func TestAddQueryInteraction_argsAndErrorCountTowardTheTotalBudget(t *testing.T)
 	})
 
 	// A failed query has no response content, so the retained total is exactly the statement, the
-	// arguments and the error.
-	want := len("SELECT * FROM t WHERE id IN (?, ?)") + len("host-a") + len("host-b") +
-		len("code: 60, message: Unknown table expression identifier 't'")
-	assert.Equal(t, int64(want), b.retained)
+	// arguments and the error, each measured as jsonEscapedLen (see Buffer.maxTotalBytes), not raw
+	// length.
+	want := jsonEscapedLen("") + jsonEscapedLen("SELECT * FROM t WHERE id IN (?, ?)") +
+		jsonEscapedLen("host-a") + jsonEscapedLen("host-b") +
+		jsonEscapedLen("code: 60, message: Unknown table expression identifier 't'")
+	assert.Equal(t, want, b.retained)
 }
 
 func TestAddQueryInteraction_argsAreDroppedOverTheTotalBudget(t *testing.T) {
 	// Being counted is not enough: an over-budget entry has to shed its arguments too, or the frame
 	// grows by them anyway. Inspect the entries directly rather than the marshalled document, so the
 	// test doesn't serialize the whole budget.
-	withCaptureLimits(t)
-	b := NewBuffer()
-	statement := strings.Repeat("x", int(maxCapturedBodyBytes))
-	for i := int64(0); i < maxCapturedTotalBytes/maxCapturedBodyBytes; i++ {
+	b := newBufferWithLimits(testMaxBodyBytes, testMaxTotalBytes)
+	statement := strings.Repeat("x", int(testMaxBodyBytes))
+	for i := int64(0); i < testMaxTotalBytes/testMaxBodyBytes; i++ {
 		b.AddQueryInteraction(querycapture.Interaction{
 			Kind: querycapture.KindSQLQuery, Statement: statement, Err: "boom",
 		})
@@ -284,7 +285,7 @@ func TestAddQueryInteraction_argsAreDroppedOverTheTotalBudget(t *testing.T) {
 	assert.True(t, last.Query.ArgsTruncated, "dropped arguments must not read as a statement that had none")
 	assert.Contains(t, last.Query.Error, "Unknown table expression",
 		"the error is kept: it is what makes an over-budget entry worth reading at all")
-	assert.LessOrEqual(t, b.retained, maxCapturedTotalBytes)
+	assert.LessOrEqual(t, b.retained, testMaxTotalBytes)
 }
 
 func TestAddQueryInteraction_kindDrivesURLScheme(t *testing.T) {

--- a/backend/harcapture/redaction_test.go
+++ b/backend/harcapture/redaction_test.go
@@ -26,7 +26,7 @@ func TestBuildSDKHAREntry_redactsSensitiveHeaders(t *testing.T) {
 	rec.WriteHeader(http.StatusOK)
 	resp := rec.Result()
 
-	entry := buildSDKHAREntry(req, nil, false, resp, nil, time.Now(), time.Millisecond)
+	entry := buildSDKHAREntry(req, nil, false, resp, nil, time.Now(), time.Millisecond, testMaxBodyBytes)
 
 	find := func(pairs []sdkHARNameValue, name string) (string, bool) {
 		for _, p := range pairs {
@@ -74,7 +74,7 @@ func TestBuildSDKHAREntry_redactsCookieValues(t *testing.T) {
 	rec.WriteHeader(http.StatusOK)
 	resp := rec.Result()
 
-	entry := buildSDKHAREntry(req, nil, false, resp, nil, time.Now(), time.Millisecond)
+	entry := buildSDKHAREntry(req, nil, false, resp, nil, time.Now(), time.Millisecond, testMaxBodyBytes)
 
 	if len(entry.Request.Cookies) != 1 || entry.Request.Cookies[0].Name != "session" {
 		t.Fatalf("request cookie not captured as expected: %+v", entry.Request.Cookies)
@@ -100,7 +100,7 @@ func TestBuildSDKHAREntry_redactsSensitiveQueryParams(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	entry := buildSDKHAREntry(req, nil, false, &http.Response{Header: http.Header{}}, nil, time.Now(), time.Millisecond)
+	entry := buildSDKHAREntry(req, nil, false, &http.Response{Header: http.Header{}}, nil, time.Now(), time.Millisecond, testMaxBodyBytes)
 
 	find := func(name string) (string, bool) {
 		for _, p := range entry.Request.QueryString {

--- a/backend/querycapture/querycapture.go
+++ b/backend/querycapture/querycapture.go
@@ -49,15 +49,22 @@
 //
 // # Known limitations
 //
-// The size bounds below apply to a single Interaction. Nothing bounds their sum
-// across the queries of one request, which run in parallel, so peak memory
-// scales with the number of refIDs a panel sends. The Recorder bounds the
-// document it produces, not the captures feeding it.
+// The size bounds below apply to a single Interaction; this interface itself
+// makes no guarantee about their sum across the queries of one request, which
+// run in parallel. In practice, the Recorder this SDK ships (backend/harcapture)
+// already closes that gap: every Interaction is folded into the same cumulative
+// retained-bytes budget that bounds HTTP capture (see Buffer.appendEntry and
+// TestAddQueryInteraction_argsAreDroppedOverTheTotalBudget), so the retained
+// document cannot grow unbounded with refID count even though this package
+// does not enforce that itself. A capture point still pays to build each
+// Interaction's Statement/Args before handing it to Record, though, so
+// transient memory ahead of that budget check still scales with the number of
+// refIDs a panel sends.
 //
 // Capture is off unless a request asked for it, and in Grafana the path that
 // does the asking is feature-toggled, restricted to admins and on-prem only.
-// That is what makes these acceptable for now rather than limits worth
-// engineering around.
+// That is what makes the remaining gap acceptable for now rather than a limit
+// worth engineering around.
 package querycapture
 
 import (

--- a/backend/querycapture/querycapture.go
+++ b/backend/querycapture/querycapture.go
@@ -133,9 +133,9 @@ const (
 // total across interactions.
 const (
 	// MaxStatementBytes caps Interaction.Statement.
-	MaxStatementBytes = 64 * 1024
+	MaxStatementBytes = 512 * 1024
 	// MaxArgsBytes caps the aggregate size of Interaction.Args.
-	MaxArgsBytes = 16 * 1024
+	MaxArgsBytes = 128 * 1024
 )
 
 type recorderContextKey struct{}


### PR DESCRIPTION
Raises the on-demand diagnostics capture size caps for more troubleshooting headroom.