### PR TITLE
Fixed NullBoolConverter bug

### DIFF
--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -369,7 +369,8 @@ var (
 					return (*bool)(nil), nil
 				}
 
-				return &v.Bool, nil
+				val := v.Bool
+				return &val, nil
 			},
 		},
 	}

--- a/data/sqlutil/sql_optimization_test.go
+++ b/data/sqlutil/sql_optimization_test.go
@@ -282,6 +282,34 @@ func TestFrameFromRows_StringConverterNoAliasing(t *testing.T) {
 	}
 }
 
+// TestFrameFromRows_NullBoolConverterNoAliasing is a regression guard for the
+// same scan-buffer reuse hazard as TestFrameFromRows_StringConverterNoAliasing
+// above, but for NullBoolConverter. It used to derive its result from
+// &v.Bool, a pointer into the reused sql.NullBool scan buffer, which
+// collapsed every row in a boolean column to the last row's value. This test
+// drives distinct per-row boolean values through FrameFromRows end-to-end and
+// asserts each row keeps its own value at its own address.
+func TestFrameFromRows_NullBoolConverterNoAliasing(t *testing.T) {
+	want := []bool{true, false, true, false}
+	rowData := make([][]interface{}, len(want))
+	for i, v := range want {
+		rowData[i] = []interface{}{v}
+	}
+	rows := makeSingleResultSetWithTypeNames([]string{"flag"}, []string{"BOOLEAN"}, rowData...) //nolint:rowserrcheck // FrameFromRows checks rows.Err() internally
+	t.Cleanup(func() { _ = rows.Close() })
+
+	frame, err := sqlutil.FrameFromRows(rows, -1, sqlutil.NullBoolConverter)
+	require.NoError(t, err)
+	require.Equal(t, len(want), frame.Rows())
+
+	for i, w := range want {
+		got, ok := frame.Fields[0].At(i).(*bool)
+		require.True(t, ok, "row %d should be a *bool", i)
+		require.NotNil(t, got, "row %d should not be nil", i)
+		require.Equal(t, w, *got, "row %d must keep its own value, not alias another row (scan-buffer reuse aliasing regression)", i)
+	}
+}
+
 // TestFrameFromRowsWithCapacity_PresizesAllFields proves the end-to-end
 // capacity API (Fix 1 plumbed through FrameFromRowsWithCapacity).
 func TestFrameFromRowsWithCapacity_PresizesAllFields(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana-plugin-sdk-go/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

4. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

-->

**What this PR does / why we need it**:
The current `NullBoolConverter` returns the address of the scanned value directly, but FrameFromRows reuses the same scan buffer across all rows so every row ends up pointing at the same address, and the last value scanned overwrites all previous ones. This updated version follows the pattern of other Converter functions by making a copy of the value first and then returning that address, ensuring each row keeps its own value and isn't overwritten by later rows.

**Which issue(s) this PR fixes**:

<!--

* Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/athena-datasource/issues/888

**Special notes for your reviewer**:

Current bug: 
<img width="2245" height="806" alt="bool-bug" src="https://github.com/user-attachments/assets/aa0a150e-6181-4861-8d6d-a6d5d524c446" />

