### PR TITLE
harcapture: mark BodySize unavailable when the aggregate budget drops a payload

### DIFF
--- a/backend/harcapture/harcapture.go
+++ b/backend/harcapture/harcapture.go
@@ -116,13 +116,21 @@ func (e *sdkHAREntry) payloadBytes() int64 {
 }
 
 // dropPayload clears an entry's payload, keeping what tells a reader the exchange happened and how it
-// went: headers, the true sizes, timings and any error.
+// went: headers, timings and any error. BodySize is set to -1 ("unavailable" in HAR) on whichever side
+// had a payload to drop, the same convention buildSDKHAREntry already uses when a single body exceeds
+// its own cap -- without this, an entry dropped for the buffer's cumulative budget looked identical to
+// one that genuinely had no body, and Content.Size kept reporting the pre-drop length next to an empty
+// Content.Text.
 func (e *sdkHAREntry) dropPayload() {
-	e.Response.Content.Text = ""
-	e.Response.Content.Encoding = ""
+	if e.Response.Content.Text != "" {
+		e.Response.Content.Text = ""
+		e.Response.Content.Encoding = ""
+		e.Response.BodySize = -1
+	}
 	if e.Request.PostData != nil {
 		e.Request.PostData.Text = ""
 		e.Request.PostData.Encoding = ""
+		e.Request.BodySize = -1
 	}
 	e.Query.dropPayload()
 }


### PR DESCRIPTION
## Summary
- `Buffer.appendEntry` calls `entry.dropPayload()` once the cumulative retained-payload budget (`maxCapturedTotalBytes`) is exceeded, blanking `Content.Text`/`PostData.Text` but leaving `BodySize` untouched -- a dropped entry looked identical to one with a genuinely small/empty body, and `Content.Size` kept reporting the pre-drop length next to the now-empty `Content.Text`.
- The per-body cap (`maxCapturedBodyBytes`) already sets `BodySize = -1` ("unavailable" in HAR) when a single body exceeds it (`buildSDKHAREntry`). This applies the same convention to the aggregate-budget drop, so both causes read identically to anything parsing the HAR.
- Guarded on there having been something to drop (`Content.Text != ""` / `PostData != nil`), so an entry that never had a body isn't falsely marked truncated.

Draft: opening for early visibility while a companion `grafana/grafana` change (using this signal to note HAR truncation alongside the existing querydata.json note) is still being scoped.

## Test plan
- [x] `go build ./backend/harcapture/...`
- [x] `go test ./backend/harcapture/...` -- all existing tests pass unmodified