### PR TITLE
Avoid misleading placeholder in User-Agent header when Grafana info is unknown

### DIFF
--- a/backend/httpclient/user_agent_middleware.go
+++ b/backend/httpclient/user_agent_middleware.go
@@ -34,10 +34,14 @@ func newUserAgentMiddleware(pluginID string, version string, haveVersionInfo boo
 				return next.RoundTrip(req)
 			}
 
-			baseUserAgent := useragent.FromContext(req.Context()).String()
+			baseUserAgent := useragent.FromContext(req.Context())
 
 			if len(req.Header.Values("User-Agent")) == 0 {
-				req.Header.Set("User-Agent", baseUserAgent+userAgentSuffix)
+				if baseUserAgent.IsUnknown() {
+					req.Header.Set("User-Agent", "Grafana"+userAgentSuffix)
+				} else {
+					req.Header.Set("User-Agent", baseUserAgent.String()+userAgentSuffix)
+				}
 			}
 
 			return next.RoundTrip(req)

--- a/backend/httpclient/user_agent_middleware_test.go
+++ b/backend/httpclient/user_agent_middleware_test.go
@@ -78,4 +78,26 @@ func TestUserAgentMiddleware(t *testing.T) {
 
 		require.Equal(t, expectedHeaders, finalHeaders)
 	})
+
+	t.Run("when no user agent is set on the request context", func(t *testing.T) {
+		testCtx := &testContext{}
+		finalRoundTripper := testCtx.createRoundTripper("final")
+		userAgent := newUserAgentMiddleware("test-plugin", "1.2.3", true)
+		rt := userAgent.CreateMiddleware(Options{}, finalRoundTripper)
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://", nil)
+		require.NoError(t, err)
+
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		if res.Body != nil {
+			require.NoError(t, res.Body.Close())
+		}
+
+		expectedHeaders := http.Header{
+			"User-Agent": []string{"Grafana test-plugin/1.2.3"},
+		}
+		require.Equal(t, expectedHeaders, req.Header)
+	})
 }

--- a/backend/useragent/user_agent.go
+++ b/backend/useragent/user_agent.go
@@ -18,6 +18,7 @@ type UserAgent struct {
 	grafanaVersion string
 	arch           string
 	os             string
+	unknown        bool
 }
 
 // New creates a new UserAgent.
@@ -46,17 +47,25 @@ func Parse(s string) (*UserAgent, error) {
 	}, nil
 }
 
-// Empty creates a new UserAgent with default values.
+// Empty creates a new UserAgent representing an unknown Grafana instance,
+// e.g. because none was provided by the Grafana instance that made the request.
 func Empty() *UserAgent {
 	return &UserAgent{
 		grafanaVersion: "0.0.0",
 		os:             "unknown",
 		arch:           "unknown",
+		unknown:        true,
 	}
 }
 
 func (ua *UserAgent) GrafanaVersion() string {
 	return ua.grafanaVersion
+}
+
+// IsUnknown returns true if this UserAgent represents an unknown Grafana instance (see Empty),
+// rather than one parsed from an actual Grafana-supplied user agent string.
+func (ua *UserAgent) IsUnknown() bool {
+	return ua.unknown
 }
 
 func (ua *UserAgent) String() string {

--- a/backend/useragent/user_agent_test.go
+++ b/backend/useragent/user_agent_test.go
@@ -128,9 +128,12 @@ func TestEmpty(t *testing.T) {
 		grafanaVersion: "0.0.0",
 		os:             "unknown",
 		arch:           "unknown",
+		unknown:        true,
 	}
 	res := Empty()
 	require.Equal(t, expected, res)
+	require.True(t, res.IsUnknown())
+	require.Equal(t, "Grafana/0.0.0 (unknown; unknown)", res.String())
 }
 
 func TestUserAgentFromContext(t *testing.T) {


### PR DESCRIPTION
Avoid setting the user-agent as `Grafana/0.0.0 (unknown; unknown) <plugin>/<version>` when information about the Grafana version is not known. Use `Grafana <plugin>/<version>` instead.