### PR TITLE
httpclient: add per-request response limit override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 .vscode/
 .idea/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 vendor/
 .vscode/
 .idea/
-.DS_Store

--- a/backend/httpclient/response_limit_middleware.go
+++ b/backend/httpclient/response_limit_middleware.go
@@ -19,14 +19,32 @@ const (
 	responseLimitEnvVar         = "GF_DATAPROXY_RESPONSE_LIMIT"
 )
 
+type responseLimitOverrideKey struct{}
+
+// WithResponseLimit returns a copy of parent that uses limit for downstream
+// response bodies. A non-positive limit leaves the existing response-limit
+// policy unchanged.
+//
+// The override is scoped to requests created with the returned context. It
+// takes precedence over Grafana configuration, the environment variable, and
+// the limit supplied to ResponseLimitMiddleware.
+func WithResponseLimit(parent context.Context, limit int64) context.Context {
+	if limit <= 0 {
+		return parent
+	}
+
+	return context.WithValue(parent, responseLimitOverrideKey{}, limit)
+}
+
 // ResponseLimitMiddleware limits the size of downstream response bodies.
 // When the limit is exceeded the response body returns ErrResponseBodyTooLarge and a
 // warning is logged with the datasource identifiers from opts.Labels.
 //
 // The limit is resolved per-request in the following priority order:
