### PR TITLE
fix(sqlutil): guard nil Replacer in StringFrameConverter

### DIFF
--- a/data/sqlutil/converter.go
+++ b/data/sqlutil/converter.go
@@ -111,7 +111,7 @@ func StringFrameConverter(s StringConverter) FrameConverter {
 				v = converted
 			}
 
-			if s.Replacer.ReplaceFunc != nil {
+			if s.Replacer != nil && s.Replacer.ReplaceFunc != nil {
 				return s.Replacer.ReplaceFunc(v)
 			}
 

--- a/data/sqlutil/converter_test.go
+++ b/data/sqlutil/converter_test.go
@@ -187,3 +187,14 @@ func TestDefaultConverter(t *testing.T) {
 		})
 	}
 }
+
+func TestStringFrameConverterNilReplacer(t *testing.T) {
+	// Replacer is optional (nil is valid, see StringConverter.Replacer). A
+	// converter with no Replacer must not panic when converting a real string.
+	fc := sqlutil.StringFrameConverter(sqlutil.StringConverter{})
+	out, err := fc.ConverterFunc(&sql.NullString{String: "hello", Valid: true})
+	assert.NoError(t, err)
+	got, ok := out.(*string)
+	assert.True(t, ok)
+	assert.Equal(t, "hello", *got)
+}


### PR DESCRIPTION
**What this PR does / why we need it**

`StringConverter.Replacer` is optional — the doc comment says "If the Replacer is not nil…", and `StringFrameConverter` already nil-checks it when picking the output field type. But the converter closure then dereferenced `s.Replacer.ReplaceFunc` without a nil check:

```go
if s.Replacer.ReplaceFunc != nil {   // panics when s.Replacer == nil
```

So any `StringConverter` created without a `Replacer` panics with a nil-pointer dereference the first time it converts a non-null string:

```go
fc := sqlutil.StringFrameConverter(sqlutil.StringConverter{})
fc.ConverterFunc(&sql.NullString{String: "hello", Valid: true}) // panic on main
```

**What this PR does**

Guards the deref with `s.Replacer != nil && s.Replacer.ReplaceFunc != nil`, matching the existing nil-check at the top. Added `TestStringFrameConverterNilReplacer` (panics on the current code, passes with the fix).

**Special notes for your reviewer**

RED→GREEN verified; full `data/sqlutil` suite green; gofmt/vet/golangci-lint clean. No API change.