### PR TITLE
chore(renovate): disable major updates for indirect Go modules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,13 @@
       "matchUpdateTypes": ["minor", "patch", "digest"]
     },
     {
+      "description": "A Go major bump is a new module path, so for an indirect dependency Renovate just swaps the require line for one that nothing resolves to (and often duplicates an existing entry), leaving a go.mod that fails `go mod tidy`. Only the direct requirer can move a major, so never open these.",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "description": "Automerge: minor/major updates need an approval from the Claude gate workflow before GitHub auto-merge fires",
       "matchUpdateTypes": ["minor", "major"],
       "automerge": true,


### PR DESCRIPTION
## What

Adds a Renovate `packageRule` that disables **major** updates for **indirect** Go modules.

## Why

A Go major bump is a different module path, so for an indirect dependency Renovate can only swap the `require` line for one that nothing in the graph resolves to — frequently duplicating an entry that is already present. The result is a `go.mod` that no longer loads.

#1681 is the example. It produced:

```diff
-	go.yaml.in/yaml/v2 v2.4.4 // indirect
+	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
```

and CI failed at the lint step before anything else ran:

```
level=error msg="Running error: context loading failed: no go files to analyze: running `go mod tidy` may solve the problem"
```

`go.yaml.in/yaml/v2` is still genuinely required by `prometheus/client_golang`, `prometheus/common`, `k8s.io/kube-openapi` and `sigs.k8s.io/yaml`. Running `go mod tidy` on that branch restores `v2 v2.4.4`, i.e. the only valid end state for #1681 is exactly what `main` already has.