-//  1. GrafanaCfg.ResponseLimit() from the request context, set by WithGrafanaConfig
-//  2. GF_DATAPROXY_RESPONSE_LIMIT env var — read once at client construction
-//  3. The limit argument, if > 0
+//  1. WithResponseLimit override from the request context
+//  2. GrafanaCfg.ResponseLimit() from the request context, set by WithGrafanaConfig
+//  3. GF_DATAPROXY_RESPONSE_LIMIT env var — read once at client construction
+//  4. The limit argument, if > 0
 //
 // If none are set, limiting is disabled.
 func ResponseLimitMiddleware(limit int64) Middleware {
@@ -40,13 +58,13 @@ func ResponseLimitMiddleware(limit int64) Middleware {
 			return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				effectiveLimit := resolveResponseLimit(req.Context(), envLimit, limit)
 
+				if effectiveLimit <= 0 {
+					return next.RoundTrip(req)
+				}
+
 				res, err := next.RoundTrip(req)
 				if err != nil {
 					return nil, err
-				}
-
-				if effectiveLimit <= 0 {
-					return res, nil
 				}
 
 				if res != nil && res.StatusCode != http.StatusSwitchingProtocols {
@@ -77,9 +95,13 @@ func parseEnvResponseLimit() int64 {
 }
 
 // resolveResponseLimit determines the effective limit for a request.
-// The per-request context value from GrafanaCfg wins if present, then the env var,
-// then the static limit argument. Returns 0 if none are set, which disables limiting.
+// The explicit request override wins if present, followed by the per-request
+// Grafana configuration value, the env var, and the static limit argument.
+// Returns 0 if none are set, which disables limiting.
 func resolveResponseLimit(ctx context.Context, envLimit, limit int64) int64 {
+	if limit, ok := ctx.Value(responseLimitOverrideKey{}).(int64); ok && limit > 0 {
+		return limit
+	}
 	if ctxLimit := config.GrafanaConfigFromContext(ctx).ResponseLimit(); ctxLimit > 0 {
 		return ctxLimit
 	}

--- a/backend/httpclient/response_limit_middleware_test.go
+++ b/backend/httpclient/response_limit_middleware_test.go
@@ -19,6 +19,7 @@ func TestResponseLimitMiddleware(t *testing.T) {
 		name               string
 		limit              int64
 		ctxLimit           *int64
+		requestLimit       *int64
 		envLimit           string
 		expectedBodyLength int
 		expectedBody       string
@@ -36,6 +37,10 @@ func TestResponseLimitMiddleware(t *testing.T) {
 		// grafana config (context) priority
 		{name: "grafana config wins over env var", limit: 0, ctxLimit: ptr(int64(3)), envLimit: "1000000", expectedBodyLength: 3, expectedBody: "dum", expectErr: true},
 		{name: "grafana config 0 falls back to env var", limit: 0, ctxLimit: ptr(int64(0)), envLimit: "3", expectedBodyLength: 3, expectedBody: "dum", expectErr: true},
+		// explicit request override priority
+		{name: "request override wins over grafana config and env var", limit: 1, ctxLimit: ptr(int64(2)), requestLimit: ptr(int64(3)), envLimit: "4", expectedBodyLength: 3, expectedBody: "dum", expectErr: true},
+		{name: "zero request override leaves existing limit unchanged", limit: 1, requestLimit: ptr(int64(0)), expectedBodyLength: 1, expectedBody: "d", expectErr: true},
+		{name: "negative request override leaves existing limit unchanged", limit: 1, requestLimit: ptr(int64(-1)), expectedBodyLength: 1, expectedBody: "d", expectErr: true},
 		{name: "no limit when nothing is set", limit: 0, expectedBodyLength: 5, expectedBody: "dummy"},
 	}
 	for _, tc := range tcs {
@@ -59,6 +64,9 @@ func TestResponseLimitMiddleware(t *testing.T) {
 					config.ResponseLimit: strconv.FormatInt(*tc.ctxLimit, 10),
 				}))
 			}
+			if tc.requestLimit != nil {
+				ctx = WithResponseLimit(ctx, *tc.requestLimit)
+			}
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.com/query", nil)
 			require.NoError(t, err)
 
@@ -77,4 +85,50 @@ func TestResponseLimitMiddleware(t *testing.T) {
 			require.Equal(t, tc.expectedBody, string(bodyBytes))
 		})
 	}
+}
+
+func TestResponseLimitMiddlewarePreservesStackedLimits(t *testing.T) {
+	outer := ResponseLimitMiddleware(100)
+	inner := ResponseLimitMiddleware(1)
+	rt, err := roundTripperFromMiddlewares(Options{}, []Middleware{outer, inner}, RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
+	}))
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, "http://test.com/query", nil)
+	require.NoError(t, err)
+
+	res, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, res.Body.Close()) })
+
+	body, err := io.ReadAll(res.Body)
+	require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	require.Equal(t, "d", string(body))
+}
+
+func TestResponseLimitOverrideDoesNotAffectOtherRequests(t *testing.T) {
+	rt := ResponseLimitMiddleware(2).CreateMiddleware(Options{}, RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Request: req, Body: io.NopCloser(strings.NewReader("dummy"))}, nil
+	}))
+	client := &http.Client{Transport: rt}
+
+	overrideCtx := WithResponseLimit(context.Background(), 4)
+	overrideReq, err := http.NewRequestWithContext(overrideCtx, http.MethodGet, "http://test.com/search", nil)
+	require.NoError(t, err)
+	overrideRes, err := client.Do(overrideReq)
+	require.NoError(t, err)
+	overrideBody, err := io.ReadAll(overrideRes.Body)
+	require.NoError(t, overrideRes.Body.Close())
+	require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	require.Equal(t, "dumm", string(overrideBody))
+
+	normalReq, err := http.NewRequest(http.MethodGet, "http://test.com/resource", nil)
+	require.NoError(t, err)
+	normalRes, err := client.Do(normalReq)
+	require.NoError(t, err)
+	normalBody, err := io.ReadAll(normalRes.Body)
+	require.NoError(t, normalRes.Body.Close())
+	require.ErrorIs(t, err, ErrResponseBodyTooLarge)
+	require.Equal(t, "du", string(normalBody))
 }


### PR DESCRIPTION
### Summary
- add `WithResponseLimit` for request-scoped downstream response limits
- allow streaming endpoints to raise their cap without weakening limits for normal requests
  - https://prometheus.io/docs/prometheus/latest/feature_flags/#search-api
  - Search API implementation in [grafana-prometheus-datasource](https://github.com/grafana/grafana-prometheus-datasource/pull/304)
- preserve existing response-limit middleware behavior
